### PR TITLE
docs: add Filecoin and signTypedData to docs and READMEs

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -56,6 +56,7 @@ ows sign tx --wallet agent-treasury --chain evm --tx-hex "deadbeef..."
 | Cosmos | secp256k1 | bech32 | `m/44'/118'/0'/0/0` |
 | Tron | secp256k1 | base58check | `m/44'/195'/0'/0/0` |
 | TON | Ed25519 | raw/bounceable | `m/44'/607'/0'` |
+| Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
 
 ## CLI Reference
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -60,6 +60,7 @@ print(sig["signature"])
 | Cosmos | secp256k1 | bech32 | `m/44'/118'/0'/0/0` |
 | Tron | secp256k1 | base58check | `m/44'/195'/0'/0/0` |
 | TON | Ed25519 | raw/bounceable | `m/44'/607'/0'` |
+| Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
 
 ## Architecture
 

--- a/docs/02-signing-interface.md
+++ b/docs/02-signing-interface.md
@@ -9,6 +9,7 @@
 | `sign` (sign transaction) | Done | CLI `ows sign tx`, `ows-signer` trait |
 | `signAndSend` (sign + broadcast) | Done | CLI `ows sign send-tx`, per-chain broadcast |
 | `signMessage` (arbitrary message signing) | Done | CLI `ows sign message`, EIP-712 supported |
+| `signTypedData` (EIP-712 typed structured data) | Done | SDK-level API, CLI `--typed-data` flag |
 | EVM broadcast (`eth_sendRawTransaction`) | Done | `send_transaction.rs` |
 | Solana broadcast (`sendTransaction`) | Done | `send_transaction.rs` |
 | Bitcoin broadcast (mempool.space REST) | Done | `send_transaction.rs` |
@@ -141,6 +142,41 @@ Message signing follows chain-specific conventions:
 - **EVM**: `personal_sign` (EIP-191) or `eth_signTypedData_v4` (EIP-712)
 - **Solana**: Ed25519 signature over the raw message bytes
 - **Cosmos**: ADR-036 off-chain signing
+- **Filecoin**: Blake2b-256 hash then secp256k1 signing
+
+### `signTypedData(request: SignTypedDataRequest): Promise<SignMessageResult>`
+
+Signs EIP-712 typed structured data. This is a dedicated operation separate from `signMessage` to provide a clean SDK interface for typed data signing without overloading the message signing API.
+
+```typescript
+interface SignTypedDataRequest {
+  walletId: WalletId;
+  chainId: ChainId;                    // Must be an EVM chain
+  typedDataJson: string;               // JSON string of EIP-712 typed data
+}
+```
+
+The `typedDataJson` field must be a JSON string containing the standard EIP-712 fields: `types`, `primaryType`, `domain`, and `message`.
+
+```json
+{
+  "types": {
+    "EIP712Domain": [
+      {"name": "name", "type": "string"},
+      {"name": "chainId", "type": "uint256"}
+    ],
+    "Transfer": [
+      {"name": "to", "type": "address"},
+      {"name": "amount", "type": "uint256"}
+    ]
+  },
+  "primaryType": "Transfer",
+  "domain": {"name": "MyDApp", "chainId": "1"},
+  "message": {"to": "0xabc...", "amount": "1000"}
+}
+```
+
+Returns a `SignMessageResult` with the signature and recovery ID. Only supported for EVM chains — calling with a non-EVM chain returns a `CHAIN_NOT_SUPPORTED` error.
 
 ## SerializedTransaction Format
 

--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -8,8 +8,8 @@
 |---------|--------|-------|
 | CAIP-2 chain ID parsing (`namespace:reference`) | Done | `ows-core/src/caip.rs` |
 | CAIP-10 account IDs (`chain_id:address`) | Done | Stored in wallet `account_id` field |
-| Registered chain families (7 families, 13 networks) | Done | `ows-core/src/chain.rs` |
-| Per-chain signers (EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark) | Done | `ows-signer/src/chains/` |
+| Registered chain families (8 families, 14 networks) | Done | `ows-core/src/chain.rs` |
+| Per-chain signers (EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin) | Done | `ows-signer/src/chains/` |
 | HD derivation: BIP-32 (secp256k1) + SLIP-10 (ed25519) | Done | `ows-signer/src/hd.rs` |
 | Default RPC endpoints | Done | `ows-core/src/config.rs` |
 | User RPC overrides via config | Done | Merge semantics |
