### PR TITLE
fix: TON derivation path and address format

### DIFF
--- a/lws/crates/lws-signer/src/chains/ton.rs
+++ b/lws/crates/lws-signer/src/chains/ton.rs
@@ -172,7 +172,7 @@ impl ChainSigner for TonSigner {
         let state_hash =
             Self::state_init_hash(&WALLET_V5R1_CODE_HASH, WALLET_V5R1_CODE_DEPTH, &data_hash);
 
-        Ok(Self::encode_address(0, &state_hash, true))
+        Ok(Self::encode_address(0, &state_hash, false))
     }
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
@@ -197,7 +197,7 @@ impl ChainSigner for TonSigner {
     }
 
     fn default_derivation_path(&self, index: u32) -> String {
-        format!("m/44'/607'/{}'/0'", index)
+        format!("m/44'/607'/{}'", index)
     }
 }
 
@@ -251,7 +251,7 @@ mod tests {
         // Private key: 9d61b19d... -> Public key: d75a9801...
         let signer = TonSigner;
         let address = signer.derive_address(&test_privkey()).unwrap();
-        assert_eq!(address, "EQCUp64SJJ505dIdcgHDG1oD8JKMLXpQzu5W6lLFdQGtA5Td");
+        assert!(address.starts_with("UQ"), "non-bounceable address should start with UQ, got: {address}");
     }
 
     #[test]
@@ -260,8 +260,8 @@ mod tests {
         let address = signer.derive_address(&test_privkey()).unwrap();
         assert_eq!(address.len(), 48, "TON address should be 48 chars");
         assert!(
-            address.starts_with("EQ"),
-            "bounceable workchain-0 address should start with EQ"
+            address.starts_with("UQ"),
+            "non-bounceable workchain-0 address should start with UQ, got: {address}"
         );
     }
 
@@ -274,7 +274,7 @@ mod tests {
             .decode(&address)
             .unwrap();
         assert_eq!(decoded.len(), 36);
-        assert_eq!(decoded[0], 0x11); // bounceable tag
+        assert_eq!(decoded[0], 0x51); // non-bounceable tag
         assert_eq!(decoded[1], 0x00); // workchain 0
 
         let crc = crc16_ccitt(&decoded[..34]);
@@ -314,8 +314,8 @@ mod tests {
     #[test]
     fn test_derivation_path() {
         let signer = TonSigner;
-        assert_eq!(signer.default_derivation_path(0), "m/44'/607'/0'/0'");
-        assert_eq!(signer.default_derivation_path(1), "m/44'/607'/1'/0'");
+        assert_eq!(signer.default_derivation_path(0), "m/44'/607'/0'");
+        assert_eq!(signer.default_derivation_path(1), "m/44'/607'/1'");
     }
 
     #[test]

--- a/lws/crates/lws-signer/src/lib.rs
+++ b/lws/crates/lws-signer/src/lib.rs
@@ -90,8 +90,8 @@ mod integration_tests {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
         let address = derive_address_for_chain(&mnemonic, ChainType::Ton);
         assert!(
-            address.starts_with("EQ"),
-            "TON bounceable address should start with EQ, got: {}",
+            address.starts_with("UQ"),
+            "TON non-bounceable address should start with UQ, got: {}",
             address
         );
         assert_eq!(address.len(), 48);


### PR DESCRIPTION
## Summary

Two fixes to TON chain support:

### 1. Derivation path: m/44'/607'/n' (3 levels, not 4)

Changed from m/44'/607'/n'/0' to m/44'/607'/n'.

The 3-level path matches Trust Wallet convention and is the de facto standard for multi-chain HD wallets on TON. Ledger uses a different (6-level) path, but Trust Wallet's 3-level path has the widest adoption among software wallets.

This matters for compatibility — wallets that already derived TON addresses using the 3-level path (e.g. via @ton/crypto deriveEd25519Path) will get different addresses with 4 levels, making existing funds inaccessible.

### 2. Non-bounceable addresses (UQ...) for wallets

Changed encode_address bounceable flag from true to false.

Why non-bounceable for wallets:
- On TON, bounceable (EQ...) and non-bounceable (UQ...) are the same underlying address — just a flag in the encoding
- When sending to a bounceable address that hasn't been deployed yet (no contract code on-chain), the funds bounce back to the sender minus fees
- New TON wallets are undeployed until their first outgoing transaction (which attaches state_init). If someone sends TON to a new wallet's bounceable address, the funds bounce back
- Non-bounceable (UQ...) tells the sender's wallet to deliver funds regardless — this is what wallet apps display for user addresses
- Bounceable (EQ...) is for smart contract addresses where bouncing is a safety feature

Tonkeeper, TonHub, and other TON wallets all display user addresses in non-bounceable format.

## Changes
- lws/crates/lws-signer/src/chains/ton.rs: derivation path + address encoding
- lws/crates/lws-signer/src/lib.rs: updated integration test