### PR TITLE
chore: skip client-side verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        with:
+          verify-metadata: false
 
   node-addons:
     strategy:


### PR DESCRIPTION
## What

Brief description of the change.

## Why

Why is this change needed? Link to related issue(s) if applicable.

Closes #

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` is clean
- [ ] `npm test` passes (if Node bindings changed)
- [ ] Tested manually with `ows` CLI

## Notes

Anything reviewers should know.
