### PR TITLE
fix(ows-cli): prevent key material exposure in process listings and memory

### DIFF
--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -810,7 +810,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-cli"
-version = "0.3.3"
+version = "0.3.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "ows-core"
-version = "0.3.3"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "serde",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "0.3.3"
+version = "0.3.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "0.3.3"
+version = "0.3.7"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/ows/crates/ows-cli/src/commands/mod.rs
+++ b/ows/crates/ows-cli/src/commands/mod.rs
@@ -14,13 +14,14 @@ use ows_core::KeyType;
 use ows_signer::process_hardening::clear_env_var;
 use ows_signer::{CryptoEnvelope, SecretBytes};
 use std::io::{self, BufRead, IsTerminal, Write};
+use zeroize::{Zeroize, Zeroizing};
 
 /// Read mnemonic from OWS_MNEMONIC env var (or LWS_MNEMONIC fallback) or stdin.
-pub fn read_mnemonic() -> Result<String, CliError> {
+pub fn read_mnemonic() -> Result<Zeroizing<String>, CliError> {
     if let Some(value) = clear_env_var("OWS_MNEMONIC").or_else(|| clear_env_var("LWS_MNEMONIC")) {
         let trimmed = value.trim().to_string();
         if !trimmed.is_empty() {
-            return Ok(trimmed);
+            return Ok(Zeroizing::new(trimmed));
         }
     }
 
@@ -40,17 +41,17 @@ pub fn read_mnemonic() -> Result<String, CliError> {
         ));
     }
 
-    Ok(trimmed)
+    Ok(Zeroizing::new(trimmed))
 }
 
 /// Read a hex-encoded private key from OWS_PRIVATE_KEY env var (or LWS_PRIVATE_KEY fallback) or stdin.
-pub fn read_private_key() -> Result<String, CliError> {
+pub fn read_private_key() -> Result<Zeroizing<String>, CliError> {
     if let Some(value) =
         clear_env_var("OWS_PRIVATE_KEY").or_else(|| clear_env_var("LWS_PRIVATE_KEY"))
     {
         let trimmed = value.trim().to_string();
         if !trimmed.is_empty() {
-            return Ok(trimmed);
+            return Ok(Zeroizing::new(trimmed));
         }
     }
 
@@ -70,21 +71,21 @@ pub fn read_private_key() -> Result<String, CliError> {
         ));
     }
 
-    Ok(trimmed)
+    Ok(Zeroizing::new(trimmed))
 }
 
 /// Resolved wallet secret — either a mnemonic phrase or a key pair (JSON).
 pub enum WalletSecret {
-    Mnemonic(String),
+    Mnemonic(Zeroizing<String>),
     /// JSON key pair: `{"secp256k1":"hex","ed25519":"hex"}`
     PrivateKeys(SecretBytes),
 }
 
 /// Read a passphrase from OWS_PASSPHRASE env var (or LWS_PASSPHRASE fallback) or prompt interactively.
