### PR TITLE
Add X links to website pages

### DIFF
--- a/website/docs/doc.html
+++ b/website/docs/doc.html
@@ -22,6 +22,7 @@
       </nav>
       <div class="header-actions">
         <a href="./" class="btn btn-outline">Docs</a>
+        <a href="https://x.com/Openwallet2026" class="btn btn-outline" target="_blank" rel="noopener noreferrer" aria-label="Open Wallet Standard on X">X</a>
         <a href="https://github.com/open-wallet-standard/core" class="btn btn-primary">GitHub</a>
       </div>
       <button class="mobile-menu-btn" onclick="document.getElementById('nav').classList.toggle('active')">

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -25,6 +25,7 @@
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 2h7l3 3v9H3V2z"/><path d="M10 2v3h3"/><path d="M5 9h6M5 11.5h4"/></svg>
           Docs
         </a>
+        <a href="https://x.com/Openwallet2026" class="btn btn-outline" target="_blank" rel="noopener noreferrer" aria-label="Open Wallet Standard on X">X</a>
         <a href="https://github.com/open-wallet-standard/core" class="btn btn-primary">GitHub</a>
       </div>
       <button class="mobile-menu-btn" onclick="document.getElementById('nav').classList.toggle('active')">

--- a/website/index.html
+++ b/website/index.html
@@ -28,6 +28,7 @@
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 2h7l3 3v9H3V2z"/><path d="M10 2v3h3"/><path d="M5 9h6M5 11.5h4"/></svg>
           Docs
         </a>
+        <a href="https://x.com/Openwallet2026" class="btn btn-outline" target="_blank" rel="noopener noreferrer" aria-label="Open Wallet Standard on X">X</a>
         <a href="https://github.com/open-wallet-standard/core" class="btn btn-primary">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
           GitHub
@@ -668,11 +669,12 @@ ows sign tx --wallet agent-treasury --chain evm --tx-hex <span class="string">"d
         <a href="docs/doc.html?slug=06-wallet-lifecycle">Lifecycle</a>
       </div>
       <div class="footer-col">
-        <h4>Packages</h4>
+        <h4>Resources</h4>
         <a href="https://www.npmjs.com/package/@open-wallet-standard/core">npm (Node.js)</a>
         <a href="https://pypi.org/project/open-wallet-standard/">PyPI (Python)</a>
         <a href="https://crates.io/crates/ows-cli">crates.io (Rust)</a>
         <a href="https://github.com/open-wallet-standard/core">GitHub</a>
+        <a href="https://x.com/Openwallet2026" target="_blank" rel="noopener noreferrer">X</a>
       </div>
     </div>
     <div class="footer-bottom">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add the Openwallet2026 X link to the website headers and homepage footer so visitors can find the project profile from the main site and docs pages.

## Why

The website needs a visible link to the project's X profile.

Closes #

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` is clean
- [ ] `npm test` passes (if Node bindings changed)
- [ ] Tested manually with `ows` CLI

## Notes

Verified the new `https://x.com/Openwallet2026` link appears in:
- `website/index.html`
- `website/docs/index.html`
- `website/docs/doc.html`
- homepage footer resources list
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcaade62-2409-4167-a090-2e11c883b1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcaade62-2409-4167-a090-2e11c883b1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