@@ -50,6 +50,7 @@ OWS groups chains into families that share a cryptographic curve and address der
 | Tron | secp256k1 | 195 | `m/44'/195'/0'/0/{index}` | Base58Check (`T...`) | `tron` |
 | TON | ed25519 | 607 | `m/44'/607'/{index}'` | Base64url wallet v5r1 (`UQ...`) | `ton` |
 | Spark | secp256k1 | 8797555 | `m/84'/0'/0'/0/{index}` | `spark:` + compressed pubkey hex | `spark` |
+| Filecoin | secp256k1 | 461 | `m/44'/461'/0'/0/{index}` | `f1` + base32(blake2b-160) | `fil` |
 
 ## Known Networks
 
@@ -77,6 +78,7 @@ Each network has a CAIP-2 chain ID and a default public RPC endpoint.
 | Tron | `tron:mainnet` | `https://api.trongrid.io` |
 | TON | `ton:mainnet` | `https://toncenter.com/api/v2` |
 | Spark | `spark:mainnet` | — |
+| Filecoin | `fil:mainnet` | `https://api.node.glif.io/rpc/v1` |
 
 Default endpoints are public, rate-limited, and suitable for development.
 
@@ -120,6 +122,7 @@ cosmos    → cosmos:cosmoshub-4
 tron      → tron:mainnet
 ton       → ton:mainnet
 spark     → spark:mainnet
+filecoin  → fil:mainnet
 ```
 
 Aliases MUST be resolved to full CAIP-2 identifiers before any processing. They MUST NOT appear in wallet files, policy files, or audit logs.
@@ -140,7 +143,8 @@ Master Seed (512 bits via PBKDF2)
     ├── m/44'/118'/0'/0/0   → Cosmos Account 0
     ├── m/44'/195'/0'/0/0   → Tron Account 0
     ├── m/44'/607'/0'       → TON Account 0
-    └── m/84'/0'/0'/0/0     → Spark Account 0
+    ├── m/84'/0'/0'/0/0     → Spark Account 0
+    └── m/44'/461'/0'/0/0   → Filecoin Account 0
 ```
 
 A single mnemonic derives accounts across all supported chains. The wallet file stores the encrypted mnemonic; the signer derives the appropriate private key using each chain's coin type and derivation path.

--- a/docs/sdk-node.md
+++ b/docs/sdk-node.md
@@ -20,6 +20,7 @@ import {
   createWallet,
   listWallets,
   signMessage,
+  signTypedData,
   deleteWallet,
 } from "@open-wallet-standard/core";
 
@@ -89,7 +90,7 @@ const solAddr = deriveAddress(mnemonic, "solana");
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mnemonic` | `string` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `string` | &mdash; | `"evm"`, `"solana"`, `"bitcoin"`, `"cosmos"`, `"tron"` |
+| `chain` | `string` | &mdash; | `"evm"`, `"solana"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` |
 | `index` | `number` | `0` | Account index in derivation path |
 
 **Returns:** `string`
@@ -109,6 +110,8 @@ console.log(wallet.accounts);
 //   { chainId: "bip122:000...", address: "bc1q...", derivationPath: "m/84'/0'/0'/0/0" },
 //   { chainId: "cosmos:cosmoshub-4", address: "cosmos1...", derivationPath: "m/44'/118'/0'/0/0" },
 //   { chainId: "tron:mainnet", address: "TKLm...", derivationPath: "m/44'/195'/0'/0/0" },
+//   { chainId: "ton:mainnet", address: "UQ...", derivationPath: "m/44'/607'/0'" },
+//   { chainId: "fil:mainnet", address: "f1...", derivationPath: "m/44'/461'/0'/0/0" },
 // ]
 ```
 
@@ -182,7 +185,7 @@ const keys = JSON.parse(keysJson);
 
 #### `importWalletMnemonic(name, mnemonic, passphrase?, index?, vaultPath?)`
 
