### PR TITLE
Add keyring-backed wallet secret storage

### DIFF
--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -122,6 +122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +154,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -262,6 +277,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -440,7 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -672,6 +707,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +741,16 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -787,7 +847,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-core"
-version = "0.3.1"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "serde",
@@ -798,16 +858,18 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "0.3.1"
+version = "0.3.9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "hex",
+ "keyring",
  "ows-core",
  "ows-signer",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "uuid",
  "zeroize",
@@ -815,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "ows-node"
-version = "0.3.1"
+version = "0.3.9"
 dependencies = [
  "napi",
  "napi-build",
@@ -825,11 +887,12 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "0.3.1"
+version = "0.3.9"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
  "bech32 0.11.1",
+ "blake2",
  "bs58",
  "coins-bip32",
  "coins-bip39",
@@ -1129,6 +1192,42 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1546,12 +1645,86 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -79,18 +79,12 @@ pub fn derive_address(
 #[napi]
 pub fn create_wallet(
     name: String,
-    passphrase: Option<String>,
     words: Option<u32>,
     vault_path_opt: Option<String>,
 ) -> Result<WalletInfo> {
-    ows_lib::create_wallet(
-        &name,
-        words,
-        passphrase.as_deref(),
-        vault_path(vault_path_opt).as_deref(),
-    )
-    .map(WalletInfo::from)
-    .map_err(map_err)
+    ows_lib::create_wallet(&name, words, vault_path(vault_path_opt).as_deref())
+        .map(WalletInfo::from)
+        .map_err(map_err)
 }
 
 /// Import a wallet from a mnemonic phrase (derives addresses for all chains).
@@ -98,23 +92,16 @@ pub fn create_wallet(
 pub fn import_wallet_mnemonic(
     name: String,
     mnemonic: String,
-    passphrase: Option<String>,
     index: Option<u32>,
     vault_path_opt: Option<String>,
 ) -> Result<WalletInfo> {
-    ows_lib::import_wallet_mnemonic(
-        &name,
-        &mnemonic,
-        passphrase.as_deref(),
-        index,
-        vault_path(vault_path_opt).as_deref(),
-    )
-    .map(WalletInfo::from)
-    .map_err(map_err)
+    ows_lib::import_wallet_mnemonic(&name, &mnemonic, index, vault_path(vault_path_opt).as_deref())
+        .map(WalletInfo::from)
+        .map_err(map_err)
 }
 
 /// Import a wallet from a hex-encoded private key.
-/// All 6 chains are supported: the provided key is used for its curve's chains,
+/// All 7 chain families are supported: the provided key is used for its curve's chains,
 /// and a random key is generated for the other curve.
 /// The optional `chain` parameter specifies the key's source chain (e.g. "evm", "solana")
 /// to determine which curve it uses. Defaults to "evm" (secp256k1).
@@ -125,9 +112,8 @@ pub fn import_wallet_mnemonic(
 pub fn import_wallet_private_key(
     name: String,
     private_key_hex: String,
-    passphrase: Option<String>,
-    vault_path_opt: Option<String>,
     chain: Option<String>,
+    vault_path_opt: Option<String>,
     secp256k1_key: Option<String>,
     ed25519_key: Option<String>,
 ) -> Result<WalletInfo> {
@@ -135,7 +121,6 @@ pub fn import_wallet_private_key(
         &name,
         &private_key_hex,
         chain.as_deref(),
-        passphrase.as_deref(),
         vault_path(vault_path_opt).as_deref(),
         secp256k1_key.as_deref(),
         ed25519_key.as_deref(),
@@ -170,15 +155,9 @@ pub fn delete_wallet(name_or_id: String, vault_path_opt: Option<String>) -> Resu
 #[napi]
 pub fn export_wallet(
     name_or_id: String,
-    passphrase: Option<String>,
     vault_path_opt: Option<String>,
 ) -> Result<String> {
-    ows_lib::export_wallet(
-        &name_or_id,
-        passphrase.as_deref(),
-        vault_path(vault_path_opt).as_deref(),
-    )
-    .map_err(map_err)
+    ows_lib::export_wallet(&name_or_id, vault_path(vault_path_opt).as_deref()).map_err(map_err)
 }
 
 /// Rename a wallet.
@@ -202,7 +181,6 @@ pub fn sign_transaction(
     wallet: String,
     chain: String,
     tx_hex: String,
-    passphrase: Option<String>,
     index: Option<u32>,
     vault_path_opt: Option<String>,
 ) -> Result<SignResult> {
@@ -210,7 +188,6 @@ pub fn sign_transaction(
         &wallet,
         &chain,
         &tx_hex,
-        passphrase.as_deref(),
         index,
         vault_path(vault_path_opt).as_deref(),
     )
@@ -227,7 +204,6 @@ pub fn sign_message(
     wallet: String,
     chain: String,
     message: String,
-    passphrase: Option<String>,
     encoding: Option<String>,
     index: Option<u32>,
     vault_path_opt: Option<String>,
@@ -236,7 +212,6 @@ pub fn sign_message(
         &wallet,
         &chain,
         &message,
-        passphrase.as_deref(),
         encoding.as_deref(),
         index,
         vault_path(vault_path_opt).as_deref(),
@@ -254,7 +229,6 @@ pub fn sign_typed_data(
     wallet: String,
     chain: String,
     typed_data_json: String,
-    passphrase: Option<String>,
     index: Option<u32>,
     vault_path_opt: Option<String>,
 ) -> Result<SignResult> {
@@ -262,7 +236,6 @@ pub fn sign_typed_data(
         &wallet,
         &chain,
         &typed_data_json,
-        passphrase.as_deref(),
         index,
         vault_path(vault_path_opt).as_deref(),
     )
@@ -279,7 +252,6 @@ pub fn sign_and_send(
     wallet: String,
     chain: String,
     tx_hex: String,
-    passphrase: Option<String>,
     index: Option<u32>,
     rpc_url: Option<String>,
     vault_path_opt: Option<String>,
@@ -288,7 +260,6 @@ pub fn sign_and_send(
         &wallet,
         &chain,
         &tx_hex,
-        passphrase.as_deref(),
         index,
         rpc_url.as_deref(),
         vault_path(vault_path_opt).as_deref(),

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -113,6 +113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +145,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -245,6 +260,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -412,7 +447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -653,6 +688,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +713,16 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "log"
@@ -708,7 +768,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-core"
-version = "0.3.3"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "serde",
@@ -719,16 +779,18 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "0.3.3"
+version = "0.3.9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "hex",
+ "keyring",
  "ows-core",
  "ows-signer",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "uuid",
  "zeroize",
@@ -736,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "ows-python"
-version = "0.3.3"
+version = "0.3.9"
 dependencies = [
  "ows-lib",
  "pyo3",
@@ -744,11 +806,12 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "0.3.3"
+version = "0.3.9"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
  "bech32 0.11.1",
+ "blake2",
  "bs58",
  "coins-bip32",
  "coins-bip39",
@@ -1094,6 +1157,42 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1517,12 +1616,86 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -26,44 +26,40 @@ fn derive_address(mnemonic: &str, chain: &str, index: Option<u32>) -> PyResult<S
 
 /// Create a new universal wallet (derives addresses for all chains).
 #[pyfunction]
-#[pyo3(signature = (name, passphrase=None, words=None, vault_path_opt=None))]
+#[pyo3(signature = (name, words=None, vault_path_opt=None))]
 fn create_wallet(
     name: &str,
-    passphrase: Option<&str>,
     words: Option<u32>,
     vault_path_opt: Option<String>,
 ) -> PyResult<PyObject> {
-    let info = ows_lib::create_wallet(name, words, passphrase, vault_path(vault_path_opt).as_deref())
+    let info = ows_lib::create_wallet(name, words, vault_path(vault_path_opt).as_deref())
         .map_err(map_err)?;
     Python::with_gil(|py| wallet_info_to_dict(py, &info))
 }
 
 /// Import a wallet from a mnemonic phrase (derives addresses for all chains).
 #[pyfunction]
-#[pyo3(signature = (name, mnemonic, passphrase=None, index=None, vault_path_opt=None))]
+#[pyo3(signature = (name, mnemonic, index=None, vault_path_opt=None))]
 fn import_wallet_mnemonic(
     name: &str,
     mnemonic: &str,
-    passphrase: Option<&str>,
     index: Option<u32>,
     vault_path_opt: Option<String>,
 ) -> PyResult<PyObject> {
-    let info = ows_lib::import_wallet_mnemonic(
-        name, mnemonic, passphrase, index, vault_path(vault_path_opt).as_deref(),
-    )
-    .map_err(map_err)?;
+    let info =
+        ows_lib::import_wallet_mnemonic(name, mnemonic, index, vault_path(vault_path_opt).as_deref())
+            .map_err(map_err)?;
     Python::with_gil(|py| wallet_info_to_dict(py, &info))
 }
 
 /// Import a wallet from a hex-encoded private key (derives addresses for all chains).
 /// Optionally specify explicit keys per curve via `secp256k1_key` and `ed25519_key`.
 #[pyfunction]
-#[pyo3(signature = (name, private_key_hex, chain=None, passphrase=None, vault_path_opt=None, secp256k1_key=None, ed25519_key=None))]
+#[pyo3(signature = (name, private_key_hex, chain=None, vault_path_opt=None, secp256k1_key=None, ed25519_key=None))]
 fn import_wallet_private_key(
     name: &str,
     private_key_hex: &str,
     chain: Option<&str>,
-    passphrase: Option<&str>,
     vault_path_opt: Option<String>,
     secp256k1_key: Option<&str>,
     ed25519_key: Option<&str>,
@@ -72,7 +68,6 @@ fn import_wallet_private_key(
         name,
         private_key_hex,
         chain,
-        passphrase,
         vault_path(vault_path_opt).as_deref(),
         secp256k1_key,
         ed25519_key,
@@ -114,13 +109,12 @@ fn delete_wallet(name_or_id: &str, vault_path_opt: Option<String>) -> PyResult<(
 
 /// Export a wallet's secret (mnemonic or private key).
 #[pyfunction]
-#[pyo3(signature = (name_or_id, passphrase=None, vault_path_opt=None))]
+#[pyo3(signature = (name_or_id, vault_path_opt=None))]
 fn export_wallet(
     name_or_id: &str,
-    passphrase: Option<&str>,
     vault_path_opt: Option<String>,
 ) -> PyResult<String> {
-    ows_lib::export_wallet(name_or_id, passphrase, vault_path(vault_path_opt).as_deref())
+    ows_lib::export_wallet(name_or_id, vault_path(vault_path_opt).as_deref())
         .map_err(map_err)
 }
 
@@ -138,17 +132,16 @@ fn rename_wallet(
 
 /// Sign a transaction.
 #[pyfunction]
-#[pyo3(signature = (wallet, chain, tx_hex, passphrase=None, index=None, vault_path_opt=None))]
+#[pyo3(signature = (wallet, chain, tx_hex, index=None, vault_path_opt=None))]
 fn sign_transaction(
     wallet: &str,
     chain: &str,
     tx_hex: &str,
-    passphrase: Option<&str>,
     index: Option<u32>,
     vault_path_opt: Option<String>,
 ) -> PyResult<PyObject> {
     let result = ows_lib::sign_transaction(
-        wallet, chain, tx_hex, passphrase, index, vault_path(vault_path_opt).as_deref(),
+        wallet, chain, tx_hex, index, vault_path(vault_path_opt).as_deref(),
     )
     .map_err(map_err)?;
 
@@ -162,18 +155,17 @@ fn sign_transaction(
 
 /// Sign a message.
 #[pyfunction]
-#[pyo3(signature = (wallet, chain, message, passphrase=None, encoding=None, index=None, vault_path_opt=None))]
+#[pyo3(signature = (wallet, chain, message, encoding=None, index=None, vault_path_opt=None))]
 fn sign_message(
     wallet: &str,
     chain: &str,
     message: &str,
-    passphrase: Option<&str>,
     encoding: Option<&str>,
     index: Option<u32>,
     vault_path_opt: Option<String>,
 ) -> PyResult<PyObject> {
     let result = ows_lib::sign_message(
-        wallet, chain, message, passphrase, encoding, index,
+        wallet, chain, message, encoding, index,
         vault_path(vault_path_opt).as_deref(),
     )
     .map_err(map_err)?;
@@ -188,17 +180,16 @@ fn sign_message(
 
 /// Sign EIP-712 typed structured data (EVM only).
 #[pyfunction]
-#[pyo3(signature = (wallet, chain, typed_data_json, passphrase=None, index=None, vault_path_opt=None))]
+#[pyo3(signature = (wallet, chain, typed_data_json, index=None, vault_path_opt=None))]
 fn sign_typed_data(
     wallet: &str,
     chain: &str,
     typed_data_json: &str,
-    passphrase: Option<&str>,
     index: Option<u32>,
     vault_path_opt: Option<String>,
 ) -> PyResult<PyObject> {
     let result = ows_lib::sign_typed_data(
-        wallet, chain, typed_data_json, passphrase, index,
+        wallet, chain, typed_data_json, index,
         vault_path(vault_path_opt).as_deref(),
     )
     .map_err(map_err)?;
@@ -213,18 +204,17 @@ fn sign_typed_data(
 
 /// Sign and broadcast a transaction.
 #[pyfunction]
-#[pyo3(signature = (wallet, chain, tx_hex, passphrase=None, index=None, rpc_url=None, vault_path_opt=None))]
+#[pyo3(signature = (wallet, chain, tx_hex, index=None, rpc_url=None, vault_path_opt=None))]
 fn sign_and_send(
     wallet: &str,
     chain: &str,
     tx_hex: &str,
-    passphrase: Option<&str>,
     index: Option<u32>,
     rpc_url: Option<&str>,
     vault_path_opt: Option<String>,
 ) -> PyResult<PyObject> {
     let result = ows_lib::sign_and_send(
-        wallet, chain, tx_hex, passphrase, index, rpc_url,
+        wallet, chain, tx_hex, index, rpc_url,
         vault_path(vault_path_opt).as_deref(),
     )
     .map_err(map_err)?;

--- a/bindings/python/tests/test_bindings.py
+++ b/bindings/python/tests/test_bindings.py
@@ -40,7 +40,7 @@ def test_create_and_list_wallets(vault_dir):
     wallet = ows.create_wallet("test-wallet", vault_path_opt=vault_dir)
     assert wallet["name"] == "test-wallet"
     assert isinstance(wallet["accounts"], list)
-    assert len(wallet["accounts"]) == 5
+    assert len(wallet["accounts"]) == 7
 
     # Verify each chain family is present
     chain_ids = [a["chain_id"] for a in wallet["accounts"]]
@@ -49,6 +49,8 @@ def test_create_and_list_wallets(vault_dir):
     assert any(c.startswith("bip122:") for c in chain_ids)
     assert any(c.startswith("cosmos:") for c in chain_ids)
     assert any(c.startswith("tron:") for c in chain_ids)
+    assert any(c.startswith("ton:") for c in chain_ids)
+    assert any(c.startswith("fil:") for c in chain_ids)
 
     wallets = ows.list_wallets(vault_path_opt=vault_dir)
     assert len(wallets) == 1
@@ -95,7 +97,7 @@ def test_import_wallet_mnemonic(vault_dir):
         "imported", phrase, vault_path_opt=vault_dir
     )
     assert wallet["name"] == "imported"
-    assert len(wallet["accounts"]) == 5
+    assert len(wallet["accounts"]) == 7
 
     # EVM account should match derived address
     evm_account = next(a for a in wallet["accounts"] if a["chain_id"].startswith("eip155:"))

--- a/docs/01-storage-format.md
+++ b/docs/01-storage-format.md
@@ -1,62 +1,50 @@
 # 01 - Storage Format
 
-> How wallets are encrypted, structured, and stored on the local filesystem.
+> How OWS stores wallet metadata on disk while keeping wallet secrets in the OS keyring.
 
 ## Implementation Status
 
 | Feature | Status | Notes |
-|---------|--------|-------|
+|---|---|---|
 | Vault directory (`~/.ows/wallets/`) | Done | `ows-lib/src/vault.rs` |
-| Wallet file format (OWS v2 envelope over Keystore v3) | Done | `ows-core/src/wallet_file.rs` |
+| Wallet file format (`ows_version = 3`) | Done | `ows-core/src/wallet_file.rs` |
 | Filesystem permissions (700 dirs, 600 files) | Done | `ows-lib/src/vault.rs` |
+| OS keyring-backed secret storage | Done | `ows-lib/src/secret_store.rs` |
 | Permission verification on startup | Partial | Warns but does not refuse to operate |
 | Audit log (`~/.ows/logs/audit.jsonl`) | Done | `ows-cli/src/audit.rs` |
-| Crypto object (AES-256-GCM + scrypt) | Done | `ows-signer/src/crypto.rs` |
-| Keystore v3 import | Not started | No v3 import/re-wrap logic |
-| `~/.ows/keys/` directory + API key files | Not started | No API key system |
-| `~/.ows/policies/` directory + policy files | Not started | No policy system |
-| `~/.ows/plugins/` directory | Not started | Plugins are hardcoded |
-| Passphrase 12-char minimum enforcement | Not started | No validation at creation time |
+| Legacy embedded `crypto` field | Legacy input only | New wallets do not write it |
 
 ## Design Decision
 
-**OWS uses an extended Ethereum Keystore v3 format with per-chain type adaptations, stored in a well-known directory with strict filesystem permissions.**
+**OWS stores wallet metadata in JSON files and stores secret material in the OS keyring.**
+
+This splits the wallet into two parts:
+
+- A metadata file in `~/.ows/wallets/` that is easy to enumerate, rename, and inspect safely.
+- A keyring entry that holds the mnemonic or private key material and is protected by the host OS account.
 
 ### Why This Approach
 
-We evaluated four storage strategies:
-
 | Approach | Pros | Cons |
 |---|---|---|
-| Raw private keys in env vars | Simple | Catastrophically insecure; keys leak into logs, process lists, LLM contexts |
-| Cloud KMS (Privy, Turnkey) | Strong security, TEE-backed | Requires network; not local-first; vendor lock-in |
-| OS keychain (macOS Keychain, Windows DPAPI) | OS-level encryption | Not portable across platforms; no standard multi-key format |
-| **Encrypted JSON keystore** | Portable, proven, auditable, local-first | Must protect against brute-force; requires passphrase management |
+| Raw secrets in env vars | Simple | Secrets leak into logs, process state, and crash output |
+| Encrypted self-contained wallet files | Portable | Keeps the most sensitive bytes on disk and requires extra secret-unlock plumbing |
+| Full wallet blob in OS keyring | Strong local protection | Harder to enumerate and back up; keyring payload size varies by platform |
+| **Metadata file + keyring secret** | Good UX, clear indexing, small keyring entries | Backup/export must be explicit |
 
-The Ethereum Keystore v3 format has been battle-tested since 2015, is implemented in every major Web3 library, and provides strong encryption with configurable KDF parameters. OWS extends it to support non-EVM chains while maintaining backward compatibility with existing EVM tooling.
-
-## Vault Directory Structure
+## Vault Layout
 
 ```
 ~/.ows/
-├── config.json                    # Global configuration
+├── config.json
 ├── wallets/
-│   ├── <wallet-id>.json           # Encrypted wallet file (one per wallet)
-│   └── ...
-├── keys/
-│   ├── <key-id>.json              # API key definition (one per key)
-│   └── ...
-├── policies/
-│   ├── <policy-id>.json           # Policy definition
-│   └── ...
-├── plugins/
-│   ├── <chain-type>/              # Chain-specific plugins
-│   │   ├── signer.js              # Signing implementation
-│   │   └── builder.js             # Transaction builder
+│   ├── <wallet-id>.json
 │   └── ...
 └── logs/
-    └── audit.jsonl                # Append-only audit log
+    └── audit.jsonl
 ```
+
+The wallet file is the source of truth for metadata. The keyring is the source of truth for secret material.
 
 ### Filesystem Permissions
 
@@ -64,25 +52,21 @@ The Ethereum Keystore v3 format has been battle-tested since 2015, is implemente
 ~/.ows/                  drwx------  (700)
 ~/.ows/wallets/          drwx------  (700)
 ~/.ows/wallets/*.json    -rw-------  (600)
-~/.ows/keys/             drwx------  (700)
-~/.ows/keys/*.json       -rw-------  (600)
-~/.ows/policies/         drwxr-xr-x  (755)
-~/.ows/config.json       -rw-------  (600)
+~/.ows/logs/             drwx------  (700)
 ~/.ows/logs/audit.jsonl  -rw-------  (600)
+~/.ows/config.json       -rw-------  (600)
 ```
-
-The `wallets/` directory and its contents MUST be readable only by the owner. Implementations MUST verify permissions on startup and refuse to operate if the vault directory is world-readable or group-readable.
 
 ## Wallet File Format
 
-Each wallet is stored as a single JSON file extending the Ethereum Keystore v3 structure:
+Each wallet is stored as a single metadata file:
 
 ```json
 {
-  "ows_version": 2,
+  "ows_version": 3,
   "id": "3198bc9c-6672-5ab3-d995-4942343ae5b6",
   "name": "agent-treasury",
-  "created_at": "2026-02-27T10:30:00Z",
+  "created_at": "2026-03-21T10:30:00Z",
   "accounts": [
     {
       "account_id": "eip155:8453:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb",
@@ -91,22 +75,7 @@ Each wallet is stored as a single JSON file extending the Ethereum Keystore v3 s
       "derivation_path": "m/44'/60'/0'/0/0"
     }
   ],
-  "crypto": {
-    "cipher": "aes-256-gcm",
-    "cipherparams": {
-      "iv": "6087dab2f9fdbbfaddc31a90"
-    },
-    "ciphertext": "5318b4d5bcd28de64ee5559e671353e16f075ecae9f99c7a79a38af5f869aa46",
-    "auth_tag": "3c5d8c2f1a4b6e9d0f2a5c8b",
-    "kdf": "scrypt",
-    "kdfparams": {
-      "dklen": 32,
-      "n": 65536,
-      "r": 8,
-      "p": 1,
-      "salt": "ae3cd4e7013836a3df6bd7241b12db061dbe2c6785853cce422d148a624ce0bd"
-    }
-  },
+  "secret_ref": "wallet:v1:8cc95b9db1c68f74:3198bc9c-6672-5ab3-d995-4942343ae5b6",
   "key_type": "mnemonic",
   "metadata": {}
 }
@@ -116,116 +85,60 @@ Each wallet is stored as a single JSON file extending the Ethereum Keystore v3 s
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `ows_version` | integer | yes | Schema version (currently `2`) |
+| `ows_version` | integer | yes | Schema version. New wallets use `3`. |
 | `id` | string | yes | UUID v4 wallet identifier |
 | `name` | string | yes | Human-readable wallet name |
 | `created_at` | string | yes | ISO 8601 creation timestamp |
-| `accounts` | array | yes | Derived accounts (see Account object) |
-| `crypto` | object | yes | Encryption parameters (see Crypto object) |
-| `key_type` | string | yes | `mnemonic` (BIP-39) or `private_key` (raw) |
-| `metadata` | object | no | Extensible metadata |
+| `accounts` | array | yes | Derived account metadata |
+| `secret_ref` | string | yes | Reference used to locate the keyring entry |
+| `key_type` | string | yes | `mnemonic` or `private_key` |
+| `metadata` | object | no | Optional future metadata |
 
-## API Key File Format
+New wallets MUST NOT serialize the legacy `crypto` field.
 
-Each API key is stored as a JSON file in `~/.ows/keys/`:
+## Secret References
 
-```json
-{
-  "id": "7a2f1b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c",
-  "name": "claude-agent",
-  "token_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "created_at": "2026-02-27T10:30:00Z",
-  "wallet_ids": ["3198bc9c-6672-5ab3-d995-4942343ae5b6"],
-  "policy_ids": ["spending-limit-01", "safe-agent-policy"],
-  "expires_at": null
-}
+OWS stores one keyring entry per wallet. The reference format is:
+
+```text
+wallet:v1:<vault_scope>:<wallet_id>
 ```
 
-### Field Definitions
+- `vault_scope` is derived from the vault path so two different vault roots do not collide.
+- `wallet_id` keeps the entry stable across wallet renames.
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `id` | string | yes | UUID v4 key identifier |
-| `name` | string | yes | Human-readable label for the key |
-| `token_hash` | string | yes | SHA-256 hex digest of the raw token. The raw token (`ows_key_...`) is shown once at creation and never stored. |
-| `created_at` | string | yes | ISO 8601 creation timestamp |
-| `wallet_ids` | array | yes | Wallet IDs this key is authorized to access |
-| `policy_ids` | array | yes | Policy IDs evaluated on every request made with this key |
-| `expires_at` | string | no | ISO 8601 expiry timestamp. `null` means no expiry. |
+## Keyring Payload
 
-The `keys/` directory and its contents use the same strict permissions as `wallets/` (`700` for the directory, `600` for files) because the `token_hash` must be protected against local reads.
-
-### Crypto Object
-
-The `crypto` object follows Keystore v3 conventions with two upgrades:
-
-1. **AES-256-GCM** is the default cipher (upgraded from AES-128-CTR). GCM provides authenticated encryption, eliminating the need for a separate MAC field.
-2. **scrypt** remains the recommended KDF with the same parameter semantics. PBKDF2-SHA256 is an acceptable alternative for resource-constrained environments.
-
-| Field | Type | Description |
-|---|---|---|
-| `cipher` | string | `aes-256-gcm` (recommended) or `aes-128-ctr` (v3 compat) |
-| `cipherparams.iv` | string | Hex-encoded initialization vector |
-| `ciphertext` | string | Hex-encoded encrypted key material |
-| `auth_tag` | string | Hex-encoded GCM auth tag (only for `aes-256-gcm`) |
-| `kdf` | string | `scrypt` (recommended) or `pbkdf2` |
-| `kdfparams` | object | KDF-specific parameters |
-
-For `aes-128-ctr` (backward compat), a `mac` field with `keccak-256(dk[16..31] ++ ciphertext)` is required, following the Keystore v3 spec.
-
-### What Gets Encrypted
-
-The `ciphertext` contains the encrypted form of either:
-
-- **BIP-39 mnemonic entropy** (128 or 256 bits) — when `key_type` is `mnemonic`. The mnemonic can derive keys for any supported chain via BIP-44 derivation paths.
-- **Raw private key** (32 bytes for secp256k1/ed25519) — when `key_type` is `private_key`. Used for imported single-chain keys.
-
-Storing the mnemonic (rather than individual private keys) enables a single encrypted blob to derive accounts across multiple chains and indices.
-
-## Passphrase Management
-
-The vault passphrase is used to derive the encryption key via the configured KDF. OWS does NOT define how the passphrase is obtained — this is deliberately left to the implementation:
-
-- **Interactive CLI**: Prompt at first use, optionally cache in OS keychain for a session
-- **Agent/daemon mode**: Read from a file descriptor (RECOMMENDED), an environment variable (`OWS_PASSPHRASE`), or a hardware token. Environment variables are the least secure option — they are readable via `/proc/[pid]/environ` by same-user processes and leak into crash dumps and child process environments. Implementations using `OWS_PASSPHRASE` MUST clear it from the process environment immediately after reading.
-- **Unlocked mode** (development only): A config flag that uses a well-known passphrase — MUST produce a visible warning
-
-The passphrase MUST be at least 12 characters. Implementations SHOULD enforce this at wallet creation time.
-
-## Audit Log
-
-All signing operations are appended to `~/.ows/logs/audit.jsonl`:
+The keyring entry stores a small JSON record:
 
 ```json
 {
-  "timestamp": "2026-02-27T10:35:22Z",
+  "version": 1,
   "wallet_id": "3198bc9c-6672-5ab3-d995-4942343ae5b6",
-  "operation": "broadcast_transaction",
-  "chain_id": "eip155:8453",
-  "details": "tx_hash=0xabc123..."
+  "key_type": "mnemonic",
+  "payload": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 }
 ```
 
-Supported operations: `create_wallet`, `import_wallet`, `export_wallet`, `broadcast_transaction`, `delete_wallet`, `rename_wallet`.
+`payload` contains:
 
-All fields except `timestamp`, `wallet_id`, and `operation` are optional.
+- The mnemonic phrase when `key_type = "mnemonic"`.
+- A JSON string with both curve keys when `key_type = "private_key"`.
 
-The audit log is append-only. Implementations MUST NOT allow deletion or modification of existing entries. Log rotation is permitted (e.g., monthly archives).
+Example private-key payload:
 
-## Backward Compatibility
+```json
+{
+  "version": 1,
+  "wallet_id": "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+  "key_type": "private_key",
+  "payload": "{\"secp256k1\":\"4c0883...\",\"ed25519\":\"9d61b1...\"}"
+}
+```
 
-Any valid Ethereum Keystore v3 file can be imported into an OWS vault. The importer:
+## Operational Notes
 
-1. Reads the v3 JSON
-2. Wraps it in the OWS envelope (adds `ows_version`, `name`, `accounts`)
-3. Optionally re-encrypts with AES-256-GCM
-
-Exported OWS wallets with `cipher: "aes-128-ctr"` and `key_type: "private_key"` are valid Keystore v3 files (minus the OWS envelope fields, which are ignored by v3 parsers).
-
-## References
-
-- [Ethereum Web3 Secret Storage Definition](https://ethereum.org/developers/docs/data-structures-and-encoding/web3-secret-storage)
-- [ERC-2335: BLS12-381 Keystore](https://eips.ethereum.org/EIPS/eip-2335)
-- [BIP-39: Mnemonic Seed Phrases](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
-- [NIST SP 800-38D: GCM Mode](https://csrc.nist.gov/publications/detail/sp/800-38d/final)
-- [Privy: Low-Level Key Management](https://privy.io/blog/powering-programmable-wallets-with-low-level-key-management)
+- Listing wallets only reads metadata files.
+- Signing and export first resolve `secret_ref`, then fetch the secret from the OS keyring.
+- Deleting a wallet removes both the metadata file and the keyring entry.
+- Wallet files are no longer self-contained backups. Use `export_wallet` or `ows wallet export` when you need a portable backup.

--- a/docs/02-signing-interface.md
+++ b/docs/02-signing-interface.md
@@ -17,7 +17,6 @@
 | Tron broadcast (`/wallet/broadcasthex`) | Done | `send_transaction.rs` |
 | Error code: `WALLET_NOT_FOUND` | Done | `ows-core/src/error.rs` |
 | Error code: `CHAIN_NOT_SUPPORTED` | Done | `ows-core/src/error.rs` |
-| Error code: `INVALID_PASSPHRASE` | Done | `ows-core/src/error.rs` |
 | Error code: `POLICY_DENIED` | Not started | No policy engine |
 | Error code: `INSUFFICIENT_FUNDS` | Not started | |
 | Error code: `VAULT_LOCKED` | Not started | No session/lock concept |
@@ -67,13 +66,11 @@ interface SignResult {
 **Flow:**
 1. Resolve `walletId` → wallet file
 2. Resolve `chainId` → chain plugin
-3. Authenticate caller: owner (passphrase/passkey) or agent (API key)
-4. If agent: verify wallet is in API key's `walletIds` scope; evaluate API key's policies against the transaction
-5. If owner: skip policy evaluation (sudo access)
-6. If policies pass (or owner), decrypt key material in the signing enclave
-7. Sign via chain plugin's signer
-8. Wipe key material
-9. Return signed transaction
+3. Resolve `secret_ref` from the wallet file
+4. Load key material from the OS keyring
+5. Sign via the chain plugin's signer
+6. Wipe key material
+7. Return signed transaction
 
 ### `signAndSend(request: SignAndSendRequest): Promise<SignAndSendResult>`
 
@@ -107,7 +104,7 @@ ows sign send-tx \
   --rpc-url https://eth-sepolia.g.alchemy.com/v2/demo   # optional override
 ```
 
-The command signs the transaction using the wallet's encrypted mnemonic, resolves the RPC endpoint (flag > config override > built-in default), broadcasts via the chain-appropriate protocol, and prints the transaction hash. Use `--json` for structured output including `tx_hash`, `chain`, `rpc_url`, and `signature`.
+The command signs the transaction using the wallet secret resolved from the OS keyring, resolves the RPC endpoint (flag > config override > built-in default), broadcasts via the chain-appropriate protocol, and prints the transaction hash. Use `--json` for structured output including `tx_hash`, `chain`, `rpc_url`, and `signature`.
 
 Per-chain broadcast protocols:
 
@@ -238,7 +235,6 @@ interface OwsError {
 | `CHAIN_NOT_SUPPORTED` | No plugin loaded for the given chain |
 | `POLICY_DENIED` | Transaction rejected by policy engine |
 | `INSUFFICIENT_FUNDS` | Account balance too low |
-| `INVALID_PASSPHRASE` | Vault passphrase incorrect |
 | `VAULT_LOCKED` | Vault has not been unlocked |
 | `BROADCAST_FAILED` | Transaction broadcast rejected by RPC node |
 | `TIMEOUT` | Confirmation wait exceeded |

--- a/docs/04-agent-access-layer.md
+++ b/docs/04-agent-access-layer.md
@@ -1,132 +1,103 @@
 # 04 - Agent Access Layer
 
-> How AI agents, CLI tools, and applications access OWS wallets through native language bindings.
+> How applications, agents, and the CLI access OWS wallets through the shared Rust core.
 
 ## Implementation Status
 
 | Feature | Status | Notes |
-|---------|--------|-------|
+|---|---|---|
 | `generate_mnemonic(words?)` | Done | 12 or 24 words |
 | `derive_address(mnemonic, chain, index?)` | Done | |
-| `create_wallet(name, chain, passphrase, ...)` | Done | |
+| `create_wallet(name, words?, vault_path?)` | Done | Stores secrets in the OS keyring |
 | `import_wallet_mnemonic(...)` | Done | |
 | `import_wallet_private_key(...)` | Done | |
-| `list_wallets(vault_path?)` | Done | |
+| `list_wallets(vault_path?)` | Done | Reads wallet metadata files |
 | `get_wallet(name_or_id, vault_path?)` | Done | |
-| `delete_wallet(name_or_id, vault_path?)` | Done | |
-| `export_wallet(name_or_id, passphrase, ...)` | Done | |
-| `rename_wallet(name_or_id, new_name, ...)` | Done | |
-| `sign_transaction(...)` | Done | |
+| `delete_wallet(name_or_id, vault_path?)` | Done | Removes file + keyring entry |
+| `export_wallet(name_or_id, vault_path?)` | Done | Reads secret from keyring |
+| `rename_wallet(name_or_id, new_name, vault_path?)` | Done | Metadata only |
+| `sign_transaction(...)` | Done | Uses keyring-backed secret resolution |
 | `sign_message(...)` | Done | |
+| `sign_typed_data(...)` | Done | EVM only |
 | `sign_and_send(...)` | Done | |
 | Node.js NAPI bindings | Done | `bindings/node/src/lib.rs` |
 | Python PyO3 bindings | Done | `bindings/python/src/lib.rs` |
-| API key scoping (agent sees only permitted wallets) | Not started | No API key system |
-| Policy evaluation on agent requests | Not started | No policy engine |
-| MCP server | Not started | |
-| Audit logging from bindings (not just CLI) | Not started | Only CLI logs to audit |
 
 ## Design Decision
 
-**OWS exposes wallet operations through native language bindings backed by the core Rust implementation. Bindings call directly into the `ows-lib` crate via FFI — no HTTP server or subprocess is required. They are compiled native modules that run in-process.**
+**OWS exposes one Rust implementation through native bindings and the CLI.**
 
-## Native Language Bindings
+There is no required background daemon and no HTTP API in the current model. All callers use the same library surface:
 
-### Node.js (NAPI)
+1. Read wallet metadata from the vault.
+2. Resolve `secret_ref` from the wallet file.
+3. Load the wallet secret from the OS keyring.
+4. Perform export, signing, or broadcast.
 
-```bash
-npm install @open-wallet-standard/core
-```
+If the OS keyring is unavailable, secret-dependent operations fail explicitly. OWS does not silently fall back to embedded file secrets for new wallets.
+
+## Node.js Example
 
 ```typescript
-import { createWallet, listWallets, signMessage, signTransaction, signAndSend } from "@open-wallet-standard/core";
+import {
+  createWallet,
+  listWallets,
+  signMessage,
+  signAndSend,
+} from "@open-wallet-standard/core";
 
-// Create a wallet
-const wallet = createWallet("agent-treasury", "evm", "my-passphrase");
-// => { id, name, chain, address, derivation_path, created_at }
-
-// List all wallets
+const wallet = createWallet("agent-treasury");
 const wallets = listWallets();
 
-// Sign a message
-const sig = signMessage("agent-treasury", "evm", "hello", "my-passphrase");
-// => { signature, recoveryId? }
-
-// Sign and broadcast a transaction
-const result = signAndSend("agent-treasury", "evm", "<tx-hex>", "my-passphrase");
-// => { txHash }
+const sig = signMessage("agent-treasury", "evm", "hello");
+const result = signAndSend("agent-treasury", "evm", "<tx-hex>");
 ```
 
-### Python (PyO3)
-
-```bash
-pip install open-wallet-standard
-```
+## Python Example
 
 ```python
-from open_wallet_standard import create_wallet, list_wallets, sign_message, sign_transaction, sign_and_send
+from open_wallet_standard import (
+    create_wallet,
+    list_wallets,
+    sign_message,
+    sign_and_send,
+)
 
-# Create a wallet
-wallet = create_wallet("agent-treasury", "evm", "my-passphrase")
-# => {"id", "name", "chain", "address", "derivation_path", "created_at"}
-
-# List all wallets
+wallet = create_wallet("agent-treasury")
 wallets = list_wallets()
 
-# Sign a message
-sig = sign_message("agent-treasury", "evm", "hello", "my-passphrase")
-# => {"signature", "recovery_id"}
-
-# Sign and broadcast a transaction
-result = sign_and_send("agent-treasury", "evm", "<tx-hex>", "my-passphrase")
-# => {"tx_hash"}
+sig = sign_message("agent-treasury", "evm", "hello")
+result = sign_and_send("agent-treasury", "evm", "<tx-hex>")
 ```
 
-### Available Functions
+## Available Operations
 
-Both bindings expose the same 13 functions:
+Node uses camelCase names. Python uses snake_case names. Both bindings expose the same operations:
 
-| Function | Description |
+| Operation | Description |
 |---|---|
-| `generate_mnemonic(words?)` | Generate a BIP-39 mnemonic (12 or 24 words) |
-| `derive_address(mnemonic, chain, index?)` | Derive a chain-specific address from a mnemonic |
-| `create_wallet(name, chain, passphrase, words?, vault_path?)` | Create a new wallet (generates mnemonic, encrypts, saves) |
-| `import_wallet_mnemonic(name, chain, mnemonic, passphrase, index?, vault_path?)` | Import a wallet from a mnemonic |
-| `import_wallet_private_key(name, chain, key_hex, passphrase, vault_path?, secp256k1_key?, ed25519_key?)` | Import a wallet from a raw private key (or explicit per-curve keys) |
-| `list_wallets(vault_path?)` | List all wallets in the vault |
-| `get_wallet(name_or_id, vault_path?)` | Get a single wallet by name or ID |
+| `generate_mnemonic(words?)` | Generate a BIP-39 mnemonic |
+| `derive_address(mnemonic, chain, index?)` | Derive an address without creating a wallet |
+| `create_wallet(name, words?, vault_path?)` | Create a wallet and store its secret in the OS keyring |
+| `import_wallet_mnemonic(name, mnemonic, index?, vault_path?)` | Import a mnemonic-backed wallet |
+| `import_wallet_private_key(name, private_key_hex, chain?, vault_path?, secp256k1_key?, ed25519_key?)` | Import a private-key wallet |
+| `list_wallets(vault_path?)` | List wallet metadata |
+| `get_wallet(name_or_id, vault_path?)` | Load one wallet's metadata |
 | `delete_wallet(name_or_id, vault_path?)` | Delete a wallet |
-| `export_wallet(name_or_id, passphrase, vault_path?)` | Export a wallet's secret (mnemonic or private key) |
+| `export_wallet(name_or_id, vault_path?)` | Export the wallet secret |
 | `rename_wallet(name_or_id, new_name, vault_path?)` | Rename a wallet |
-| `sign_transaction(wallet, chain, tx_hex, passphrase, index?, vault_path?)` | Sign a transaction |
-| `sign_message(wallet, chain, message, passphrase, encoding?, index?, vault_path?)` | Sign a message |
-| `sign_and_send(wallet, chain, tx_hex, passphrase, index?, rpc_url?, vault_path?)` | Sign and broadcast a transaction |
+| `sign_transaction(wallet, chain, tx_hex, index?, vault_path?)` | Sign a transaction |
+| `sign_message(wallet, chain, message, encoding?, index?, vault_path?)` | Sign a message |
+| `sign_typed_data(wallet, chain, typed_data_json, index?, vault_path?)` | Sign EIP-712 typed data |
+| `sign_and_send(wallet, chain, tx_hex, index?, rpc_url?, vault_path?)` | Sign and broadcast a transaction |
 
-All functions operate on the default vault (`~/.ows/`) unless a custom `vault_path` is provided. The passphrase is used to decrypt wallet key material for signing operations.
+All operations default to the vault root at `~/.ows/` unless a custom `vault_path` is provided.
 
-> **Note:** Because the bindings run in-process, key material is decrypted within the application's address space. For use cases where key isolation is critical, consider running OWS in a separate subprocess.
+## Security Model
 
-## Agent Interaction Example
+- Wallet metadata is stored on disk.
+- Mnemonics and private keys are stored in the OS keyring.
+- Signing happens inside the caller process today, using secret material fetched on demand.
+- Applications do not need to manage secret prompts or encrypted wallet envelopes for new wallets.
 
-Here's how an AI agent interacts with OWS through the bindings using an API key. The API key scopes the agent to specific wallets and policies.
-
-```
-Agent: "I need to send 0.01 ETH to 0x4B08... on Base"
-
-1. Agent calls list_wallets to find available wallets
-   → Returns only wallets in the API key's scope
-   → [{ id: "3198bc9c-...", name: "agent-treasury", ... }]
-
-2. Agent calls sign_and_send to execute
-   → API key verified: wallet is in key's scope
-   → Policy engine evaluates the API key's attached policies
-   → Signing enclave decrypts key, signs, wipes
-   → Transaction broadcast to Base RPC
-   → Returns: { tx_hash: "0xabc..." }
-```
-
-At no point does the agent see the private key. The API key determines which wallets the agent can access, and the policies attached to the key constrain what operations are permitted.
-
-## References
-
-- [Privy Server Wallet REST API](https://docs.privy.io/guide/server-wallets/create)
+This keeps the public API small and makes the storage model the same across CLI, Node, and Python.

--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -147,7 +147,7 @@ Master Seed (512 bits via PBKDF2)
     └── m/44'/461'/0'/0/0   → Filecoin Account 0
 ```
 
-A single mnemonic derives accounts across all supported chains. The wallet file stores the encrypted mnemonic; the signer derives the appropriate private key using each chain's coin type and derivation path.
+A single mnemonic derives accounts across all supported chains. The wallet file stores account metadata and a `secret_ref`; the signer loads the mnemonic from the OS keyring and derives the appropriate private key using each chain's coin type and derivation path.
 
 ## Adding a New Chain
 

--- a/docs/sdk-cli.md
+++ b/docs/sdk-cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-> Command-line interface for managing wallets, signing, and key operations.
+> Command-line interface for wallet management, export, and signing.
 
 ## Install
 
@@ -16,84 +16,82 @@ cd core/ows
 cargo build --workspace --release
 ```
 
+Wallet metadata is stored under `~/.ows/wallets/`. Mnemonics and private keys are stored in the OS keyring.
+
 ## Wallet Commands
 
 ### `ows wallet create`
 
-Create a new wallet. Generates a BIP-39 mnemonic and derives addresses for all supported chains.
+Create a new wallet and store its mnemonic in the OS keyring.
 
 ```bash
 ows wallet create --name "my-wallet"
 ```
 
 | Flag | Description |
-|------|-------------|
+|---|---|
 | `--name <NAME>` | Wallet name (required) |
-| `--passphrase <PASS>` | Encryption passphrase (prompted if omitted) |
-| `--words <12\|24>` | Mnemonic word count (default: 12) |
-
-Output:
-
-```
-Created wallet 3198bc9c-...
-  eip155:1                              0xab16...   m/44'/60'/0'/0/0
-  solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp  7Kz9...    m/44'/501'/0'/0'
-  bip122:000000000019d6689c085ae165831e93   bc1q...    m/84'/0'/0'/0/0
-  cosmos:cosmoshub-4                     cosmos1... m/44'/118'/0'/0/0
-  tron:mainnet                           TKLm...    m/44'/195'/0'/0/0
-```
+| `--words <12|24>` | Mnemonic word count (default: 12) |
+| `--show-mnemonic` | Print the generated mnemonic once for backup |
 
 ### `ows wallet import`
 
-Import an existing wallet from a mnemonic or private key.
+Import a wallet from a mnemonic or private key.
 
 ```bash
-# Import from mnemonic (reads from OWS_MNEMONIC env or stdin)
-echo "goose puzzle decorate ..." | ows wallet import --name "imported" --mnemonic
+# Import from mnemonic (reads OWS_MNEMONIC or stdin)
+echo "abandon abandon ..." | ows wallet import --name imported --mnemonic
 
-# Import from private key (reads from OWS_PRIVATE_KEY env or stdin)
-echo "4c0883a691..." | ows wallet import --name "from-evm" --private-key
+# Import from private key (reads OWS_PRIVATE_KEY or stdin)
+echo "4c0883a691..." | ows wallet import --name from-evm --private-key
 
-# Import an Ed25519 key (e.g. from Solana)
-echo "9d61b19d..." | ows wallet import --name "from-sol" --private-key --chain solana
-
-# Import explicit keys for both curves (no stdin needed)
-ows wallet import --name "both" \
-  --secp256k1-key "4c0883a691..." \
-  --ed25519-key "9d61b19d..."
+# Import both curve keys from env vars
+OWS_SECP256K1_KEY=4c0883a691... \
+OWS_ED25519_KEY=9d61b19d... \
+ows wallet import --name both
 ```
 
 | Flag | Description |
-|------|-------------|
+|---|---|
 | `--name <NAME>` | Wallet name (required) |
 | `--mnemonic` | Import a mnemonic phrase |
 | `--private-key` | Import a raw private key |
-| `--chain <CHAIN>` | Source chain for private key import (determines curve, default: evm) |
-| `--index <N>` | Account index for HD derivation (mnemonic only, default: 0) |
-| `--secp256k1-key <HEX>` | Explicit secp256k1 private key. When combined with `--ed25519-key`, `--private-key` is not required. |
-| `--ed25519-key <HEX>` | Explicit Ed25519 private key. When combined with `--secp256k1-key`, `--private-key` is not required. |
-
-Private key imports generate all 6 chain accounts: the provided key is used for its curve's chains, and a random key is generated for the other curve. Use `--secp256k1-key` and `--ed25519-key` together to supply both keys explicitly.
+| `--chain <CHAIN>` | Source chain for private-key import (default: evm) |
+| `--index <N>` | Account index for mnemonic import (default: 0) |
 
 ### `ows wallet export`
 
-Export a wallet's secret to stdout. Requires an interactive terminal.
+Export a wallet secret to stdout.
 
 ```bash
 ows wallet export --wallet "my-wallet"
 ```
 
-- Mnemonic wallets output the phrase.
-- Private key wallets output JSON: `{"secp256k1":"hex...","ed25519":"hex..."}`.
-
-If the wallet is passphrase-protected, you will be prompted.
+- Mnemonic wallets print the phrase.
+- Private-key wallets print JSON with `secp256k1` and `ed25519`.
 
 ### `ows wallet list`
 
-List all wallets in the vault.
+List wallet metadata stored in the vault.
 
 ```bash
 ows wallet list
+```
+
+### `ows wallet rename`
+
+Rename a wallet.
+
+```bash
+ows wallet rename --wallet old-name --new-name new-name
+```
+
+### `ows wallet delete`
+
+Delete a wallet and its matching keyring entry.
+
+```bash
+ows wallet delete --wallet my-wallet --confirm
 ```
 
 ### `ows wallet info`
@@ -108,40 +106,60 @@ ows wallet info
 
 ### `ows sign message`
 
-Sign a message with chain-specific formatting (e.g., EIP-191 for EVM, `\x19TRON Signed Message` for Tron).
+Sign a message with chain-specific formatting.
 
 ```bash
-ows sign message --wallet "my-wallet" --chain evm --message "hello world"
+ows sign message --wallet my-wallet --chain evm --message "hello world"
 ```
 
 | Flag | Description |
-|------|-------------|
+|---|---|
 | `--wallet <NAME>` | Wallet name or ID |
-| `--chain <CHAIN>` | Chain family: `evm`, `solana`, `bitcoin`, `cosmos`, `tron` |
+| `--chain <CHAIN>` | Chain family or CAIP-2 chain ID |
 | `--message <MSG>` | Message to sign |
-| `--passphrase <PASS>` | Decryption passphrase |
-| `--encoding <ENC>` | Message encoding: `utf8` (default) or `hex` |
+| `--encoding <ENC>` | `utf8` (default) or `hex` |
+| `--typed-data <JSON>` | EIP-712 typed data for EVM chains |
+| `--index <N>` | Account index (default: 0) |
+| `--json` | Print structured JSON output |
 
 ### `ows sign tx`
 
-Sign a raw transaction (hex-encoded bytes).
+Sign a raw transaction.
 
 ```bash
-ows sign tx --wallet "my-wallet" --chain evm --tx "02f8..."
+ows sign tx --wallet my-wallet --chain evm --tx "02f8..."
 ```
 
 | Flag | Description |
-|------|-------------|
+|---|---|
 | `--wallet <NAME>` | Wallet name or ID |
-| `--chain <CHAIN>` | Chain family |
-| `--tx <HEX>` | Hex-encoded transaction bytes |
-| `--passphrase <PASS>` | Decryption passphrase |
+| `--chain <CHAIN>` | Chain family or CAIP-2 chain ID |
+| `--tx <HEX>` | Hex-encoded unsigned transaction bytes |
+| `--index <N>` | Account index (default: 0) |
+| `--json` | Print structured JSON output |
+
+### `ows sign send-tx`
+
+Sign and broadcast a transaction.
+
+```bash
+ows sign send-tx --wallet my-wallet --chain evm --tx "02f8..."
+```
+
+| Flag | Description |
+|---|---|
+| `--wallet <NAME>` | Wallet name or ID |
+| `--chain <CHAIN>` | Chain family or CAIP-2 chain ID |
+| `--tx <HEX>` | Hex-encoded unsigned transaction bytes |
+| `--index <N>` | Account index (default: 0) |
+| `--rpc-url <URL>` | Override the configured RPC endpoint |
+| `--json` | Print structured JSON output |
 
 ## Mnemonic Commands
 
 ### `ows mnemonic generate`
 
-Generate a new BIP-39 mnemonic phrase.
+Generate a mnemonic phrase.
 
 ```bash
 ows mnemonic generate --words 24
@@ -149,40 +167,20 @@ ows mnemonic generate --words 24
 
 ### `ows mnemonic derive`
 
-Derive an address from a mnemonic for a given chain. Reads the mnemonic from the `OWS_MNEMONIC` environment variable or stdin.
+Derive an address from a mnemonic read from `OWS_MNEMONIC` or stdin.
 
 ```bash
-echo "word1 word2 ..." | ows mnemonic derive --chain evm
+echo "abandon abandon ..." | ows mnemonic derive --chain evm
 ```
 
-## System Commands
-
-### `ows update`
-
-Update the `ows` binary to the latest release. Also updates Node.js and Python bindings if they are installed.
-
-```bash
-ows update
-ows update --force   # re-download even if already on latest
-```
-
-### `ows uninstall`
-
-Remove `ows` from the system. Also uninstalls Node.js and Python bindings if present.
-
-```bash
-ows uninstall          # keep wallet data
-ows uninstall --purge  # also remove ~/.ows (all wallet data)
-```
-
-## File Layout
+## Vault Layout
 
 ```
 ~/.ows/
-  bin/
-    ows                  # CLI binary
-  wallets/
-    <uuid>/
-      wallet.json        # Encrypted keystore (Keystore v3)
-      meta.json          # Name, chain, creation time
+├── wallets/
+│   └── <wallet-id>.json   # Wallet metadata
+└── logs/
+    └── audit.jsonl
 ```
+
+The wallet file is metadata only. Secret material is stored in the OS keyring.

--- a/docs/sdk-node.md
+++ b/docs/sdk-node.md
@@ -1,6 +1,6 @@
 # Node.js SDK
 
-> Native bindings for Node.js via NAPI. No CLI, no server, no subprocess &mdash; the Rust core runs in-process.
+> Native bindings for Node.js via NAPI. No CLI, no server, no subprocess.
 
 [![npm](https://img.shields.io/npm/v/@open-wallet-standard/core)](https://www.npmjs.com/package/@open-wallet-standard/core)
 
@@ -10,328 +10,162 @@
 npm install @open-wallet-standard/core
 ```
 
-The package includes prebuilt native binaries for macOS (arm64, x64) and Linux (x64, arm64). No Rust toolchain required.
+Wallet metadata is stored under `~/.ows/wallets/`. Mnemonics and private keys are stored in the OS keyring.
 
 ## Quick Start
 
 ```javascript
 import {
-  generateMnemonic,
   createWallet,
   listWallets,
   signMessage,
-  signTypedData,
-  deleteWallet,
+  exportWallet,
 } from "@open-wallet-standard/core";
 
-const mnemonic = generateMnemonic(12);
 const wallet = createWallet("my-wallet");
+console.log(wallet.accounts.length); // 7
+
+const wallets = listWallets();
 const sig = signMessage("my-wallet", "evm", "hello");
+const phrase = exportWallet("my-wallet");
+
+console.log(wallets.length);
 console.log(sig.signature);
+console.log(phrase.split(" ").length);
 ```
 
-## API Reference
-
-### Types
+## Types
 
 ```typescript
 interface AccountInfo {
-  chainId: string;        // CAIP-2 chain ID (e.g. "eip155:1")
-  address: string;        // Chain-native address
-  derivationPath: string; // BIP-44 path (e.g. "m/44'/60'/0'/0/0")
+  chainId: string;
+  address: string;
+  derivationPath: string;
 }
 
 interface WalletInfo {
-  id: string;             // UUID v4
+  id: string;
   name: string;
   accounts: AccountInfo[];
-  createdAt: string;      // ISO 8601
+  createdAt: string;
 }
 
 interface SignResult {
-  signature: string;      // Hex-encoded signature
-  recoveryId?: number;    // EVM/Tron recovery ID (v value)
+  signature: string;
+  recoveryId?: number;
 }
 
 interface SendResult {
-  txHash: string;         // Transaction hash
+  txHash: string;
 }
 ```
 
-### Mnemonic
+## API
+
+### Mnemonics
 
 #### `generateMnemonic(words?)`
 
-Generate a new BIP-39 mnemonic phrase.
-
-```javascript
-const phrase = generateMnemonic(12);  // or 24
-// => "goose puzzle decorate much stable beach ..."
-```
-
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `words` | `number` | `12` | Word count (12 or 24) |
-
-**Returns:** `string`
+Generate a new 12- or 24-word BIP-39 mnemonic.
 
 #### `deriveAddress(mnemonic, chain, index?)`
 
 Derive an address from a mnemonic without creating a wallet.
 
-```javascript
-const addr = deriveAddress(mnemonic, "evm");
-// => "0xCc1e2c3D077b7c0f5301ef400bDE30d0e23dF1C6"
-
-const solAddr = deriveAddress(mnemonic, "solana");
-// => "DzkqyvQrBvLqKSMhCoXoGK65e9PvyWjb6YjS4BqcxN2i"
-```
-
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mnemonic` | `string` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `string` | &mdash; | `"evm"`, `"solana"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` |
-| `index` | `number` | `0` | Account index in derivation path |
-
-**Returns:** `string`
-
 ### Wallet Management
 
-#### `createWallet(name, passphrase?, words?, vaultPath?)`
+#### `createWallet(name, words?, vaultPath?)`
 
-Create a new wallet. Generates a mnemonic and derives addresses for all supported chains.
+Create a wallet, derive accounts for all supported chain families, store the secret in the OS keyring, and write wallet metadata to the vault.
 
-```javascript
-const wallet = createWallet("agent-treasury");
-console.log(wallet.accounts);
-// => [
-//   { chainId: "eip155:1", address: "0x...", derivationPath: "m/44'/60'/0'/0/0" },
-//   { chainId: "solana:5eykt4...", address: "7Kz9...", derivationPath: "m/44'/501'/0'/0'" },
-//   { chainId: "bip122:000...", address: "bc1q...", derivationPath: "m/84'/0'/0'/0/0" },
-//   { chainId: "cosmos:cosmoshub-4", address: "cosmos1...", derivationPath: "m/44'/118'/0'/0/0" },
-//   { chainId: "tron:mainnet", address: "TKLm...", derivationPath: "m/44'/195'/0'/0/0" },
-//   { chainId: "ton:mainnet", address: "UQ...", derivationPath: "m/44'/607'/0'" },
-//   { chainId: "fil:mainnet", address: "f1...", derivationPath: "m/44'/461'/0'/0/0" },
-// ]
-```
+#### `importWalletMnemonic(name, mnemonic, index?, vaultPath?)`
 
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `name` | `string` | &mdash; | Wallet name |
-| `passphrase` | `string` | `undefined` | Encryption passphrase |
-| `words` | `number` | `12` | Mnemonic word count |
-| `vaultPath` | `string` | `~/.ows/wallets` | Custom vault directory |
+Import a mnemonic-backed wallet.
 
-**Returns:** `WalletInfo`
+#### `importWalletPrivateKey(name, privateKeyHex, chain?, vaultPath?, secp256k1Key?, ed25519Key?)`
+
+Import a private-key wallet. When only one curve key is provided, OWS generates the other curve's key so the wallet still has all 7 chain accounts.
 
 #### `listWallets(vaultPath?)`
 
-List all wallets in the vault.
-
-```javascript
-const wallets = listWallets();
-console.log(wallets.length); // => 1
-```
-
-**Returns:** `WalletInfo[]`
+List wallet metadata from the vault.
 
 #### `getWallet(nameOrId, vaultPath?)`
 
-Look up a wallet by name or UUID.
-
-```javascript
-const wallet = getWallet("agent-treasury");
-```
-
-**Returns:** `WalletInfo`
-
-#### `deleteWallet(nameOrId, vaultPath?)`
-
-Delete a wallet from the vault.
-
-```javascript
-deleteWallet("agent-treasury");
-```
+Load one wallet by name or ID.
 
 #### `renameWallet(nameOrId, newName, vaultPath?)`
 
-Rename a wallet.
+Rename a wallet. The keyring entry stays stable because it is keyed by wallet ID.
 
-```javascript
-renameWallet("old-name", "new-name");
-```
+#### `deleteWallet(nameOrId, vaultPath?)`
 
-#### `exportWallet(nameOrId, passphrase?, vaultPath?)`
+Delete the metadata file and the matching keyring entry.
 
-Export a wallet's secret.
+#### `exportWallet(nameOrId, vaultPath?)`
 
-- **Mnemonic wallets** return the phrase string.
-- **Private key wallets** return a JSON string with both curve keys:
+Export the wallet secret.
 
-```javascript
-// Mnemonic wallet
-const phrase = exportWallet("mn-wallet");
-// => "goose puzzle decorate much ..."
-
-// Private key wallet
-const keysJson = exportWallet("pk-wallet");
-const keys = JSON.parse(keysJson);
-// => { secp256k1: "4c0883a6...", ed25519: "9d61b19d..." }
-```
-
-**Returns:** `string`
-
-### Import
-
-#### `importWalletMnemonic(name, mnemonic, passphrase?, index?, vaultPath?)`
-
-Import a wallet from a BIP-39 mnemonic. Derives all 7 chain accounts via HD paths.
-
-```javascript
-const wallet = importWalletMnemonic("imported", "goose puzzle decorate ...");
-```
-
-**Returns:** `WalletInfo`
-
-#### `importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?)`
-
-Import a wallet from a hex-encoded private key. All 7 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
-
-The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
-
-Alternatively, provide explicit keys for each curve via `secp256k1Key` and `ed25519Key`. When both are given, `privateKeyHex` and `chain` are ignored.
-
-```javascript
-// Import an EVM private key — generates a random Ed25519 key for Solana/TON
-const wallet = importWalletPrivateKey("from-evm", "4c0883a691...");
-console.log(wallet.accounts.length); // => 7
-
-// Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
-const wallet2 = importWalletPrivateKey(
-  "from-solana", "9d61b19d...", undefined, undefined, "solana"
-);
-console.log(wallet2.accounts.length); // => 6
-
-// Import explicit keys for both curves
-const wallet3 = importWalletPrivateKey(
-  "both-keys", "", undefined, undefined, undefined,
-  "4c0883a691...",  // secp256k1 key
-  "9d61b19d..."     // ed25519 key
-);
-console.log(wallet3.accounts.length); // => 6
-```
-
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `name` | `string` | &mdash; | Wallet name |
-| `privateKeyHex` | `string` | &mdash; | Hex-encoded private key (with or without `0x` prefix). Ignored when both curve keys are provided. |
-| `passphrase` | `string` | `undefined` | Encryption passphrase |
-| `vaultPath` | `string` | `~/.ows/wallets` | Custom vault directory |
-| `chain` | `string` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"ton"` (Ed25519) |
-| `secp256k1Key` | `string` | `undefined` | Explicit secp256k1 private key (hex). Overrides random generation for secp256k1 chains. |
-| `ed25519Key` | `string` | `undefined` | Explicit Ed25519 private key (hex). Overrides random generation for Ed25519 chains. |
-
-**Returns:** `WalletInfo`
+- Mnemonic wallets return the phrase string.
+- Private-key wallets return JSON with `secp256k1` and `ed25519` fields.
 
 ### Signing
 
-#### `signMessage(wallet, chain, message, passphrase?, encoding?, index?, vaultPath?)`
+#### `signMessage(wallet, chain, message, encoding?, index?, vaultPath?)`
 
 Sign a message with chain-specific formatting.
 
-```javascript
-const result = signMessage("agent-treasury", "evm", "hello world");
-console.log(result.signature);  // hex string
-console.log(result.recoveryId); // 0 or 1
-```
+#### `signTypedData(wallet, chain, typedDataJson, index?, vaultPath?)`
 
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `wallet` | `string` | &mdash; | Wallet name or ID |
-| `chain` | `string` | &mdash; | Chain family |
-| `message` | `string` | &mdash; | Message to sign |
-| `passphrase` | `string` | `undefined` | Decryption passphrase |
-| `encoding` | `string` | `"utf8"` | `"utf8"` or `"hex"` |
-| `index` | `number` | `0` | Account index |
-| `vaultPath` | `string` | `~/.ows/wallets` | Custom vault directory |
+Sign EIP-712 typed data for EVM chains.
 
-**Returns:** `SignResult`
+#### `signTransaction(wallet, chain, txHex, index?, vaultPath?)`
 
-#### `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, vaultPath?)`
+Sign a raw transaction.
 
-Sign EIP-712 typed structured data (EVM only).
+#### `signAndSend(wallet, chain, txHex, index?, rpcUrl?, vaultPath?)`
+
+Sign and broadcast a transaction.
+
+## Examples
+
+### Import from mnemonic
 
 ```javascript
-const typedData = JSON.stringify({
-  types: {
-    EIP712Domain: [
-      { name: "name", type: "string" },
-      { name: "chainId", type: "uint256" },
-    ],
-    Transfer: [
-      { name: "to", type: "address" },
-      { name: "amount", type: "uint256" },
-    ],
-  },
-  primaryType: "Transfer",
-  domain: { name: "MyDApp", chainId: "1" },
-  message: { to: "0xabc...", amount: "1000" },
-});
+import { importWalletMnemonic } from "@open-wallet-standard/core";
 
-const result = signTypedData("agent-treasury", "evm", typedData);
-console.log(result.signature);  // hex string
-console.log(result.recoveryId); // 27 or 28
-```
-
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `wallet` | `string` | &mdash; | Wallet name or ID |
-| `chain` | `string` | &mdash; | Must be an EVM chain |
-| `typedDataJson` | `string` | &mdash; | JSON string of EIP-712 typed data |
-| `passphrase` | `string` | `undefined` | Decryption passphrase |
-| `index` | `number` | `0` | Account index |
-| `vaultPath` | `string` | `~/.ows/wallets` | Custom vault directory |
-
-**Returns:** `SignResult`
-
-#### `signTransaction(wallet, chain, txHex, passphrase?, index?, vaultPath?)`
-
-Sign a raw transaction (hex-encoded bytes).
-
-```javascript
-const result = signTransaction("agent-treasury", "evm", "02f8...");
-console.log(result.signature);
-```
-
-**Returns:** `SignResult`
-
-#### `signAndSend(wallet, chain, txHex, passphrase?, index?, rpcUrl?, vaultPath?)`
-
-Sign and broadcast a transaction. Requires an RPC URL.
-
-```javascript
-const result = signAndSend(
-  "agent-treasury", "evm", "02f8...",
-  undefined, undefined, "https://mainnet.infura.io/v3/..."
+const wallet = importWalletMnemonic(
+  "imported",
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 );
-console.log(result.txHash);
+
+console.log(wallet.accounts.length); // 7
 ```
 
-**Returns:** `SendResult`
-
-## Custom Vault Path
-
-Every function accepts an optional `vaultPath` parameter. When omitted, the default vault at `~/.ows/wallets/` is used. This is useful for testing or running isolated environments:
+### Import explicit curve keys
 
 ```javascript
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { importWalletPrivateKey } from "@open-wallet-standard/core";
 
-const tmpVault = mkdtempSync(join(tmpdir(), "ows-test-"));
+const wallet = importWalletPrivateKey(
+  "both-keys",
+  "",
+  undefined,
+  undefined,
+  "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+  "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
+);
 
-const wallet = createWallet("test-wallet", undefined, 12, tmpVault);
-// ... use wallet ...
-
-rmSync(tmpVault, { recursive: true, force: true });
+console.log(wallet.accounts.length); // 7
 ```
+
+### Custom vault root
+
+```javascript
+import { createWallet } from "@open-wallet-standard/core";
+
+const wallet = createWallet("isolated", 12, "/tmp/ows-test");
+console.log(wallet.id);
+```
+
+`vaultPath` points at the vault root, not the `wallets/` subdirectory. When omitted, OWS uses `~/.ows/`.

--- a/docs/sdk-python.md
+++ b/docs/sdk-python.md
@@ -1,6 +1,6 @@
 # Python SDK
 
-> Native bindings for Python via PyO3. No CLI, no server, no subprocess &mdash; the Rust core runs in-process.
+> Native bindings for Python via PyO3. No CLI, no server, no subprocess.
 
 [![PyPI](https://img.shields.io/pypi/v/open-wallet-standard)](https://pypi.org/project/open-wallet-standard/)
 
@@ -10,52 +10,50 @@
 pip install open-wallet-standard
 ```
 
-Prebuilt wheels are available for macOS (arm64, x64) and Linux (x64, arm64) on Python 3.9&ndash;3.13.
+Wallet metadata is stored under `~/.ows/wallets/`. Mnemonics and private keys are stored in the OS keyring.
 
 ## Quick Start
 
 ```python
 from open_wallet_standard import (
-    generate_mnemonic,
     create_wallet,
     list_wallets,
     sign_message,
-    sign_typed_data,
-    delete_wallet,
+    export_wallet,
 )
 
-mnemonic = generate_mnemonic(12)
 wallet = create_wallet("my-wallet")
+wallets = list_wallets()
 sig = sign_message("my-wallet", "evm", "hello")
+phrase = export_wallet("my-wallet")
+
+print(len(wallet["accounts"]))  # 7
+print(len(wallets))
 print(sig["signature"])
+print(len(phrase.split()))
 ```
 
-## API Reference
-
-### Return Types
-
-All functions return Python dicts. Wallet functions return:
+## Return Types
 
 ```python
 # WalletInfo
 {
-    "id": "3198bc9c-...",             # UUID v4
+    "id": "3198bc9c-...",
     "name": "my-wallet",
-    "created_at": "2026-03-09T...",   # ISO 8601
+    "created_at": "2026-03-21T10:30:00Z",
     "accounts": [
         {
             "chain_id": "eip155:1",
             "address": "0xab16...",
             "derivation_path": "m/44'/60'/0'/0/0",
-        },
-        # ... one per supported chain
+        }
     ],
 }
 
 # SignResult
 {
-    "signature": "bea6b4ee...",       # Hex-encoded
-    "recovery_id": 0,                 # EVM/Tron only (None for others)
+    "signature": "bea6b4ee...",
+    "recovery_id": 0,
 }
 
 # SendResult
@@ -64,219 +62,110 @@ All functions return Python dicts. Wallet functions return:
 }
 ```
 
-### Mnemonic
+## API
+
+### Mnemonics
 
 #### `generate_mnemonic(words=12)`
 
-Generate a new BIP-39 mnemonic phrase.
+Generate a new 12- or 24-word mnemonic.
 
-```python
-phrase = generate_mnemonic(12)  # or 24
-# => "goose puzzle decorate much stable beach ..."
-```
-
-#### `derive_address(mnemonic, chain, index=0)`
+#### `derive_address(mnemonic, chain, index=None)`
 
 Derive an address from a mnemonic without creating a wallet.
 
-```python
-addr = derive_address(mnemonic, "evm")
-# => "0xCc1e2c3D077b7c0f5301ef400bDE30d0e23dF1C6"
-
-sol_addr = derive_address(mnemonic, "solana")
-# => "DzkqyvQrBvLqKSMhCoXoGK65e9PvyWjb6YjS4BqcxN2i"
-```
-
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mnemonic` | `str` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `str` | &mdash; | `"evm"`, `"solana"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` |
-| `index` | `int` | `0` | Account index in derivation path |
-
 ### Wallet Management
 
-#### `create_wallet(name, passphrase=None, words=12, vault_path=None)`
+#### `create_wallet(name, words=None, vault_path_opt=None)`
 
-Create a new wallet. Derives addresses for all supported chains.
+Create a wallet, derive accounts for all supported chain families, store the secret in the OS keyring, and write wallet metadata to the vault.
 
-```python
-wallet = create_wallet("agent-treasury")
-for acct in wallet["accounts"]:
-    print(f"{acct['chain_id']}: {acct['address']}")
-```
+#### `import_wallet_mnemonic(name, mnemonic, index=None, vault_path_opt=None)`
 
-#### `list_wallets(vault_path=None)`
+Import a mnemonic-backed wallet.
 
-List all wallets in the vault.
+#### `import_wallet_private_key(name, private_key_hex, chain=None, vault_path_opt=None, secp256k1_key=None, ed25519_key=None)`
 
-```python
-wallets = list_wallets()
-print(len(wallets))
-```
+Import a private-key wallet. When only one curve key is provided, OWS generates the other curve's key so the wallet still has all 7 chain accounts.
 
-#### `get_wallet(name_or_id, vault_path=None)`
+#### `list_wallets(vault_path_opt=None)`
 
-Look up a wallet by name or UUID.
+List wallet metadata from the vault.
 
-```python
-wallet = get_wallet("agent-treasury")
-```
+#### `get_wallet(name_or_id, vault_path_opt=None)`
 
-#### `delete_wallet(name_or_id, vault_path=None)`
+Load one wallet by name or ID.
 
-Delete a wallet from the vault.
+#### `rename_wallet(name_or_id, new_name, vault_path_opt=None)`
 
-```python
-delete_wallet("agent-treasury")
-```
+Rename a wallet. The keyring entry stays stable because it is keyed by wallet ID.
 
-#### `rename_wallet(name_or_id, new_name, vault_path=None)`
+#### `delete_wallet(name_or_id, vault_path_opt=None)`
 
-Rename a wallet.
+Delete the metadata file and the matching keyring entry.
 
-```python
-rename_wallet("old-name", "new-name")
-```
+#### `export_wallet(name_or_id, vault_path_opt=None)`
 
-#### `export_wallet(name_or_id, passphrase=None, vault_path=None)`
+Export the wallet secret.
 
-Export a wallet's secret.
-
-- **Mnemonic wallets** return the phrase string.
-- **Private key wallets** return a JSON string with both curve keys.
-
-```python
-# Mnemonic wallet
-phrase = export_wallet("mn-wallet")
-# => "goose puzzle decorate much ..."
-
-# Private key wallet
-import json
-keys = json.loads(export_wallet("pk-wallet"))
-# => {"secp256k1": "4c0883a6...", "ed25519": "9d61b19d..."}
-```
-
-### Import
-
-#### `import_wallet_mnemonic(name, mnemonic, passphrase=None, index=None, vault_path=None)`
-
-Import a wallet from a BIP-39 mnemonic. Derives all 7 chain accounts via HD paths.
-
-```python
-wallet = import_wallet_mnemonic("imported", "goose puzzle decorate ...")
-```
-
-#### `import_wallet_private_key(name, private_key_hex, chain=None, passphrase=None, vault_path=None, secp256k1_key=None, ed25519_key=None)`
-
-Import a wallet from a hex-encoded private key. All 7 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
-
-The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
-
-Alternatively, provide explicit keys for each curve via `secp256k1_key` and `ed25519_key`. When both are given, `private_key_hex` and `chain` are ignored.
-
-```python
-# Import an EVM private key — generates a random Ed25519 key for Solana/TON
-wallet = import_wallet_private_key("from-evm", "4c0883a691...")
-print(len(wallet["accounts"]))  # => 7
-
-# Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
-wallet = import_wallet_private_key(
-    "from-solana", "9d61b19d...", chain="solana"
-)
-print(len(wallet["accounts"]))  # => 7
-
-# Import explicit keys for both curves
-wallet = import_wallet_private_key(
-    "both-keys", "",
-    secp256k1_key="4c0883a691...",
-    ed25519_key="9d61b19d..."
-)
-print(len(wallet["accounts"]))  # => 7
-```
-
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `name` | `str` | &mdash; | Wallet name |
-| `private_key_hex` | `str` | &mdash; | Hex-encoded private key. Ignored when both curve keys are provided. |
-| `chain` | `str` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"ton"` (Ed25519) |
-| `passphrase` | `str` | `None` | Encryption passphrase |
-| `vault_path` | `str` | `None` | Custom vault directory |
-| `secp256k1_key` | `str` | `None` | Explicit secp256k1 private key (hex) |
-| `ed25519_key` | `str` | `None` | Explicit Ed25519 private key (hex) |
+- Mnemonic wallets return the phrase string.
+- Private-key wallets return JSON with `secp256k1` and `ed25519` fields.
 
 ### Signing
 
-#### `sign_message(wallet, chain, message, passphrase=None, encoding=None, index=None, vault_path=None)`
+#### `sign_message(wallet, chain, message, encoding=None, index=None, vault_path_opt=None)`
 
 Sign a message with chain-specific formatting.
 
-```python
-result = sign_message("agent-treasury", "evm", "hello world")
-print(result["signature"])   # hex string
-print(result["recovery_id"]) # 0 or 1
-```
+#### `sign_typed_data(wallet, chain, typed_data_json, index=None, vault_path_opt=None)`
 
-#### `sign_typed_data(wallet, chain, typed_data_json, passphrase=None, index=None, vault_path=None)`
+Sign EIP-712 typed data for EVM chains.
 
-Sign EIP-712 typed structured data (EVM only).
+#### `sign_transaction(wallet, chain, tx_hex, index=None, vault_path_opt=None)`
 
-```python
-import json
+Sign a raw transaction.
 
-typed_data = json.dumps({
-    "types": {
-        "EIP712Domain": [
-            {"name": "name", "type": "string"},
-            {"name": "chainId", "type": "uint256"},
-        ],
-        "Transfer": [
-            {"name": "to", "type": "address"},
-            {"name": "amount", "type": "uint256"},
-        ],
-    },
-    "primaryType": "Transfer",
-    "domain": {"name": "MyDApp", "chainId": "1"},
-    "message": {"to": "0xabc...", "amount": "1000"},
-})
-
-result = sign_typed_data("agent-treasury", "evm", typed_data)
-print(result["signature"])   # hex string
-print(result["recovery_id"]) # 27 or 28
-```
-
-#### `sign_transaction(wallet, chain, tx_hex, passphrase=None, index=None, vault_path=None)`
-
-Sign a raw transaction (hex-encoded bytes).
-
-```python
-result = sign_transaction("agent-treasury", "evm", "02f8...")
-print(result["signature"])
-```
-
-#### `sign_and_send(wallet, chain, tx_hex, passphrase=None, index=None, rpc_url=None, vault_path=None)`
+#### `sign_and_send(wallet, chain, tx_hex, index=None, rpc_url=None, vault_path_opt=None)`
 
 Sign and broadcast a transaction.
 
+## Examples
+
+### Import from mnemonic
+
 ```python
-result = sign_and_send(
-    "agent-treasury", "evm", "02f8...",
-    rpc_url="https://mainnet.infura.io/v3/..."
+from open_wallet_standard import import_wallet_mnemonic
+
+wallet = import_wallet_mnemonic(
+    "imported",
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
 )
-print(result["tx_hash"])
+
+print(len(wallet["accounts"]))  # 7
 ```
 
-## Custom Vault Path
-
-Every function accepts an optional `vault_path` parameter for testing or isolation:
+### Import explicit curve keys
 
 ```python
-import tempfile
-import shutil
+from open_wallet_standard import import_wallet_private_key
 
-vault = tempfile.mkdtemp(prefix="ows-test-")
-try:
-    wallet = create_wallet("test", vault_path=vault)
-    # ... use wallet ...
-finally:
-    shutil.rmtree(vault)
+wallet = import_wallet_private_key(
+    "both-keys",
+    "",
+    secp256k1_key="4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+    ed25519_key="9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+)
+
+print(len(wallet["accounts"]))  # 7
 ```
+
+### Custom vault root
+
+```python
+from open_wallet_standard import create_wallet
+
+wallet = create_wallet("isolated", vault_path_opt="/tmp/ows-test")
+print(wallet["id"])
+```
+
+`vault_path_opt` points at the vault root, not the `wallets/` subdirectory. When omitted, OWS uses `~/.ows/`.

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -197,6 +197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +356,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -761,6 +787,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +812,16 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -857,10 +908,12 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "k256",
+ "keyring",
  "ows-core",
  "ows-signer",
  "serde",
  "serde_json",
+ "sha2",
  "sha3",
  "tempfile",
  "thiserror 2.0.18",
@@ -1186,6 +1239,42 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1626,7 +1715,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1635,7 +1724,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1653,14 +1751,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1670,10 +1785,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1682,10 +1809,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1694,10 +1833,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1706,10 +1857,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/ows/crates/ows-cli/src/commands/mod.rs
+++ b/ows/crates/ows-cli/src/commands/mod.rs
@@ -9,12 +9,10 @@ pub mod uninstall;
 pub mod update;
 pub mod wallet;
 
-use crate::{vault, CliError};
-use ows_core::KeyType;
+use crate::CliError;
 use ows_signer::process_hardening::clear_env_var;
-use ows_signer::{CryptoEnvelope, SecretBytes};
 use std::io::{self, BufRead, IsTerminal, Write};
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroizing;
 
 /// Read mnemonic from OWS_MNEMONIC env var (or LWS_MNEMONIC fallback) or stdin.
 pub fn read_mnemonic() -> Result<Zeroizing<String>, CliError> {
@@ -72,103 +70,4 @@ pub fn read_private_key() -> Result<Zeroizing<String>, CliError> {
     }
 
     Ok(Zeroizing::new(trimmed))
-}
-
-/// Resolved wallet secret — either a mnemonic phrase or a key pair (JSON).
-pub enum WalletSecret {
-    Mnemonic(Zeroizing<String>),
-    /// JSON key pair: `{"secp256k1":"hex","ed25519":"hex"}`
-    PrivateKeys(SecretBytes),
-}
-
-/// Read a passphrase from OWS_PASSPHRASE env var (or LWS_PASSPHRASE fallback) or prompt interactively.
-pub fn read_passphrase() -> Zeroizing<String> {
-    if let Some(value) = clear_env_var("OWS_PASSPHRASE").or_else(|| clear_env_var("LWS_PASSPHRASE"))
-    {
-        return Zeroizing::new(value);
-    }
-    let stdin = io::stdin();
-    if stdin.is_terminal() {
-        eprint!("Passphrase (empty for none): ");
-        io::stderr().flush().ok();
-        let mut line = String::new();
-        stdin.lock().read_line(&mut line).unwrap_or(0);
-        Zeroizing::new(line.trim().to_string())
-    } else {
-        Zeroizing::new(String::new())
-    }
-}
-
-/// Look up a wallet by name or ID, decrypt it, and return the secret.
-/// Handles both mnemonic and private key wallets.
-pub fn resolve_wallet_secret(wallet_name: &str) -> Result<WalletSecret, CliError> {
-    let wallet = vault::load_wallet_by_name_or_id(wallet_name)?;
-    let envelope: CryptoEnvelope = serde_json::from_value(wallet.crypto.clone())?;
-
-    // Try empty passphrase first, then prompt if it fails
-    let secret = match ows_signer::decrypt(&envelope, "") {
-        Ok(s) => s,
-        Err(_) => {
-            let passphrase = read_passphrase();
-            ows_signer::decrypt(&envelope, &passphrase)?
-        }
-    };
-
-    match wallet.key_type {
-        KeyType::Mnemonic => {
-            let phrase =
-                Zeroizing::new(String::from_utf8(secret.expose().to_vec()).map_err(|_| {
-                    CliError::InvalidArgs("wallet contains invalid mnemonic".into())
-                })?);
-            Ok(WalletSecret::Mnemonic(phrase))
-        }
-        KeyType::PrivateKey => Ok(WalletSecret::PrivateKeys(secret)),
-    }
-}
-
-/// Extract a private key for a specific curve from a JSON key pair.
-fn extract_key_for_curve(
-    json_bytes: &[u8],
-    curve: ows_signer::Curve,
-) -> Result<SecretBytes, CliError> {
-    let s = String::from_utf8(json_bytes.to_vec())
-        .map_err(|_| CliError::InvalidArgs("invalid key data".into()))?;
-    let obj: serde_json::Value = serde_json::from_str(&s)?;
-    let field = match curve {
-        ows_signer::Curve::Secp256k1 => "secp256k1",
-        ows_signer::Curve::Ed25519 => "ed25519",
-    };
-    let hex_key = obj[field]
-        .as_str()
-        .ok_or_else(|| CliError::InvalidArgs(format!("missing {field} key in wallet")))?;
-    let bytes = hex::decode(hex_key)
-        .map_err(|e| CliError::InvalidArgs(format!("invalid {field} hex: {e}")))?;
-    Ok(SecretBytes::from_slice(&bytes))
-}
-
-/// Resolve a wallet secret into the private key bytes for a specific chain.
-///
-/// This is the single place where `WalletSecret` → `SecretBytes` conversion
-/// happens, so signing commands don't duplicate HD derivation / key-pair
-/// extraction logic.
-pub fn resolve_signing_key(
-    wallet_name: &str,
-    chain_type: ows_core::ChainType,
-    index: u32,
-) -> Result<SecretBytes, CliError> {
-    let wallet_secret = resolve_wallet_secret(wallet_name)?;
-    let signer = ows_signer::signer_for_chain(chain_type);
-
-    match wallet_secret {
-        WalletSecret::Mnemonic(mut phrase) => {
-            let mnemonic = ows_signer::Mnemonic::from_phrase(&phrase)?;
-            phrase.zeroize();
-            let path = signer.default_derivation_path(index);
-            let curve = signer.curve();
-            Ok(ows_signer::HdDeriver::derive_from_mnemonic_cached(
-                &mnemonic, "", &path, curve,
-            )?)
-        }
-        WalletSecret::PrivateKeys(secret) => extract_key_for_curve(secret.expose(), signer.curve()),
-    }
 }

--- a/ows/crates/ows-cli/src/commands/send_transaction.rs
+++ b/ows/crates/ows-cli/src/commands/send_transaction.rs
@@ -1,4 +1,4 @@
-use crate::{audit, parse_chain, CliError};
+use crate::{audit, CliError};
 
 pub fn run(
     chain_str: &str,
@@ -8,17 +8,14 @@ pub fn run(
     json_output: bool,
     rpc_url_override: Option<&str>,
 ) -> Result<(), CliError> {
-    let chain = parse_chain(chain_str)?;
-    let key = super::resolve_signing_key(wallet_name, chain.chain_type, index)?;
-
-    let tx_hex_clean = tx_hex.strip_prefix("0x").unwrap_or(tx_hex);
-    let tx_bytes = hex::decode(tx_hex_clean)
-        .map_err(|e| CliError::InvalidArgs(format!("invalid hex transaction: {e}")))?;
-
-    // Delegate sign → encode → broadcast to the library so this pipeline
-    // is never duplicated between the CLI and the library.
-    let result =
-        ows_lib::sign_encode_and_broadcast(key.expose(), chain_str, &tx_bytes, rpc_url_override)?;
+    let result = ows_lib::sign_and_send(
+        wallet_name,
+        chain_str,
+        tx_hex,
+        Some(index),
+        rpc_url_override,
+        None,
+    )?;
 
     if json_output {
         let obj = serde_json::json!({

--- a/ows/crates/ows-cli/src/commands/sign_message.rs
+++ b/ows/crates/ows-cli/src/commands/sign_message.rs
@@ -1,6 +1,3 @@
-use ows_signer::chains::EvmSigner;
-use ows_signer::signer_for_chain;
-
 use crate::{parse_chain, CliError};
 
 pub fn run(
@@ -13,39 +10,25 @@ pub fn run(
     json_output: bool,
 ) -> Result<(), CliError> {
     let chain = parse_chain(chain_str)?;
-    let key = super::resolve_signing_key(wallet_name, chain.chain_type, index)?;
-
-    let signer = signer_for_chain(chain.chain_type);
-
     let output = if let Some(td_json) = typed_data {
         if chain.chain_type != ows_core::ChainType::Evm {
             return Err(CliError::InvalidArgs(
                 "--typed-data is only supported for EVM chains".into(),
             ));
         }
-        EvmSigner.sign_typed_data(key.expose(), td_json)?
+        ows_lib::sign_typed_data(wallet_name, chain_str, td_json, Some(index), None)?
     } else {
-        let msg_bytes = match encoding {
-            "utf8" => message.as_bytes().to_vec(),
-            "hex" => hex::decode(message)
-                .map_err(|e| CliError::InvalidArgs(format!("invalid hex message: {e}")))?,
-            _ => {
-                return Err(CliError::InvalidArgs(format!(
-                    "unsupported encoding: {encoding} (use 'utf8' or 'hex')"
-                )))
-            }
-        };
-        signer.sign_message(key.expose(), &msg_bytes)?
+        ows_lib::sign_message(wallet_name, chain_str, message, Some(encoding), Some(index), None)?
     };
 
     if json_output {
         let obj = serde_json::json!({
-            "signature": hex::encode(&output.signature),
+            "signature": output.signature,
             "recovery_id": output.recovery_id,
         });
         println!("{}", serde_json::to_string_pretty(&obj)?);
     } else {
-        println!("{}", hex::encode(&output.signature));
+        println!("{}", output.signature);
     }
 
     Ok(())

--- a/ows/crates/ows-cli/src/commands/sign_transaction.rs
+++ b/ows/crates/ows-cli/src/commands/sign_transaction.rs
@@ -1,6 +1,4 @@
-use ows_signer::signer_for_chain;
-
-use crate::{parse_chain, CliError};
+use crate::CliError;
 
 pub fn run(
     chain_str: &str,
@@ -9,24 +7,16 @@ pub fn run(
     index: u32,
     json_output: bool,
 ) -> Result<(), CliError> {
-    let chain = parse_chain(chain_str)?;
-    let key = super::resolve_signing_key(wallet_name, chain.chain_type, index)?;
-
-    let tx_hex_clean = tx_hex.strip_prefix("0x").unwrap_or(tx_hex);
-    let tx_bytes = hex::decode(tx_hex_clean)
-        .map_err(|e| CliError::InvalidArgs(format!("invalid hex transaction: {e}")))?;
-
-    let signer = signer_for_chain(chain.chain_type);
-    let output = signer.sign_transaction(key.expose(), &tx_bytes)?;
+    let output = ows_lib::sign_transaction(wallet_name, chain_str, tx_hex, Some(index), None)?;
 
     if json_output {
         let obj = serde_json::json!({
-            "signature": hex::encode(&output.signature),
+            "signature": output.signature,
             "recovery_id": output.recovery_id,
         });
         println!("{}", serde_json::to_string_pretty(&obj)?);
     } else {
-        println!("{}", hex::encode(&output.signature));
+        println!("{}", output.signature);
     }
 
     Ok(())

--- a/ows/crates/ows-cli/src/commands/wallet.rs
+++ b/ows/crates/ows-cli/src/commands/wallet.rs
@@ -7,7 +7,7 @@ use zeroize::Zeroize;
 pub fn create(name: &str, words: u32, show_mnemonic: bool) -> Result<(), CliError> {
     // Generate mnemonic, then import it to create the wallet
     let mut mnemonic_phrase = ows_lib::generate_mnemonic(words)?;
-    let info = ows_lib::import_wallet_mnemonic(name, &mnemonic_phrase, None, Some(0), None)?;
+    let info = ows_lib::import_wallet_mnemonic(name, &mnemonic_phrase, Some(0), None)?;
 
     audit::log_wallet_created(&info);
 
@@ -29,7 +29,7 @@ pub fn create(name: &str, words: u32, show_mnemonic: bool) -> Result<(), CliErro
         println!("{mnemonic_phrase}");
     } else {
         eprintln!();
-        eprintln!("Mnemonic encrypted and saved to vault.");
+        eprintln!("Mnemonic stored in the OS keyring.");
         eprintln!("Use --show-mnemonic at creation time if you need a backup copy.");
     }
 
@@ -68,7 +68,7 @@ pub fn import(
 
     let info = if use_mnemonic {
         let phrase = super::read_mnemonic()?;
-        ows_lib::import_wallet_mnemonic(name, &phrase, None, Some(index), None)?
+        ows_lib::import_wallet_mnemonic(name, &phrase, Some(index), None)?
     } else {
         // Read from env/stdin only when both curve keys are not already provided
         let private_key_hex = if both_curve_keys {
@@ -80,7 +80,6 @@ pub fn import(
             name,
             &private_key_hex,
             chain,
-            None,
             None,
             secp256k1_key,
             ed25519_key,
@@ -109,14 +108,7 @@ pub fn export(wallet_name: &str) -> Result<(), CliError> {
         ));
     }
 
-    // Try empty passphrase first, then prompt if it fails
-    let mut exported = match ows_lib::export_wallet(wallet_name, None, None) {
-        Ok(s) => s,
-        Err(_) => {
-            let passphrase = super::read_passphrase();
-            ows_lib::export_wallet(wallet_name, Some(&passphrase), None)?
-        }
-    };
+    let mut exported = ows_lib::export_wallet(wallet_name, None)?;
 
     let is_key_pair = exported.starts_with('{');
     eprintln!();
@@ -172,7 +164,7 @@ pub fn list() -> Result<(), CliError> {
     for w in &wallets {
         println!("ID:      {}", w.id);
         println!("Name:    {}", w.name);
-        println!("Secured: ✓ (encrypted)");
+        println!("Secured: ✓ (OS keyring)");
         for acct in &w.accounts {
             println!("  {} → {}", acct.chain_id, acct.address);
         }

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -121,7 +121,7 @@ enum SignCommands {
         /// Chain (ethereum, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
         #[arg(long)]
         chain: String,
-        /// Wallet name or ID (uses stored encrypted mnemonic)
+        /// Wallet name or ID (uses keyring-backed wallet secrets)
         #[arg(long, env = "OWS_WALLET")]
         wallet: String,
         /// Message to sign
@@ -145,7 +145,7 @@ enum SignCommands {
         /// Chain (ethereum, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
         #[arg(long)]
         chain: String,
-        /// Wallet name or ID (uses stored encrypted mnemonic)
+        /// Wallet name or ID (uses keyring-backed wallet secrets)
         #[arg(long, env = "OWS_WALLET")]
         wallet: String,
         /// Hex-encoded unsigned transaction bytes
@@ -163,7 +163,7 @@ enum SignCommands {
         /// Chain (ethereum, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
         #[arg(long)]
         chain: String,
-        /// Wallet name or ID (uses stored encrypted mnemonic)
+        /// Wallet name or ID (uses keyring-backed wallet secrets)
         #[arg(long, env = "OWS_WALLET")]
         wallet: String,
         /// Hex-encoded unsigned transaction bytes

--- a/ows/crates/ows-core/src/error.rs
+++ b/ows/crates/ows-core/src/error.rs
@@ -5,7 +5,6 @@ use serde::{Serialize, Serializer};
 pub enum OwsErrorCode {
     WalletNotFound,
     ChainNotSupported,
-    InvalidPassphrase,
     InvalidInput,
     CaipParseError,
 }
@@ -17,9 +16,6 @@ pub enum OwsError {
 
     #[error("chain not supported: {chain}")]
     ChainNotSupported { chain: String },
-
-    #[error("invalid passphrase")]
-    InvalidPassphrase,
 
     #[error("invalid input: {message}")]
     InvalidInput { message: String },
@@ -33,7 +29,6 @@ impl OwsError {
         match self {
             OwsError::WalletNotFound { .. } => OwsErrorCode::WalletNotFound,
             OwsError::ChainNotSupported { .. } => OwsErrorCode::ChainNotSupported,
-            OwsError::InvalidPassphrase => OwsErrorCode::InvalidPassphrase,
             OwsError::InvalidInput { .. } => OwsErrorCode::InvalidInput,
             OwsError::CaipParseError { .. } => OwsErrorCode::CaipParseError,
         }
@@ -73,10 +68,6 @@ mod tests {
         assert_eq!(
             OwsError::ChainNotSupported { chain: "x".into() }.code(),
             OwsErrorCode::ChainNotSupported
-        );
-        assert_eq!(
-            OwsError::InvalidPassphrase.code(),
-            OwsErrorCode::InvalidPassphrase
         );
         assert_eq!(
             OwsError::InvalidInput {

--- a/ows/crates/ows-core/src/wallet_file.rs
+++ b/ows/crates/ows-core/src/wallet_file.rs
@@ -14,7 +14,13 @@ pub struct EncryptedWallet {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chain_type: Option<ChainType>,
     pub accounts: Vec<WalletAccount>,
-    pub crypto: serde_json::Value,
+    /// Reference to the wallet secret stored in the OS keyring.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_ref: Option<String>,
+    /// Legacy embedded crypto envelope from older wallet formats.
+    /// New wallets must not serialize this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crypto: Option<serde_json::Value>,
     pub key_type: KeyType,
     #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
     pub metadata: serde_json::Value,
@@ -29,13 +35,13 @@ pub struct WalletAccount {
     pub derivation_path: String,
 }
 
-/// Type of key material stored in the ciphertext.
+/// Type of key material referenced by the wallet file.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum KeyType {
     Mnemonic,
-    /// Multi-curve key pair: encrypted JSON `{"secp256k1":"hex","ed25519":"hex"}`.
-    /// Supports all 6 chains.
+    /// Multi-curve key pair JSON `{"secp256k1":"hex","ed25519":"hex"}`.
+    /// Supports all 7 chain families.
     PrivateKey,
 }
 
@@ -44,17 +50,18 @@ impl EncryptedWallet {
         id: String,
         name: String,
         accounts: Vec<WalletAccount>,
-        crypto: serde_json::Value,
+        secret_ref: String,
         key_type: KeyType,
     ) -> Self {
         EncryptedWallet {
-            ows_version: 2,
+            ows_version: 3,
             id,
             name,
             created_at: chrono::Utc::now().to_rfc3339(),
             chain_type: None,
             accounts,
-            crypto,
+            secret_ref: Some(secret_ref),
+            crypto: None,
             key_type,
             metadata: serde_json::Value::Null,
         }
@@ -75,7 +82,7 @@ mod tests {
                 chain_id: "eip155:1".to_string(),
                 derivation_path: "m/44'/60'/0'/0/0".to_string(),
             }],
-            serde_json::json!({"cipher": "aes-256-gcm"}),
+            "wallet:v1:test:test-id".to_string(),
             KeyType::Mnemonic,
         )
     }
@@ -87,8 +94,13 @@ mod tests {
         let deserialized: EncryptedWallet = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.id, "test-id");
         assert_eq!(deserialized.name, "test-wallet");
-        assert_eq!(deserialized.ows_version, 2);
+        assert_eq!(deserialized.ows_version, 3);
         assert!(deserialized.chain_type.is_none());
+        assert_eq!(
+            deserialized.secret_ref.as_deref(),
+            Some("wallet:v1:test:test-id")
+        );
+        assert!(deserialized.crypto.is_none());
     }
 
     #[test]
@@ -100,12 +112,12 @@ mod tests {
     }
 
     #[test]
-    fn test_v2_no_chain_type_field() {
+    fn test_v3_no_chain_type_field() {
         let wallet = dummy_wallet();
         let json = serde_json::to_value(&wallet).unwrap();
         assert!(
             json.get("chain_type").is_none(),
-            "v2 wallets should not serialize chain_type"
+            "v3 wallets should not serialize chain_type"
         );
     }
 
@@ -119,11 +131,12 @@ mod tests {
             "name",
             "created_at",
             "accounts",
-            "crypto",
+            "secret_ref",
             "key_type",
         ] {
             assert!(json.get(key).is_some(), "missing key: {key}");
         }
+        assert!(json.get("crypto").is_none());
     }
 
     #[test]
@@ -135,7 +148,7 @@ mod tests {
 
     #[test]
     fn test_v1_backward_compat() {
-        // Simulate a v1 wallet JSON with chain_type field
+        // Simulate a legacy wallet JSON with embedded crypto and v1 chain_type field.
         let v1_json = serde_json::json!({
             "lws_version": 1,
             "id": "old-id",
@@ -154,5 +167,7 @@ mod tests {
         let wallet: EncryptedWallet = serde_json::from_value(v1_json).unwrap();
         assert_eq!(wallet.ows_version, 1);
         assert_eq!(wallet.chain_type, Some(ChainType::Evm));
+        assert!(wallet.secret_ref.is_none());
+        assert!(wallet.crypto.is_some());
     }
 }

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -22,6 +22,8 @@ uuid = { version = "1", features = ["v4"] }
 hex = "0.4"
 base64 = "0.22"
 getrandom = "0.2"
+keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
+sha2 = "0.10"
 zeroize = "1"
 
 [dev-dependencies]

--- a/ows/crates/ows-lib/src/error.rs
+++ b/ows/crates/ows-lib/src/error.rs
@@ -20,6 +20,15 @@ pub enum OwsLibError {
     #[error("broadcast failed: {0}")]
     BroadcastFailed(String),
 
+    #[error("wallet '{0}' uses the legacy embedded-secret format, which is no longer supported")]
+    LegacyWalletUnsupported(String),
+
+    #[error("secret store unavailable: {0}")]
+    SecretStoreUnavailable(String),
+
+    #[error("wallet secret not found: {0}")]
+    SecretNotFound(String),
+
     #[error("{0}")]
     Crypto(#[from] CryptoError),
 

--- a/ows/crates/ows-lib/src/lib.rs
+++ b/ows/crates/ows-lib/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod migrate;
 pub mod ops;
+mod secret_store;
 pub mod types;
 pub mod vault;
 

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -5,12 +5,10 @@ use ows_core::{
     default_chain_for_type, ChainType, Config, EncryptedWallet, KeyType, WalletAccount,
     ALL_CHAIN_TYPES,
 };
-use ows_signer::{
-    decrypt, encrypt, signer_for_chain, CryptoEnvelope, HdDeriver, Mnemonic, MnemonicStrength,
-    SecretBytes,
-};
+use ows_signer::{signer_for_chain, HdDeriver, Mnemonic, MnemonicStrength, SecretBytes};
 
 use crate::error::OwsLibError;
+use crate::secret_store;
 use crate::types::{AccountInfo, SendResult, SignResult, WalletInfo};
 use crate::vault;
 
@@ -159,15 +157,49 @@ pub fn derive_address(
     Ok(address)
 }
 
+fn save_wallet_with_secret(
+    wallet_id: String,
+    name: &str,
+    accounts: Vec<WalletAccount>,
+    key_type: KeyType,
+    payload: &str,
+    vault_path: Option<&Path>,
+) -> Result<WalletInfo, OwsLibError> {
+    let secret_ref = secret_store::secret_ref_for_wallet(&wallet_id, vault_path);
+    secret_store::store_wallet_secret(&secret_ref, &wallet_id, key_type.clone(), payload)?;
+
+    let wallet = EncryptedWallet::new(
+        wallet_id,
+        name.to_string(),
+        accounts,
+        secret_ref.clone(),
+        key_type,
+    );
+
+    if let Err(err) = vault::save_encrypted_wallet(&wallet, vault_path) {
+        let _ = secret_store::delete_wallet_secret(&secret_ref);
+        return Err(err);
+    }
+
+    Ok(wallet_to_info(&wallet))
+}
+
+fn load_wallet_secret(wallet: &EncryptedWallet) -> Result<SecretBytes, OwsLibError> {
+    let secret_ref = wallet
+        .secret_ref
+        .as_deref()
+        .ok_or_else(|| OwsLibError::LegacyWalletUnsupported(wallet.id.clone()))?;
+    let payload = secret_store::load_wallet_secret(secret_ref)?;
+    Ok(SecretBytes::from_slice(payload.as_bytes()))
+}
+
 /// Create a new universal wallet: generates mnemonic, derives addresses for all chains,
-/// encrypts, and saves to vault.
+/// stores the secret in the OS keyring, and saves wallet metadata to the vault.
 pub fn create_wallet(
     name: &str,
     words: Option<u32>,
-    passphrase: Option<&str>,
     vault_path: Option<&Path>,
 ) -> Result<WalletInfo, OwsLibError> {
-    let passphrase = passphrase.unwrap_or("");
     let words = words.unwrap_or(12);
     let strength = match words {
         12 => MnemonicStrength::Words12,
@@ -183,32 +215,20 @@ pub fn create_wallet(
     let accounts = derive_all_accounts(&mnemonic, 0)?;
 
     let phrase = mnemonic.phrase();
-    let crypto_envelope = encrypt(phrase.expose(), passphrase)?;
-    let crypto_json = serde_json::to_value(&crypto_envelope)?;
-
     let wallet_id = uuid::Uuid::new_v4().to_string();
+    let payload = std::str::from_utf8(phrase.expose())
+        .map_err(|_| OwsLibError::InvalidInput("wallet contains invalid UTF-8 mnemonic".into()))?;
 
-    let wallet = EncryptedWallet::new(
-        wallet_id,
-        name.to_string(),
-        accounts,
-        crypto_json,
-        KeyType::Mnemonic,
-    );
-
-    vault::save_encrypted_wallet(&wallet, vault_path)?;
-    Ok(wallet_to_info(&wallet))
+    save_wallet_with_secret(wallet_id, name, accounts, KeyType::Mnemonic, payload, vault_path)
 }
 
 /// Import a wallet from a mnemonic phrase. Derives addresses for all chains.
 pub fn import_wallet_mnemonic(
     name: &str,
     mnemonic_phrase: &str,
-    passphrase: Option<&str>,
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<WalletInfo, OwsLibError> {
-    let passphrase = passphrase.unwrap_or("");
     let index = index.unwrap_or(0);
 
     if vault::wallet_name_exists(name, vault_path)? {
@@ -219,21 +239,11 @@ pub fn import_wallet_mnemonic(
     let accounts = derive_all_accounts(&mnemonic, index)?;
 
     let phrase = mnemonic.phrase();
-    let crypto_envelope = encrypt(phrase.expose(), passphrase)?;
-    let crypto_json = serde_json::to_value(&crypto_envelope)?;
-
     let wallet_id = uuid::Uuid::new_v4().to_string();
+    let payload = std::str::from_utf8(phrase.expose())
+        .map_err(|_| OwsLibError::InvalidInput("wallet contains invalid UTF-8 mnemonic".into()))?;
 
-    let wallet = EncryptedWallet::new(
-        wallet_id,
-        name.to_string(),
-        accounts,
-        crypto_json,
-        KeyType::Mnemonic,
-    );
-
-    vault::save_encrypted_wallet(&wallet, vault_path)?;
-    Ok(wallet_to_info(&wallet))
+    save_wallet_with_secret(wallet_id, name, accounts, KeyType::Mnemonic, payload, vault_path)
 }
 
 /// Decode a hex-encoded key, stripping an optional `0x` prefix.
@@ -245,7 +255,7 @@ fn decode_hex_key(hex_str: &str) -> Result<Vec<u8>, OwsLibError> {
 
 /// Import a wallet from a hex-encoded private key.
 /// The `chain` parameter specifies which chain the key originates from (e.g. "evm", "solana").
-/// A random key is generated for the other curve so all 6 chains are supported.
+/// A random key is generated for the other curve so all 7 chain families are supported.
 ///
 /// Alternatively, provide both `secp256k1_key_hex` and `ed25519_key_hex` to supply
 /// explicit keys for each curve. When both are given, `private_key_hex` and `chain`
@@ -255,13 +265,10 @@ pub fn import_wallet_private_key(
     name: &str,
     private_key_hex: &str,
     chain: Option<&str>,
-    passphrase: Option<&str>,
     vault_path: Option<&Path>,
     secp256k1_key_hex: Option<&str>,
     ed25519_key_hex: Option<&str>,
 ) -> Result<WalletInfo, OwsLibError> {
-    let passphrase = passphrase.unwrap_or("");
-
     if vault::wallet_name_exists(name, vault_path)? {
         return Err(OwsLibError::WalletNameExists(name.to_string()));
     }
@@ -311,23 +318,19 @@ pub fn import_wallet_private_key(
     };
 
     let accounts = derive_all_accounts_from_keys(&keys)?;
-
     let payload = keys.to_json_bytes();
-    let crypto_envelope = encrypt(&payload, passphrase)?;
-    let crypto_json = serde_json::to_value(&crypto_envelope)?;
+    let payload = String::from_utf8(payload)
+        .map_err(|_| OwsLibError::InvalidInput("wallet contains invalid key data".into()))?;
 
     let wallet_id = uuid::Uuid::new_v4().to_string();
-
-    let wallet = EncryptedWallet::new(
+    save_wallet_with_secret(
         wallet_id,
-        name.to_string(),
+        name,
         accounts,
-        crypto_json,
         KeyType::PrivateKey,
-    );
-
-    vault::save_encrypted_wallet(&wallet, vault_path)?;
-    Ok(wallet_to_info(&wallet))
+        &payload,
+        vault_path,
+    )
 }
 
 /// List all wallets in the vault.
@@ -346,6 +349,9 @@ pub fn get_wallet(name_or_id: &str, vault_path: Option<&Path>) -> Result<WalletI
 pub fn delete_wallet(name_or_id: &str, vault_path: Option<&Path>) -> Result<(), OwsLibError> {
     let wallet = vault::load_wallet_by_name_or_id(name_or_id, vault_path)?;
     vault::delete_wallet_file(&wallet.id, vault_path)?;
+    if let Some(secret_ref) = wallet.secret_ref.as_deref() {
+        let _ = secret_store::delete_wallet_secret(secret_ref);
+    }
     Ok(())
 }
 
@@ -353,13 +359,10 @@ pub fn delete_wallet(name_or_id: &str, vault_path: Option<&Path>) -> Result<(), 
 /// Mnemonic wallets return the phrase. Private key wallets return JSON with both keys.
 pub fn export_wallet(
     name_or_id: &str,
-    passphrase: Option<&str>,
     vault_path: Option<&Path>,
 ) -> Result<String, OwsLibError> {
-    let passphrase = passphrase.unwrap_or("");
     let wallet = vault::load_wallet_by_name_or_id(name_or_id, vault_path)?;
-    let envelope: CryptoEnvelope = serde_json::from_value(wallet.crypto.clone())?;
-    let secret = decrypt(&envelope, passphrase)?;
+    let secret = load_wallet_secret(&wallet)?;
 
     match wallet.key_type {
         KeyType::Mnemonic => String::from_utf8(secret.expose().to_vec()).map_err(|_| {
@@ -399,18 +402,16 @@ pub fn sign_transaction(
     wallet: &str,
     chain: &str,
     tx_hex: &str,
-    passphrase: Option<&str>,
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<SignResult, OwsLibError> {
-    let passphrase = passphrase.unwrap_or("");
     let chain = parse_chain(chain)?;
 
     let tx_hex_clean = tx_hex.strip_prefix("0x").unwrap_or(tx_hex);
     let tx_bytes = hex::decode(tx_hex_clean)
         .map_err(|e| OwsLibError::InvalidInput(format!("invalid hex transaction: {e}")))?;
 
-    let key = decrypt_signing_key(wallet, chain.chain_type, passphrase, index, vault_path)?;
+    let key = decrypt_signing_key(wallet, chain.chain_type, index, vault_path)?;
     let signer = signer_for_chain(chain.chain_type);
     let output = signer.sign_transaction(key.expose(), &tx_bytes)?;
 
@@ -425,12 +426,10 @@ pub fn sign_message(
     wallet: &str,
     chain: &str,
     message: &str,
-    passphrase: Option<&str>,
     encoding: Option<&str>,
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<SignResult, OwsLibError> {
-    let passphrase = passphrase.unwrap_or("");
     let chain = parse_chain(chain)?;
 
     let encoding = encoding.unwrap_or("utf8");
@@ -445,7 +444,7 @@ pub fn sign_message(
         }
     };
 
-    let key = decrypt_signing_key(wallet, chain.chain_type, passphrase, index, vault_path)?;
+    let key = decrypt_signing_key(wallet, chain.chain_type, index, vault_path)?;
     let signer = signer_for_chain(chain.chain_type);
     let output = signer.sign_message(key.expose(), &msg_bytes)?;
 
@@ -461,11 +460,9 @@ pub fn sign_typed_data(
     wallet: &str,
     chain: &str,
     typed_data_json: &str,
-    passphrase: Option<&str>,
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<SignResult, OwsLibError> {
-    let passphrase = passphrase.unwrap_or("");
     let chain = parse_chain(chain)?;
 
     if chain.chain_type != ows_core::ChainType::Evm {
@@ -474,7 +471,7 @@ pub fn sign_typed_data(
         ));
     }
 
-    let key = decrypt_signing_key(wallet, chain.chain_type, passphrase, index, vault_path)?;
+    let key = decrypt_signing_key(wallet, chain.chain_type, index, vault_path)?;
     let evm_signer = ows_signer::chains::EvmSigner;
     let output = evm_signer.sign_typed_data(key.expose(), typed_data_json)?;
 
@@ -489,19 +486,17 @@ pub fn sign_and_send(
     wallet: &str,
     chain: &str,
     tx_hex: &str,
-    passphrase: Option<&str>,
     index: Option<u32>,
     rpc_url: Option<&str>,
     vault_path: Option<&Path>,
 ) -> Result<SendResult, OwsLibError> {
-    let passphrase = passphrase.unwrap_or("");
     let chain_info = parse_chain(chain)?;
 
     let tx_hex_clean = tx_hex.strip_prefix("0x").unwrap_or(tx_hex);
     let tx_bytes = hex::decode(tx_hex_clean)
         .map_err(|e| OwsLibError::InvalidInput(format!("invalid hex transaction: {e}")))?;
 
-    let key = decrypt_signing_key(wallet, chain_info.chain_type, passphrase, index, vault_path)?;
+    let key = decrypt_signing_key(wallet, chain_info.chain_type, index, vault_path)?;
 
     sign_encode_and_broadcast(key.expose(), chain, &tx_bytes, rpc_url)
 }
@@ -545,13 +540,11 @@ pub fn sign_encode_and_broadcast(
 fn decrypt_signing_key(
     wallet_name_or_id: &str,
     chain_type: ChainType,
-    passphrase: &str,
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<SecretBytes, OwsLibError> {
     let wallet = vault::load_wallet_by_name_or_id(wallet_name_or_id, vault_path)?;
-    let envelope: CryptoEnvelope = serde_json::from_value(wallet.crypto.clone())?;
-    let secret = decrypt(&envelope, passphrase)?;
+    let secret = load_wallet_secret(&wallet)?;
 
     match wallet.key_type {
         KeyType::Mnemonic => {
@@ -779,7 +772,6 @@ mod tests {
     fn save_privkey_wallet(
         name: &str,
         privkey_hex: &str,
-        passphrase: &str,
         vault: &Path,
     ) -> WalletInfo {
         let key_bytes = hex::decode(privkey_hex).unwrap();
@@ -793,18 +785,17 @@ mod tests {
             ed25519: ed_key,
         };
         let accounts = derive_all_accounts_from_keys(&keys).unwrap();
-        let payload = keys.to_json_bytes();
-        let crypto_envelope = encrypt(&payload, passphrase).unwrap();
-        let crypto_json = serde_json::to_value(&crypto_envelope).unwrap();
-        let wallet = EncryptedWallet::new(
-            uuid::Uuid::new_v4().to_string(),
-            name.to_string(),
+        let payload = String::from_utf8(keys.to_json_bytes()).unwrap();
+        let wallet_id = uuid::Uuid::new_v4().to_string();
+        save_wallet_with_secret(
+            wallet_id,
+            name,
             accounts,
-            crypto_json,
             KeyType::PrivateKey,
-        );
-        vault::save_encrypted_wallet(&wallet, Some(vault)).unwrap();
-        wallet_to_info(&wallet)
+            &payload,
+            Some(vault),
+        )
+        .unwrap()
     }
 
     const TEST_PRIVKEY: &str = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318";
@@ -898,15 +889,15 @@ mod tests {
         let v2 = tempfile::tempdir().unwrap();
 
         // Create
-        let w1 = create_wallet("w1", None, None, Some(v1.path())).unwrap();
+        let w1 = create_wallet("w1", None, Some(v1.path())).unwrap();
         assert!(!w1.accounts.is_empty());
 
         // Export mnemonic
-        let phrase = export_wallet("w1", None, Some(v1.path())).unwrap();
+        let phrase = export_wallet("w1", Some(v1.path())).unwrap();
         assert_eq!(phrase.split_whitespace().count(), 12);
 
         // Re-import into fresh vault
-        let w2 = import_wallet_mnemonic("w2", &phrase, None, None, Some(v2.path())).unwrap();
+        let w2 = import_wallet_mnemonic("w2", &phrase, None, Some(v2.path())).unwrap();
 
         // Addresses must match exactly
         assert_eq!(w1.accounts.len(), w2.accounts.len());
@@ -924,19 +915,11 @@ mod tests {
     fn mnemonic_wallet_sign_message_all_chains() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("multi-sign", None, None, Some(vault)).unwrap();
+        create_wallet("multi-sign", None, Some(vault)).unwrap();
 
         let chains = ["evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark"];
         for chain in &chains {
-            let result = sign_message(
-                "multi-sign",
-                chain,
-                "test msg",
-                None,
-                None,
-                None,
-                Some(vault),
-            );
+            let result = sign_message("multi-sign", chain, "test msg", None, None, Some(vault));
             assert!(
                 result.is_ok(),
                 "sign_message should work for {chain}: {:?}",
@@ -954,7 +937,7 @@ mod tests {
     fn mnemonic_wallet_sign_tx_all_chains() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("tx-sign", None, None, Some(vault)).unwrap();
+        create_wallet("tx-sign", None, Some(vault)).unwrap();
 
         let generic_tx_hex = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
         // Solana requires a properly formatted serialized transaction:
@@ -971,7 +954,7 @@ mod tests {
             } else {
                 generic_tx_hex
             };
-            let result = sign_transaction("tx-sign", chain, tx, None, None, Some(vault));
+            let result = sign_transaction("tx-sign", chain, tx, None, Some(vault));
             assert!(
                 result.is_ok(),
                 "sign_transaction should work for {chain}: {:?}",
@@ -984,10 +967,10 @@ mod tests {
     fn mnemonic_wallet_signing_is_deterministic() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("det-sign", None, None, Some(vault)).unwrap();
+        create_wallet("det-sign", None, Some(vault)).unwrap();
 
-        let s1 = sign_message("det-sign", "evm", "hello", None, None, None, Some(vault)).unwrap();
-        let s2 = sign_message("det-sign", "evm", "hello", None, None, None, Some(vault)).unwrap();
+        let s1 = sign_message("det-sign", "evm", "hello", None, None, Some(vault)).unwrap();
+        let s2 = sign_message("det-sign", "evm", "hello", None, None, Some(vault)).unwrap();
         assert_eq!(
             s1.signature, s2.signature,
             "same message should produce same signature"
@@ -998,10 +981,10 @@ mod tests {
     fn mnemonic_wallet_different_messages_produce_different_sigs() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("diff-msg", None, None, Some(vault)).unwrap();
+        create_wallet("diff-msg", None, Some(vault)).unwrap();
 
-        let s1 = sign_message("diff-msg", "evm", "hello", None, None, None, Some(vault)).unwrap();
-        let s2 = sign_message("diff-msg", "evm", "world", None, None, None, Some(vault)).unwrap();
+        let s1 = sign_message("diff-msg", "evm", "hello", None, None, Some(vault)).unwrap();
+        let s2 = sign_message("diff-msg", "evm", "world", None, None, Some(vault)).unwrap();
         assert_ne!(s1.signature, s2.signature);
     }
 
@@ -1012,18 +995,9 @@ mod tests {
     #[test]
     fn privkey_wallet_sign_message() {
         let dir = tempfile::tempdir().unwrap();
-        save_privkey_wallet("pk-sign", TEST_PRIVKEY, "", dir.path());
+        save_privkey_wallet("pk-sign", TEST_PRIVKEY, dir.path());
 
-        let sig = sign_message(
-            "pk-sign",
-            "evm",
-            "hello",
-            None,
-            None,
-            None,
-            Some(dir.path()),
-        )
-        .unwrap();
+        let sig = sign_message("pk-sign", "evm", "hello", None, None, Some(dir.path())).unwrap();
         assert!(!sig.signature.is_empty());
         assert!(sig.recovery_id.is_some());
     }
@@ -1031,19 +1005,19 @@ mod tests {
     #[test]
     fn privkey_wallet_sign_transaction() {
         let dir = tempfile::tempdir().unwrap();
-        save_privkey_wallet("pk-tx", TEST_PRIVKEY, "", dir.path());
+        save_privkey_wallet("pk-tx", TEST_PRIVKEY, dir.path());
 
         let tx = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
-        let sig = sign_transaction("pk-tx", "evm", tx, None, None, Some(dir.path())).unwrap();
+        let sig = sign_transaction("pk-tx", "evm", tx, None, Some(dir.path())).unwrap();
         assert!(!sig.signature.is_empty());
     }
 
     #[test]
     fn privkey_wallet_export_returns_json() {
         let dir = tempfile::tempdir().unwrap();
-        save_privkey_wallet("pk-export", TEST_PRIVKEY, "", dir.path());
+        save_privkey_wallet("pk-export", TEST_PRIVKEY, dir.path());
 
-        let exported = export_wallet("pk-export", None, Some(dir.path())).unwrap();
+        let exported = export_wallet("pk-export", Some(dir.path())).unwrap();
         let obj: serde_json::Value = serde_json::from_str(&exported).unwrap();
         assert_eq!(
             obj["secp256k1"].as_str().unwrap(),
@@ -1056,10 +1030,10 @@ mod tests {
     #[test]
     fn privkey_wallet_signing_is_deterministic() {
         let dir = tempfile::tempdir().unwrap();
-        save_privkey_wallet("pk-det", TEST_PRIVKEY, "", dir.path());
+        save_privkey_wallet("pk-det", TEST_PRIVKEY, dir.path());
 
-        let s1 = sign_message("pk-det", "evm", "test", None, None, None, Some(dir.path())).unwrap();
-        let s2 = sign_message("pk-det", "evm", "test", None, None, None, Some(dir.path())).unwrap();
+        let s1 = sign_message("pk-det", "evm", "test", None, None, Some(dir.path())).unwrap();
+        let s2 = sign_message("pk-det", "evm", "test", None, None, Some(dir.path())).unwrap();
         assert_eq!(s1.signature, s2.signature);
     }
 
@@ -1068,11 +1042,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
 
-        create_wallet("mn-w", None, None, Some(vault)).unwrap();
-        save_privkey_wallet("pk-w", TEST_PRIVKEY, "", vault);
+        create_wallet("mn-w", None, Some(vault)).unwrap();
+        save_privkey_wallet("pk-w", TEST_PRIVKEY, vault);
 
-        let mn_sig = sign_message("mn-w", "evm", "hello", None, None, None, Some(vault)).unwrap();
-        let pk_sig = sign_message("pk-w", "evm", "hello", None, None, None, Some(vault)).unwrap();
+        let mn_sig = sign_message("mn-w", "evm", "hello", None, None, Some(vault)).unwrap();
+        let pk_sig = sign_message("pk-w", "evm", "hello", None, None, Some(vault)).unwrap();
         assert_ne!(
             mn_sig.signature, pk_sig.signature,
             "different keys should produce different signatures"
@@ -1088,7 +1062,6 @@ mod tests {
             "pk-api",
             TEST_PRIVKEY,
             Some("evm"),
-            None,
             Some(vault),
             None,
             None,
@@ -1100,11 +1073,11 @@ mod tests {
         );
 
         // Should be able to sign
-        let sig = sign_message("pk-api", "evm", "hello", None, None, None, Some(vault)).unwrap();
+        let sig = sign_message("pk-api", "evm", "hello", None, None, Some(vault)).unwrap();
         assert!(!sig.signature.is_empty());
 
         // Export should return JSON key pair with original key
-        let exported = export_wallet("pk-api", None, Some(vault)).unwrap();
+        let exported = export_wallet("pk-api", Some(vault)).unwrap();
         let obj: serde_json::Value = serde_json::from_str(&exported).unwrap();
         assert_eq!(obj["secp256k1"].as_str().unwrap(), TEST_PRIVKEY);
     }
@@ -1121,7 +1094,6 @@ mod tests {
             "pk-both",
             "",   // ignored when both curve keys provided
             None, // chain ignored too
-            None,
             Some(vault),
             Some(secp_key),
             Some(ed_key),
@@ -1135,104 +1107,22 @@ mod tests {
         );
 
         // Sign on EVM (secp256k1)
-        let sig = sign_message("pk-both", "evm", "hello", None, None, None, Some(vault)).unwrap();
+        let sig = sign_message("pk-both", "evm", "hello", None, None, Some(vault)).unwrap();
         assert!(!sig.signature.is_empty());
 
         // Sign on Solana (ed25519)
-        let sig =
-            sign_message("pk-both", "solana", "hello", None, None, None, Some(vault)).unwrap();
+        let sig = sign_message("pk-both", "solana", "hello", None, None, Some(vault)).unwrap();
         assert!(!sig.signature.is_empty());
 
         // Export should return both keys
-        let exported = export_wallet("pk-both", None, Some(vault)).unwrap();
+        let exported = export_wallet("pk-both", Some(vault)).unwrap();
         let obj: serde_json::Value = serde_json::from_str(&exported).unwrap();
         assert_eq!(obj["secp256k1"].as_str().unwrap(), secp_key);
         assert_eq!(obj["ed25519"].as_str().unwrap(), ed_key);
     }
 
     // ================================================================
-    // 5. PASSPHRASE PROTECTION
-    // ================================================================
-
-    #[test]
-    fn passphrase_protected_mnemonic_wallet() {
-        let dir = tempfile::tempdir().unwrap();
-        let vault = dir.path();
-
-        create_wallet("pass-mn", None, Some("s3cret"), Some(vault)).unwrap();
-
-        // Sign with correct passphrase
-        let sig = sign_message(
-            "pass-mn",
-            "evm",
-            "hello",
-            Some("s3cret"),
-            None,
-            None,
-            Some(vault),
-        )
-        .unwrap();
-        assert!(!sig.signature.is_empty());
-
-        // Export with correct passphrase
-        let phrase = export_wallet("pass-mn", Some("s3cret"), Some(vault)).unwrap();
-        assert_eq!(phrase.split_whitespace().count(), 12);
-
-        // Wrong passphrase should fail
-        assert!(sign_message(
-            "pass-mn",
-            "evm",
-            "hello",
-            Some("wrong"),
-            None,
-            None,
-            Some(vault)
-        )
-        .is_err());
-        assert!(export_wallet("pass-mn", Some("wrong"), Some(vault)).is_err());
-
-        // No passphrase should fail (defaults to empty string, which is wrong)
-        assert!(sign_message("pass-mn", "evm", "hello", None, None, None, Some(vault)).is_err());
-    }
-
-    #[test]
-    fn passphrase_protected_privkey_wallet() {
-        let dir = tempfile::tempdir().unwrap();
-        save_privkey_wallet("pass-pk", TEST_PRIVKEY, "mypass", dir.path());
-
-        // Correct passphrase
-        let sig = sign_message(
-            "pass-pk",
-            "evm",
-            "hello",
-            Some("mypass"),
-            None,
-            None,
-            Some(dir.path()),
-        )
-        .unwrap();
-        assert!(!sig.signature.is_empty());
-
-        let exported = export_wallet("pass-pk", Some("mypass"), Some(dir.path())).unwrap();
-        let obj: serde_json::Value = serde_json::from_str(&exported).unwrap();
-        assert_eq!(obj["secp256k1"].as_str().unwrap(), TEST_PRIVKEY);
-
-        // Wrong passphrase
-        assert!(sign_message(
-            "pass-pk",
-            "evm",
-            "hello",
-            Some("wrong"),
-            None,
-            None,
-            Some(dir.path())
-        )
-        .is_err());
-        assert!(export_wallet("pass-pk", Some("wrong"), Some(dir.path())).is_err());
-    }
-
-    // ================================================================
-    // 6. SIGNATURE VERIFICATION (prove signatures are cryptographically valid)
+    // 5. SIGNATURE VERIFICATION (prove signatures are cryptographically valid)
     // ================================================================
 
     #[test]
@@ -1241,7 +1131,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
 
-        let info = create_wallet("verify-evm", None, None, Some(vault)).unwrap();
+        let info = create_wallet("verify-evm", None, Some(vault)).unwrap();
         let evm_addr = info
             .accounts
             .iter()
@@ -1254,7 +1144,6 @@ mod tests {
             "verify-evm",
             "evm",
             "hello world",
-            None,
             None,
             None,
             Some(vault),
@@ -1307,8 +1196,8 @@ mod tests {
     fn error_nonexistent_wallet() {
         let dir = tempfile::tempdir().unwrap();
         assert!(get_wallet("nope", Some(dir.path())).is_err());
-        assert!(export_wallet("nope", None, Some(dir.path())).is_err());
-        assert!(sign_message("nope", "evm", "x", None, None, None, Some(dir.path())).is_err());
+        assert!(export_wallet("nope", Some(dir.path())).is_err());
+        assert!(sign_message("nope", "evm", "x", None, None, Some(dir.path())).is_err());
         assert!(delete_wallet("nope", Some(dir.path())).is_err());
     }
 
@@ -1316,8 +1205,8 @@ mod tests {
     fn error_duplicate_wallet_name() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("dup", None, None, Some(vault)).unwrap();
-        assert!(create_wallet("dup", None, None, Some(vault)).is_err());
+        create_wallet("dup", None, Some(vault)).unwrap();
+        assert!(create_wallet("dup", None, Some(vault)).is_err());
     }
 
     #[test]
@@ -1327,7 +1216,6 @@ mod tests {
             "bad",
             "not-hex",
             Some("evm"),
-            None,
             Some(dir.path()),
             None,
             None,
@@ -1339,20 +1227,16 @@ mod tests {
     fn error_invalid_chain_for_signing() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("chain-err", None, None, Some(vault)).unwrap();
-        assert!(
-            sign_message("chain-err", "fakecoin", "hi", None, None, None, Some(vault)).is_err()
-        );
+        create_wallet("chain-err", None, Some(vault)).unwrap();
+        assert!(sign_message("chain-err", "fakecoin", "hi", None, None, Some(vault)).is_err());
     }
 
     #[test]
     fn error_invalid_tx_hex() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("hex-err", None, None, Some(vault)).unwrap();
-        assert!(
-            sign_transaction("hex-err", "evm", "not-valid-hex!", None, None, Some(vault)).is_err()
-        );
+        create_wallet("hex-err", None, Some(vault)).unwrap();
+        assert!(sign_transaction("hex-err", "evm", "not-valid-hex!", None, Some(vault)).is_err());
     }
 
     // ================================================================
@@ -1370,7 +1254,7 @@ mod tests {
     fn get_wallet_by_name_and_id() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        let info = create_wallet("lookup", None, None, Some(vault)).unwrap();
+        let info = create_wallet("lookup", None, Some(vault)).unwrap();
 
         let by_name = get_wallet("lookup", Some(vault)).unwrap();
         assert_eq!(by_name.id, info.id);
@@ -1383,7 +1267,7 @@ mod tests {
     fn rename_wallet_works() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        let info = create_wallet("before", None, None, Some(vault)).unwrap();
+        let info = create_wallet("before", None, Some(vault)).unwrap();
 
         rename_wallet("before", "after", Some(vault)).unwrap();
 
@@ -1396,8 +1280,8 @@ mod tests {
     fn rename_to_existing_name_fails() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("a", None, None, Some(vault)).unwrap();
-        create_wallet("b", None, None, Some(vault)).unwrap();
+        create_wallet("a", None, Some(vault)).unwrap();
+        create_wallet("b", None, Some(vault)).unwrap();
         assert!(rename_wallet("a", "b", Some(vault)).is_err());
     }
 
@@ -1405,7 +1289,7 @@ mod tests {
     fn delete_wallet_removes_from_list() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("del-me", None, None, Some(vault)).unwrap();
+        create_wallet("del-me", None, Some(vault)).unwrap();
         assert_eq!(list_wallets(Some(vault)).unwrap().len(), 1);
 
         delete_wallet("del-me", Some(vault)).unwrap();
@@ -1420,14 +1304,13 @@ mod tests {
     fn sign_message_hex_encoding() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("hex-enc", None, None, Some(vault)).unwrap();
+        create_wallet("hex-enc", None, Some(vault)).unwrap();
 
         // "hello" in hex
         let sig = sign_message(
             "hex-enc",
             "evm",
             "68656c6c6f",
-            None,
             Some("hex"),
             None,
             Some(vault),
@@ -1440,7 +1323,6 @@ mod tests {
             "hex-enc",
             "evm",
             "hello",
-            None,
             Some("utf8"),
             None,
             Some(vault),
@@ -1456,12 +1338,11 @@ mod tests {
     fn sign_message_invalid_encoding() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        create_wallet("bad-enc", None, None, Some(vault)).unwrap();
+        create_wallet("bad-enc", None, Some(vault)).unwrap();
         assert!(sign_message(
             "bad-enc",
             "evm",
             "hello",
-            None,
             Some("base64"),
             None,
             Some(vault)
@@ -1478,17 +1359,17 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
 
-        create_wallet("w1", None, None, Some(vault)).unwrap();
-        create_wallet("w2", None, None, Some(vault)).unwrap();
-        save_privkey_wallet("w3", TEST_PRIVKEY, "", vault);
+        create_wallet("w1", None, Some(vault)).unwrap();
+        create_wallet("w2", None, Some(vault)).unwrap();
+        save_privkey_wallet("w3", TEST_PRIVKEY, vault);
 
         let wallets = list_wallets(Some(vault)).unwrap();
         assert_eq!(wallets.len(), 3);
 
         // All can sign independently
-        let s1 = sign_message("w1", "evm", "test", None, None, None, Some(vault)).unwrap();
-        let s2 = sign_message("w2", "evm", "test", None, None, None, Some(vault)).unwrap();
-        let s3 = sign_message("w3", "evm", "test", None, None, None, Some(vault)).unwrap();
+        let s1 = sign_message("w1", "evm", "test", None, None, Some(vault)).unwrap();
+        let s2 = sign_message("w2", "evm", "test", None, None, Some(vault)).unwrap();
+        let s3 = sign_message("w3", "evm", "test", None, None, Some(vault)).unwrap();
 
         // All signatures should be different (different keys)
         assert_ne!(s1.signature, s2.signature);
@@ -1498,8 +1379,8 @@ mod tests {
         // Delete one, others survive
         delete_wallet("w2", Some(vault)).unwrap();
         assert_eq!(list_wallets(Some(vault)).unwrap().len(), 2);
-        assert!(sign_message("w1", "evm", "test", None, None, None, Some(vault)).is_ok());
-        assert!(sign_message("w3", "evm", "test", None, None, None, Some(vault)).is_ok());
+        assert!(sign_message("w1", "evm", "test", None, None, Some(vault)).is_ok());
+        assert!(sign_message("w3", "evm", "test", None, None, Some(vault)).is_ok());
     }
 
     // ================================================================
@@ -1519,7 +1400,7 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
-        save_privkey_wallet("send-bug", TEST_PRIVKEY, "", vault);
+        save_privkey_wallet("send-bug", TEST_PRIVKEY, vault);
 
         // Build a minimal unsigned EIP-1559 transaction
         let items: Vec<u8> = [
@@ -1540,12 +1421,11 @@ mod tests {
         let tx_hex = hex::encode(&unsigned_tx);
 
         // Sign the transaction via the library
-        let sign_result =
-            sign_transaction("send-bug", "evm", &tx_hex, None, None, Some(vault)).unwrap();
+        let sign_result = sign_transaction("send-bug", "evm", &tx_hex, None, Some(vault)).unwrap();
         let raw_signature = hex::decode(&sign_result.signature).unwrap();
 
         // Now encode the full signed transaction (what the library does correctly)
-        let key = decrypt_signing_key("send-bug", ChainType::Evm, "", None, Some(vault)).unwrap();
+        let key = decrypt_signing_key("send-bug", ChainType::Evm, None, Some(vault)).unwrap();
         let signer = signer_for_chain(ChainType::Evm);
         let output = signer.sign_transaction(key.expose(), &unsigned_tx).unwrap();
         let full_signed_tx = signer
@@ -1587,7 +1467,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let vault = tmp.path();
 
-        let w = save_privkey_wallet("typed-data-test", TEST_PRIVKEY, "pass", vault);
+        let w = save_privkey_wallet("typed-data-test", TEST_PRIVKEY, vault);
 
         let typed_data = r#"{
             "types": {
@@ -1599,7 +1479,7 @@ mod tests {
             "message": {"value": "1"}
         }"#;
 
-        let result = sign_typed_data(&w.id, "solana", typed_data, Some("pass"), None, Some(vault));
+        let result = sign_typed_data(&w.id, "solana", typed_data, None, Some(vault));
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -1613,7 +1493,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let vault = tmp.path();
 
-        let w = save_privkey_wallet("typed-data-evm", TEST_PRIVKEY, "pass", vault);
+        let w = save_privkey_wallet("typed-data-evm", TEST_PRIVKEY, vault);
 
         let typed_data = r#"{
             "types": {
@@ -1629,7 +1509,7 @@ mod tests {
             "message": {"value": "42"}
         }"#;
 
-        let result = sign_typed_data(&w.id, "evm", typed_data, Some("pass"), None, Some(vault));
+        let result = sign_typed_data(&w.id, "evm", typed_data, None, Some(vault));
         assert!(result.is_ok(), "sign_typed_data failed: {:?}", result.err());
 
         let sign_result = result.unwrap();

--- a/ows/crates/ows-lib/src/secret_store.rs
+++ b/ows/crates/ows-lib/src/secret_store.rs
@@ -1,0 +1,124 @@
+use std::path::Path;
+
+use ows_core::KeyType;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+use crate::error::OwsLibError;
+
+const SERVICE: &str = "ows";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SecretRecord {
+    version: u32,
+    wallet_id: String,
+    key_type: KeyType,
+    payload: String,
+}
+
+pub fn secret_ref_for_wallet(wallet_id: &str, vault_path: Option<&Path>) -> String {
+    let vault = crate::vault::resolve_vault_path(vault_path);
+    let digest = Sha256::digest(vault.to_string_lossy().as_bytes());
+    let scope = hex::encode(&digest[..8]);
+    format!("wallet:v1:{scope}:{wallet_id}")
+}
+
+pub fn store_wallet_secret(
+    secret_ref: &str,
+    wallet_id: &str,
+    key_type: KeyType,
+    payload: &str,
+) -> Result<(), OwsLibError> {
+    let record = SecretRecord {
+        version: 1,
+        wallet_id: wallet_id.to_string(),
+        key_type,
+        payload: payload.to_string(),
+    };
+    let serialized = Zeroizing::new(
+        serde_json::to_string(&record)
+            .map_err(|e| OwsLibError::SecretStoreUnavailable(e.to_string()))?,
+    );
+    write_secret(secret_ref, &serialized)
+}
+
+pub fn load_wallet_secret(secret_ref: &str) -> Result<Zeroizing<String>, OwsLibError> {
+    let serialized = read_secret(secret_ref)?;
+    let record: SecretRecord = serde_json::from_str(&serialized)
+        .map_err(|e| OwsLibError::SecretStoreUnavailable(e.to_string()))?;
+    Ok(Zeroizing::new(record.payload))
+}
+
+pub fn delete_wallet_secret(secret_ref: &str) -> Result<(), OwsLibError> {
+    delete_secret(secret_ref)
+}
+
+#[cfg(not(test))]
+fn write_secret(secret_ref: &str, serialized: &str) -> Result<(), OwsLibError> {
+    let entry = keyring::Entry::new(SERVICE, secret_ref)
+        .map_err(|e| OwsLibError::SecretStoreUnavailable(e.to_string()))?;
+    entry
+        .set_password(serialized)
+        .map_err(|e| OwsLibError::SecretStoreUnavailable(e.to_string()))
+}
+
+#[cfg(not(test))]
+fn read_secret(secret_ref: &str) -> Result<Zeroizing<String>, OwsLibError> {
+    let entry = keyring::Entry::new(SERVICE, secret_ref)
+        .map_err(|e| OwsLibError::SecretStoreUnavailable(e.to_string()))?;
+    match entry.get_password() {
+        Ok(value) => Ok(Zeroizing::new(value)),
+        Err(keyring::Error::NoEntry) => Err(OwsLibError::SecretNotFound(secret_ref.to_string())),
+        Err(e) => Err(OwsLibError::SecretStoreUnavailable(e.to_string())),
+    }
+}
+
+#[cfg(not(test))]
+fn delete_secret(secret_ref: &str) -> Result<(), OwsLibError> {
+    let entry = keyring::Entry::new(SERVICE, secret_ref)
+        .map_err(|e| OwsLibError::SecretStoreUnavailable(e.to_string()))?;
+    match entry.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(OwsLibError::SecretStoreUnavailable(e.to_string())),
+    }
+}
+
+#[cfg(test)]
+fn write_secret(secret_ref: &str, serialized: &str) -> Result<(), OwsLibError> {
+    let mut store = test_store()
+        .lock()
+        .map_err(|_| OwsLibError::SecretStoreUnavailable("test store lock poisoned".into()))?;
+    store.insert(secret_ref.to_string(), serialized.to_string());
+    Ok(())
+}
+
+#[cfg(test)]
+fn read_secret(secret_ref: &str) -> Result<Zeroizing<String>, OwsLibError> {
+    let store = test_store()
+        .lock()
+        .map_err(|_| OwsLibError::SecretStoreUnavailable("test store lock poisoned".into()))?;
+    let value = store
+        .get(secret_ref)
+        .cloned()
+        .ok_or_else(|| OwsLibError::SecretNotFound(secret_ref.to_string()))?;
+    Ok(Zeroizing::new(value))
+}
+
+#[cfg(test)]
+fn delete_secret(secret_ref: &str) -> Result<(), OwsLibError> {
+    let mut store = test_store()
+        .lock()
+        .map_err(|_| OwsLibError::SecretStoreUnavailable("test store lock poisoned".into()))?;
+    store.remove(secret_ref);
+    Ok(())
+}
+
+#[cfg(test)]
+fn test_store() -> &'static std::sync::Mutex<std::collections::HashMap<String, String>> {
+    static STORE: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<String, String>>,
+    > = std::sync::OnceLock::new();
+    STORE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+

--- a/ows/crates/ows-lib/src/vault.rs
+++ b/ows/crates/ows-lib/src/vault.rs
@@ -196,7 +196,7 @@ mod tests {
                 chain_id: "eip155:1".to_string(),
                 derivation_path: "m/44'/60'/0'/0/0".to_string(),
             }],
-            serde_json::json!({"cipher": "aes-256-gcm"}),
+            "wallet:v1:test:test-id".to_string(),
             KeyType::Mnemonic,
         );
 
@@ -220,7 +220,7 @@ mod tests {
                 chain_id: "eip155:1".to_string(),
                 derivation_path: "m/44'/60'/0'/0/0".to_string(),
             }],
-            serde_json::json!({"cipher": "aes-256-gcm"}),
+            "wallet:v1:test:uuid-123".to_string(),
             KeyType::Mnemonic,
         );
 
@@ -248,7 +248,7 @@ mod tests {
             "del-id".to_string(),
             "del-wallet".to_string(),
             vec![],
-            serde_json::json!({}),
+            "wallet:v1:test:del-id".to_string(),
             KeyType::Mnemonic,
         );
 
@@ -268,7 +268,7 @@ mod tests {
             "id-1".to_string(),
             "existing-name".to_string(),
             vec![],
-            serde_json::json!({}),
+            "wallet:v1:test:id-1".to_string(),
             KeyType::Mnemonic,
         );
 


### PR DESCRIPTION
## Summary

This PR moves wallet secret storage to the OS keyring.

Instead of embedding mnemonic/private key material directly in wallet files, new wallets now store only metadata on disk and keep secrets in the platform keyring. Wallet files reference secrets through `secret_ref`.

This is an intentional simplification for the current early-stage design:
- wallet files remain the source of truth for metadata and account indexing
- mnemonic/private keys are no longer persisted in wallet files
- keyring-backed storage becomes the primary wallet model

## What Changed

- added a new keyring-backed secret store in `ows-lib`
- changed wallet file schema to use `secret_ref` for new wallets
- updated wallet create/import/export/sign flows to resolve secrets from the OS keyring
- updated CLI commands to use the new keyring-backed model
- updated Node and Python bindings to match the new API shape
- refreshed docs to describe the new storage behavior

## Design Notes

- wallet metadata stays file-based to preserve vault listing and indexing behavior
- each wallet maps to its own keyring entry
- this PR favors a clean keyring-first model over compatibility-oriented storage abstractions
- legacy embedded `crypto` is no longer the main path for new wallets

## Testing

- `cargo test --workspace`
- `cargo check` in `bindings/node`
- `cargo check` in `bindings/python`

## Notes

This PR is focused on establishing the keyring-backed storage direction first. Follow-up work can further refine legacy wallet handling and keyring cleanup semantics if needed.