-pub fn read_passphrase() -> String {
+pub fn read_passphrase() -> Zeroizing<String> {
     if let Some(value) = clear_env_var("OWS_PASSPHRASE").or_else(|| clear_env_var("LWS_PASSPHRASE"))
     {
-        return value;
+        return Zeroizing::new(value);
     }
     let stdin = io::stdin();
     if stdin.is_terminal() {
@@ -92,9 +93,9 @@ pub fn read_passphrase() -> String {
         io::stderr().flush().ok();
         let mut line = String::new();
         stdin.lock().read_line(&mut line).unwrap_or(0);
-        line.trim().to_string()
+        Zeroizing::new(line.trim().to_string())
     } else {
-        String::new()
+        Zeroizing::new(String::new())
     }
 }
 
@@ -115,8 +116,10 @@ pub fn resolve_wallet_secret(wallet_name: &str) -> Result<WalletSecret, CliError
 
     match wallet.key_type {
         KeyType::Mnemonic => {
-            let phrase = String::from_utf8(secret.expose().to_vec())
-                .map_err(|_| CliError::InvalidArgs("wallet contains invalid mnemonic".into()))?;
+            let phrase =
+                Zeroizing::new(String::from_utf8(secret.expose().to_vec()).map_err(|_| {
+                    CliError::InvalidArgs("wallet contains invalid mnemonic".into())
+                })?);
             Ok(WalletSecret::Mnemonic(phrase))
         }
         KeyType::PrivateKey => Ok(WalletSecret::PrivateKeys(secret)),
@@ -157,8 +160,9 @@ pub fn resolve_signing_key(
     let signer = ows_signer::signer_for_chain(chain_type);
 
     match wallet_secret {
-        WalletSecret::Mnemonic(phrase) => {
+        WalletSecret::Mnemonic(mut phrase) => {
             let mnemonic = ows_signer::Mnemonic::from_phrase(&phrase)?;
+            phrase.zeroize();
             let path = signer.default_derivation_path(index);
             let curve = signer.curve();
             Ok(ows_signer::HdDeriver::derive_from_mnemonic_cached(

--- a/ows/crates/ows-cli/src/commands/wallet.rs
+++ b/ows/crates/ows-cli/src/commands/wallet.rs
@@ -2,10 +2,11 @@ use std::io::IsTerminal;
 
 use crate::audit;
 use crate::CliError;
+use zeroize::Zeroize;
 
 pub fn create(name: &str, words: u32, show_mnemonic: bool) -> Result<(), CliError> {
     // Generate mnemonic, then import it to create the wallet
-    let mnemonic_phrase = ows_lib::generate_mnemonic(words)?;
+    let mut mnemonic_phrase = ows_lib::generate_mnemonic(words)?;
     let info = ows_lib::import_wallet_mnemonic(name, &mnemonic_phrase, None, Some(0), None)?;
 
     audit::log_wallet_created(&info);
@@ -32,6 +33,7 @@ pub fn create(name: &str, words: u32, show_mnemonic: bool) -> Result<(), CliErro
         eprintln!("Use --show-mnemonic at creation time if you need a backup copy.");
     }
 
+    mnemonic_phrase.zeroize();
     Ok(())
 }
 
@@ -41,13 +43,17 @@ pub fn import(
     use_private_key: bool,
     chain: Option<&str>,
     index: u32,
-    secp256k1_key: Option<&str>,
-    ed25519_key: Option<&str>,
 ) -> Result<(), CliError> {
+    // Read curve-specific keys from environment variables (cleared immediately after reading)
+    let secp256k1_key = ows_signer::process_hardening::clear_env_var("OWS_SECP256K1_KEY");
+    let ed25519_key = ows_signer::process_hardening::clear_env_var("OWS_ED25519_KEY");
+    let secp256k1_key = secp256k1_key.as_deref().filter(|s| !s.is_empty());
+    let ed25519_key = ed25519_key.as_deref().filter(|s| !s.is_empty());
+
     let has_curve_keys = secp256k1_key.is_some() || ed25519_key.is_some();
     let both_curve_keys = secp256k1_key.is_some() && ed25519_key.is_some();
 
-    // Must specify exactly one import mode: --mnemonic, --private-key, or both curve keys
+    // Must specify exactly one import mode: --mnemonic, --private-key, or both curve keys (via env)
     if use_mnemonic && (use_private_key || has_curve_keys) {
         return Err(CliError::InvalidArgs(
             "cannot combine --mnemonic with --private-key or curve-specific keys".into(),
@@ -55,7 +61,8 @@ pub fn import(
     }
     if !use_mnemonic && !use_private_key && !both_curve_keys {
         return Err(CliError::InvalidArgs(
-            "specify --mnemonic, --private-key, or both --secp256k1-key and --ed25519-key".into(),
+            "specify --mnemonic, --private-key, or set OWS_SECP256K1_KEY and OWS_ED25519_KEY"
+                .into(),
         ));
     }
 
@@ -63,9 +70,9 @@ pub fn import(
         let phrase = super::read_mnemonic()?;
         ows_lib::import_wallet_mnemonic(name, &phrase, None, Some(index), None)?
     } else {
-        // Read from stdin only when both curve keys are not already provided
+        // Read from env/stdin only when both curve keys are not already provided
         let private_key_hex = if both_curve_keys {
-            String::new()
+            zeroize::Zeroizing::new(String::new())
         } else {
             super::read_private_key()?
         };
@@ -103,7 +110,7 @@ pub fn export(wallet_name: &str) -> Result<(), CliError> {
     }
 
     // Try empty passphrase first, then prompt if it fails
-    let exported = match ows_lib::export_wallet(wallet_name, None, None) {
+    let mut exported = match ows_lib::export_wallet(wallet_name, None, None) {
         Ok(s) => s,
         Err(_) => {
             let passphrase = super::read_passphrase();
@@ -121,6 +128,7 @@ pub fn export(wallet_name: &str) -> Result<(), CliError> {
     eprintln!("Do not share it. Store it securely offline.");
     eprintln!();
     println!("{exported}");
+    exported.zeroize();
 
     let info = ows_lib::get_wallet(wallet_name, None)?;
     audit::log_wallet_exported(&info.id);

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -83,12 +83,6 @@ enum WalletCommands {
         /// Account index for HD derivation (mnemonic only)
         #[arg(long, default_value = "0")]
         index: u32,
-        /// Explicit secp256k1 private key (hex). When both --secp256k1-key and --ed25519-key are given, --private-key and stdin are not required.
-        #[arg(long)]
-        secp256k1_key: Option<String>,
-        /// Explicit ed25519 private key (hex). When both --secp256k1-key and --ed25519-key are given, --private-key and stdin are not required.
-        #[arg(long)]
-        ed25519_key: Option<String>,
     },
     /// Export wallet secret (mnemonic or private key) to stdout
     Export {
@@ -278,17 +272,7 @@ fn run(cli: Cli) -> Result<(), CliError> {
                 private_key,
                 chain,
                 index,
-                secp256k1_key,
-                ed25519_key,
-            } => commands::wallet::import(
-                &name,
-                mnemonic,
-                private_key,
-                chain.as_deref(),
-                index,
-                secp256k1_key.as_deref(),
-                ed25519_key.as_deref(),
-            ),
+            } => commands::wallet::import(&name, mnemonic, private_key, chain.as_deref(), index),
             WalletCommands::Export { wallet } => commands::wallet::export(&wallet),
             WalletCommands::Delete { wallet, confirm } => {
                 commands::wallet::delete(&wallet, confirm)


### PR DESCRIPTION
## Summary

- **Remove `--secp256k1-key` / `--ed25519-key` CLI args**: raw private keys were visible in `ps aux`. Keys are now read from `OWS_SECP256K1_KEY` / `OWS_ED25519_KEY` env vars, cleared immediately via `clear_env_var()` — same pattern as [`af2122e`](https://github.com/open-wallet-standard/core/commit/af2122e).
- **`Zeroizing<String>` return types**: Change `read_mnemonic()`, `read_private_key()`, `read_passphrase()` return types to `Zeroizing<String>` so secret strings are overwritten on drop.
- **`WalletSecret::Mnemonic` holds `Zeroizing<String>`**: explicitly zeroize in `resolve_signing_key()` after HD derivation.
- **Zeroize `exported` string** in `wallet export` after printing.
- **Zeroize generated mnemonic** in `wallet create` after use.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 235 tests, 0 failures

## Files modified

- `ows/crates/ows-cli/src/main.rs`
- `ows/crates/ows-cli/src/commands/mod.rs`
- `ows/crates/ows-cli/src/commands/wallet.rs`