-Import a wallet from a BIP-39 mnemonic. Derives all 6 chain accounts via HD paths.
+Import a wallet from a BIP-39 mnemonic. Derives all 7 chain accounts via HD paths.
 
 ```javascript
 const wallet = importWalletMnemonic("imported", "goose puzzle decorate ...");
@@ -192,7 +195,7 @@ const wallet = importWalletMnemonic("imported", "goose puzzle decorate ...");
 
 #### `importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?)`
 
-Import a wallet from a hex-encoded private key. All 6 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
+Import a wallet from a hex-encoded private key. All 7 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
 
 The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
 
@@ -201,7 +204,7 @@ Alternatively, provide explicit keys for each curve via `secp256k1Key` and `ed25
 ```javascript
 // Import an EVM private key — generates a random Ed25519 key for Solana/TON
 const wallet = importWalletPrivateKey("from-evm", "4c0883a691...");
-console.log(wallet.accounts.length); // => 6
+console.log(wallet.accounts.length); // => 7
 
 // Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
 const wallet2 = importWalletPrivateKey(
@@ -224,7 +227,7 @@ console.log(wallet3.accounts.length); // => 6
 | `privateKeyHex` | `string` | &mdash; | Hex-encoded private key (with or without `0x` prefix). Ignored when both curve keys are provided. |
 | `passphrase` | `string` | `undefined` | Encryption passphrase |
 | `vaultPath` | `string` | `~/.ows/wallets` | Custom vault directory |
-| `chain` | `string` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"` (secp256k1) or `"solana"`, `"ton"` (Ed25519) |
+| `chain` | `string` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"ton"` (Ed25519) |
 | `secp256k1Key` | `string` | `undefined` | Explicit secp256k1 private key (hex). Overrides random generation for secp256k1 chains. |
 | `ed25519Key` | `string` | `undefined` | Explicit Ed25519 private key (hex). Overrides random generation for Ed25519 chains. |
 
@@ -249,6 +252,43 @@ console.log(result.recoveryId); // 0 or 1
 | `message` | `string` | &mdash; | Message to sign |
 | `passphrase` | `string` | `undefined` | Decryption passphrase |
 | `encoding` | `string` | `"utf8"` | `"utf8"` or `"hex"` |
+| `index` | `number` | `0` | Account index |
+| `vaultPath` | `string` | `~/.ows/wallets` | Custom vault directory |
+
+**Returns:** `SignResult`
+
+#### `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, vaultPath?)`
+
+Sign EIP-712 typed structured data (EVM only).
+
+```javascript
+const typedData = JSON.stringify({
+  types: {
+    EIP712Domain: [
+      { name: "name", type: "string" },
+      { name: "chainId", type: "uint256" },
+    ],
+    Transfer: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+  },
+  primaryType: "Transfer",
+  domain: { name: "MyDApp", chainId: "1" },
+  message: { to: "0xabc...", amount: "1000" },
+});
+
+const result = signTypedData("agent-treasury", "evm", typedData);
+console.log(result.signature);  // hex string
+console.log(result.recoveryId); // 27 or 28
+```
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `wallet` | `string` | &mdash; | Wallet name or ID |
+| `chain` | `string` | &mdash; | Must be an EVM chain |
+| `typedDataJson` | `string` | &mdash; | JSON string of EIP-712 typed data |
+| `passphrase` | `string` | `undefined` | Decryption passphrase |
 | `index` | `number` | `0` | Account index |
 | `vaultPath` | `string` | `~/.ows/wallets` | Custom vault directory |
 

--- a/docs/sdk-python.md
+++ b/docs/sdk-python.md
@@ -20,6 +20,7 @@ from open_wallet_standard import (
     create_wallet,
     list_wallets,
     sign_message,
+    sign_typed_data,
     delete_wallet,
 )
 
@@ -89,7 +90,7 @@ sol_addr = derive_address(mnemonic, "solana")
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mnemonic` | `str` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `str` | &mdash; | `"evm"`, `"solana"`, `"bitcoin"`, `"cosmos"`, `"tron"` |
+| `chain` | `str` | &mdash; | `"evm"`, `"solana"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` |
 | `index` | `int` | `0` | Account index in derivation path |
 
 ### Wallet Management
@@ -159,7 +160,7 @@ keys = json.loads(export_wallet("pk-wallet"))
 
 #### `import_wallet_mnemonic(name, mnemonic, passphrase=None, index=None, vault_path=None)`
 
