### PR TITLE
chore: bump version to 0.3.7

### DIFF
--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-node"
-version = "0.3.3"
+version = "0.3.7"
 edition = "2021"
 description = "Node.js native bindings for the Open Wallet Standard"
 

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-darwin-arm64",
-  "version": "0.3.3",
+  "version": "0.3.7",
   "os": [
     "darwin"
   ],

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-darwin-x64",
-  "version": "0.3.3",
+  "version": "0.3.7",
   "os": [
     "darwin"
   ],

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-linux-arm64-gnu",
-  "version": "0.3.3",
+  "version": "0.3.7",
   "os": [
     "linux"
   ],

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-linux-x64-gnu",
-  "version": "0.3.3",
+  "version": "0.3.7",
   "os": [
     "linux"
   ],

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-wallet-standard/core",
-  "version": "0.3.3",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-wallet-standard/core",
-      "version": "0.3.3",
+      "version": "0.3.7",
       "license": "MIT",
       "bin": {
         "ows": "bin/ows"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core",
-  "version": "0.3.3",
+  "version": "0.3.7",
   "description": "Node.js native bindings for the Open Wallet Standard",
   "main": "index.js",
   "types": "index.d.ts",
@@ -31,10 +31,10 @@
     "@napi-rs/cli": "^2.18.0"
   },
   "optionalDependencies": {
-    "@open-wallet-standard/core-linux-x64-gnu": "0.3.3",
-    "@open-wallet-standard/core-linux-arm64-gnu": "0.3.3",
-    "@open-wallet-standard/core-darwin-x64": "0.3.3",
-    "@open-wallet-standard/core-darwin-arm64": "0.3.3"
+    "@open-wallet-standard/core-linux-x64-gnu": "0.3.7",
+    "@open-wallet-standard/core-linux-arm64-gnu": "0.3.7",
+    "@open-wallet-standard/core-darwin-x64": "0.3.7",
+    "@open-wallet-standard/core-darwin-arm64": "0.3.7"
   },
   "license": "MIT",
   "files": [

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-python"
-version = "0.3.3"
+version = "0.3.7"
 edition = "2021"
 description = "Python native bindings for the Open Wallet Standard"
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "open-wallet-standard"
-version = "0.3.3"
+version = "0.3.7"
 description = "Python native bindings for the Open Wallet Standard"
 requires-python = ">=3.8"
 license = { text = "MIT" }

--- a/ows/crates/ows-cli/Cargo.toml
+++ b/ows/crates/ows-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-cli"
-version = "0.3.3"
+version = "0.3.7"
 edition = "2021"
 license = "MIT"
 description = "CLI for the Open Wallet Standard"
@@ -12,9 +12,9 @@ name = "ows"
 path = "src/main.rs"
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=0.3.3" }
-ows-signer = { path = "../ows-signer", version = "=0.3.3" }
-ows-lib = { path = "../ows-lib", version = "=0.3.3" }
+ows-core = { path = "../ows-core", version = "=0.3.7" }
+ows-signer = { path = "../ows-signer", version = "=0.3.7" }
+ows-lib = { path = "../ows-lib", version = "=0.3.7" }
 clap = { version = "4", features = ["derive", "env"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -27,4 +27,4 @@ serde = { version = "1", features = ["derive"] }
 zeroize = "1"
 
 [dev-dependencies]
-ows-signer = { path = "../ows-signer", version = "=0.3.3", features = ["fast-kdf"] }
+ows-signer = { path = "../ows-signer", version = "=0.3.7", features = ["fast-kdf"] }

--- a/ows/crates/ows-core/Cargo.toml
+++ b/ows/crates/ows-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-core"
-version = "0.3.3"
+version = "0.3.7"
 edition = "2021"
 license = "MIT"
 description = "Core types and traits for the Open Wallet Standard"

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-lib"
-version = "0.3.3"
+version = "0.3.7"
 edition = "2021"
 license = "MIT"
 description = "High-level library API for the Open Wallet Standard"
@@ -12,8 +12,8 @@ default = []
 fast-kdf = ["ows-signer/fast-kdf"]
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=0.3.3" }
-ows-signer = { path = "../ows-signer", version = "=0.3.3" }
+ows-core = { path = "../ows-core", version = "=0.3.7" }
+ows-signer = { path = "../ows-signer", version = "=0.3.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -28,4 +28,4 @@ zeroize = "1"
 tempfile = "3"
 sha3 = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"] }
-ows-signer = { path = "../ows-signer", version = "=0.3.3", features = ["fast-kdf"] }
+ows-signer = { path = "../ows-signer", version = "=0.3.7", features = ["fast-kdf"] }

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-signer"
-version = "0.3.3"
+version = "0.3.7"
 edition = "2021"
 license = "MIT"
 description = "Cryptographic signing and key management for the Open Wallet Standard"
@@ -12,7 +12,7 @@ default = []
 fast-kdf = []
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=0.3.3" }
+ows-core = { path = "../ows-core", version = "=0.3.7" }
 k256 = { version = "0.13", features = ["ecdsa", "arithmetic"] }
 ed25519-dalek = { version = "2", features = ["hazmat"] }
 coins-bip32 = "0.11"

--- a/skills/ows/SKILL.md
+++ b/skills/ows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ows
 description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, Bitcoin, Cosmos, Tron, and TON via CLI, Node.js, or Python.
-version: 0.3.3
+version: 0.3.7
 metadata:
   openclaw:
     requires:


### PR DESCRIPTION
## What

Brief description of the change.

## Why

Why is this change needed? Link to related issue(s) if applicable.

Closes #

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` is clean
- [ ] `npm test` passes (if Node bindings changed)
- [ ] Tested manually with `ows` CLI

## Notes

Anything reviewers should know.