-Import a wallet from a BIP-39 mnemonic. Derives all 6 chain accounts via HD paths.
+Import a wallet from a BIP-39 mnemonic. Derives all 7 chain accounts via HD paths.
 
 ```python
 wallet = import_wallet_mnemonic("imported", "goose puzzle decorate ...")
@@ -167,7 +168,7 @@ wallet = import_wallet_mnemonic("imported", "goose puzzle decorate ...")
 
 #### `import_wallet_private_key(name, private_key_hex, chain=None, passphrase=None, vault_path=None, secp256k1_key=None, ed25519_key=None)`
 
-Import a wallet from a hex-encoded private key. All 6 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
+Import a wallet from a hex-encoded private key. All 7 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
 
 The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
 
@@ -176,13 +177,13 @@ Alternatively, provide explicit keys for each curve via `secp256k1_key` and `ed2
 ```python
 # Import an EVM private key — generates a random Ed25519 key for Solana/TON
 wallet = import_wallet_private_key("from-evm", "4c0883a691...")
-print(len(wallet["accounts"]))  # => 6
+print(len(wallet["accounts"]))  # => 7
 
 # Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
 wallet = import_wallet_private_key(
     "from-solana", "9d61b19d...", chain="solana"
 )
-print(len(wallet["accounts"]))  # => 6
+print(len(wallet["accounts"]))  # => 7
 
 # Import explicit keys for both curves
 wallet = import_wallet_private_key(
@@ -190,14 +191,14 @@ wallet = import_wallet_private_key(
     secp256k1_key="4c0883a691...",
     ed25519_key="9d61b19d..."
 )
-print(len(wallet["accounts"]))  # => 6
+print(len(wallet["accounts"]))  # => 7
 ```
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `name` | `str` | &mdash; | Wallet name |
 | `private_key_hex` | `str` | &mdash; | Hex-encoded private key. Ignored when both curve keys are provided. |
-| `chain` | `str` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"` (secp256k1) or `"solana"`, `"ton"` (Ed25519) |
+| `chain` | `str` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"ton"` (Ed25519) |
 | `passphrase` | `str` | `None` | Encryption passphrase |
 | `vault_path` | `str` | `None` | Custom vault directory |
 | `secp256k1_key` | `str` | `None` | Explicit secp256k1 private key (hex) |
@@ -213,6 +214,34 @@ Sign a message with chain-specific formatting.
 result = sign_message("agent-treasury", "evm", "hello world")
 print(result["signature"])   # hex string
 print(result["recovery_id"]) # 0 or 1
+```
+
+#### `sign_typed_data(wallet, chain, typed_data_json, passphrase=None, index=None, vault_path=None)`
+
+Sign EIP-712 typed structured data (EVM only).
+
+```python
+import json
+
+typed_data = json.dumps({
+    "types": {
+        "EIP712Domain": [
+            {"name": "name", "type": "string"},
+            {"name": "chainId", "type": "uint256"},
+        ],
+        "Transfer": [
+            {"name": "to", "type": "address"},
+            {"name": "amount", "type": "uint256"},
+        ],
+    },
+    "primaryType": "Transfer",
+    "domain": {"name": "MyDApp", "chainId": "1"},
+    "message": {"to": "0xabc...", "amount": "1000"},
+})
+
+result = sign_typed_data("agent-treasury", "evm", typed_data)
+print(result["signature"])   # hex string
+print(result["recovery_id"]) # 27 or 28
 ```
 
 #### `sign_transaction(wallet, chain, tx_hex, passphrase=None, index=None, vault_path=None)`

--- a/readme/partials/supported-chains.md
+++ b/readme/partials/supported-chains.md
@@ -8,3 +8,4 @@
 | Cosmos | secp256k1 | bech32 | `m/44'/118'/0'/0/0` |
 | Tron | secp256k1 | base58check | `m/44'/195'/0'/0/0` |
 | TON | Ed25519 | raw/bounceable | `m/44'/607'/0'` |
+| Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |


### PR DESCRIPTION
## Summary

- Add Filecoin (f1 secp256k1) to supported chains documentation, known networks table, shorthand aliases, and HD derivation diagram
- Add `signTypedData` (EIP-712) as a dedicated operation in the signing interface spec
- Add `signTypedData` / `sign_typed_data` API reference to Node.js and Python SDK docs
- Update chain counts from 6 → 7 across all SDK docs and code examples
- Regenerate READMEs from updated partials

## Test plan

- [x] `./readme/generate.sh --check` passes
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)