### PR TITLE
Add CLI passphrase cache and explicit prompts

### DIFF
--- a/docs/05-key-isolation.md
+++ b/docs/05-key-isolation.md
@@ -15,10 +15,10 @@
 | Subprocess signing enclave (child process) | Not started | Keys are decrypted in-process, not isolated |
 | Unix domain socket / pipe IPC | Not started | No enclave transport |
 | JSON-RPC enclave protocol (`sign`, `sign_message`, `unlock`, `lock`, `status`) | Not started | |
-| Passphrase delivery: interactive prompt | Not started | |
+| Passphrase delivery: interactive prompt | Partial | CLI prompts directly for wallet create/import/export/sign |
 | Passphrase delivery: file descriptor | Not started | |
 | Passphrase delivery: env var (`OWS_PASSPHRASE`) with immediate clear | Partial | Passphrase passed as param, not read from env |
-| Session-based unlock/lock | Not started | Each operation re-decrypts (or uses cache) |
+| Session-based unlock/lock | Partial | CLI-only passphrase cache via OS keyring |
 
 **Note:** The current implementation provides in-process hardening (mlock, zeroize, anti-debug) but does NOT implement the subprocess isolation model described in the spec. Keys are decrypted within the calling process's address space.
 

--- a/docs/sdk-cli.md
+++ b/docs/sdk-cli.md
@@ -20,7 +20,7 @@ cargo build --workspace --release
 
 ### `ows wallet create`
 
-Create a new wallet. Generates a BIP-39 mnemonic and derives addresses for all supported chains.
+Create a new wallet. Generates a BIP-39 mnemonic, prompts for a vault passphrase, and derives addresses for all supported chains.
 
 ```bash
 ows wallet create --name "my-wallet"
@@ -29,8 +29,14 @@ ows wallet create --name "my-wallet"
 | Flag | Description |
 |------|-------------|
 | `--name <NAME>` | Wallet name (required) |
-| `--passphrase <PASS>` | Encryption passphrase (prompted if omitted) |
 | `--words <12\|24>` | Mnemonic word count (default: 12) |
+| `--show-mnemonic` | Print the generated mnemonic for backup (dangerous) |
+
+Passphrase behavior:
+
+- If `OWS_PASSPHRASE` is set, it is used directly.
+- Otherwise the CLI prompts interactively and asks for confirmation.
+- Press Enter twice only if you intentionally want an empty passphrase.
 
 Output:
 
@@ -57,10 +63,10 @@ echo "4c0883a691..." | ows wallet import --name "from-evm" --private-key
 # Import an Ed25519 key (e.g. from Solana)
 echo "9d61b19d..." | ows wallet import --name "from-sol" --private-key --chain solana
 
-# Import explicit keys for both curves (no stdin needed)
-ows wallet import --name "both" \
-  --secp256k1-key "4c0883a691..." \
-  --ed25519-key "9d61b19d..."
+# Import explicit keys for both curves (via environment)
+OWS_SECP256K1_KEY="4c0883a691..." \
+OWS_ED25519_KEY="9d61b19d..." \
+ows wallet import --name "both"
 ```
 
 | Flag | Description |
@@ -70,10 +76,8 @@ ows wallet import --name "both" \
 | `--private-key` | Import a raw private key |
 | `--chain <CHAIN>` | Source chain for private key import (determines curve, default: evm) |
 | `--index <N>` | Account index for HD derivation (mnemonic only, default: 0) |
-| `--secp256k1-key <HEX>` | Explicit secp256k1 private key. When combined with `--ed25519-key`, `--private-key` is not required. |
-| `--ed25519-key <HEX>` | Explicit Ed25519 private key. When combined with `--secp256k1-key`, `--private-key` is not required. |
 
-Private key imports generate all 6 chain accounts: the provided key is used for its curve's chains, and a random key is generated for the other curve. Use `--secp256k1-key` and `--ed25519-key` together to supply both keys explicitly.
+Private key imports generate all 6 chain accounts: the provided key is used for its curve's chains, and a random key is generated for the other curve. Use `OWS_SECP256K1_KEY` and `OWS_ED25519_KEY` together to supply both keys explicitly.
 
 ### `ows wallet export`
 
@@ -86,7 +90,36 @@ ows wallet export --wallet "my-wallet"
 - Mnemonic wallets output the phrase.
 - Private key wallets output JSON: `{"secp256k1":"hex...","ed25519":"hex..."}`.
 
-If the wallet is passphrase-protected, you will be prompted.
+Passphrase resolution order:
+
+1. `OWS_PASSPHRASE`
+2. cached CLI passphrase from the OS keyring
+3. empty passphrase
+4. interactive prompt
+
+### `ows wallet unlock`
+
+Cache the current vault passphrase in the OS keyring for repeated interactive CLI use.
+
+```bash
+ows wallet unlock --wallet "my-wallet"
+```
+
+### `ows wallet lock`
+
+Remove any cached vault passphrase from the OS keyring.
+
+```bash
+ows wallet lock
+```
+
+### `ows wallet status`
+
+Show whether a vault passphrase is currently cached.
+
+```bash
+ows wallet status
+```
 
 ### `ows wallet list`
 
@@ -119,7 +152,6 @@ ows sign message --wallet "my-wallet" --chain evm --message "hello world"
 | `--wallet <NAME>` | Wallet name or ID |
 | `--chain <CHAIN>` | Chain family: `evm`, `solana`, `bitcoin`, `cosmos`, `tron` |
 | `--message <MSG>` | Message to sign |
-| `--passphrase <PASS>` | Decryption passphrase |
 | `--encoding <ENC>` | Message encoding: `utf8` (default) or `hex` |
 
 ### `ows sign tx`
@@ -135,7 +167,6 @@ ows sign tx --wallet "my-wallet" --chain evm --tx "02f8..."
 | `--wallet <NAME>` | Wallet name or ID |
 | `--chain <CHAIN>` | Chain family |
 | `--tx <HEX>` | Hex-encoded transaction bytes |
-| `--passphrase <PASS>` | Decryption passphrase |
 
 ## Mnemonic Commands
 

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -197,6 +197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +358,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +449,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -761,6 +808,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +834,25 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -825,12 +907,14 @@ dependencies = [
  "chrono",
  "clap",
  "hex",
+ "keyring",
  "ows-core",
  "ows-lib",
  "ows-signer",
  "rpassword",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "zeroize",
@@ -928,6 +1012,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polyval"
@@ -1186,6 +1276,42 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1626,7 +1752,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1635,7 +1761,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1653,14 +1788,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1670,10 +1822,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1682,10 +1846,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1694,10 +1870,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1706,10 +1894,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/ows/crates/ows-cli/Cargo.toml
+++ b/ows/crates/ows-cli/Cargo.toml
@@ -25,6 +25,8 @@ tempfile = "3"
 rpassword = "7"
 serde = { version = "1", features = ["derive"] }
 zeroize = "1"
+sha2 = "0.10"
+keyring = { version = "3", default-features = false, features = ["apple-native", "windows-native", "linux-native-sync-persistent"] }
 
 [dev-dependencies]
 ows-signer = { path = "../ows-signer", version = "=0.3.9", features = ["fast-kdf"] }

--- a/ows/crates/ows-cli/src/commands/mod.rs
+++ b/ows/crates/ows-cli/src/commands/mod.rs
@@ -9,8 +9,8 @@ pub mod uninstall;
 pub mod update;
 pub mod wallet;
 
-use crate::{vault, CliError};
-use ows_core::KeyType;
+use crate::{passphrase_cache, vault, CliError};
+use ows_core::{EncryptedWallet, KeyType};
 use ows_signer::process_hardening::clear_env_var;
 use ows_signer::{CryptoEnvelope, SecretBytes};
 use std::io::{self, BufRead, IsTerminal, Write};
@@ -81,38 +81,113 @@ pub enum WalletSecret {
     PrivateKeys(SecretBytes),
 }
 
+pub fn read_passphrase_from_env() -> Option<Zeroizing<String>> {
+    clear_env_var("OWS_PASSPHRASE")
+        .or_else(|| clear_env_var("LWS_PASSPHRASE"))
+        .map(Zeroizing::new)
+}
+
+fn prompt_hidden(prompt: &str) -> Result<Zeroizing<String>, CliError> {
+    if !io::stdin().is_terminal() {
+        return Err(CliError::InvalidArgs(
+            "passphrase required; set OWS_PASSPHRASE or use an interactive terminal".into(),
+        ));
+    }
+
+    Ok(Zeroizing::new(rpassword::prompt_password(prompt)?))
+}
+
 /// Read a passphrase from OWS_PASSPHRASE env var (or LWS_PASSPHRASE fallback) or prompt interactively.
-pub fn read_passphrase() -> Zeroizing<String> {
-    if let Some(value) = clear_env_var("OWS_PASSPHRASE").or_else(|| clear_env_var("LWS_PASSPHRASE"))
-    {
-        return Zeroizing::new(value);
+pub fn read_passphrase() -> Result<Zeroizing<String>, CliError> {
+    if let Some(value) = read_passphrase_from_env() {
+        return Ok(value);
     }
-    let stdin = io::stdin();
-    if stdin.is_terminal() {
-        eprint!("Passphrase (empty for none): ");
-        io::stderr().flush().ok();
-        let mut line = String::new();
-        stdin.lock().read_line(&mut line).unwrap_or(0);
-        Zeroizing::new(line.trim().to_string())
-    } else {
-        Zeroizing::new(String::new())
+
+    prompt_hidden("Vault passphrase: ")
+}
+
+/// Read and confirm the passphrase for a newly created/imported wallet.
+pub fn read_new_passphrase() -> Result<Zeroizing<String>, CliError> {
+    if let Some(value) = read_passphrase_from_env() {
+        return Ok(value);
     }
+
+    let passphrase = prompt_hidden("New wallet passphrase (leave empty for none): ")?;
+    let confirm = prompt_hidden("Confirm passphrase: ")?;
+    if passphrase.as_str() != confirm.as_str() {
+        return Err(CliError::InvalidArgs(
+            "passphrase confirmation did not match".into(),
+        ));
+    }
+
+    Ok(passphrase)
+}
+
+fn wallet_envelope(wallet: &EncryptedWallet) -> Result<CryptoEnvelope, CliError> {
+    Ok(serde_json::from_value(wallet.crypto.clone())?)
+}
+
+pub fn wallet_accepts_passphrase(
+    wallet: &EncryptedWallet,
+    passphrase: &str,
+) -> Result<bool, CliError> {
+    match ows_signer::decrypt(&wallet_envelope(wallet)?, passphrase) {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}
+
+pub fn ensure_wallet_passphrase(
+    wallet: &EncryptedWallet,
+    passphrase: &str,
+) -> Result<(), CliError> {
+    ows_signer::decrypt(&wallet_envelope(wallet)?, passphrase)?;
+    Ok(())
+}
+
+pub fn resolve_wallet_passphrase(wallet_name: &str) -> Result<Zeroizing<String>, CliError> {
+    let wallet = vault::load_wallet_by_name_or_id(wallet_name)?;
+    resolve_wallet_passphrase_for(&wallet)
+}
+
+fn resolve_wallet_passphrase_for(wallet: &EncryptedWallet) -> Result<Zeroizing<String>, CliError> {
+    if let Some(passphrase) = read_passphrase_from_env() {
+        ensure_wallet_passphrase(wallet, passphrase.as_str())?;
+        return Ok(passphrase);
+    }
+
+    match passphrase_cache::load(None) {
+        Ok(Some(passphrase)) => {
+            if wallet_accepts_passphrase(wallet, passphrase.as_str())? {
+                return Ok(passphrase);
+            }
+            let _ = passphrase_cache::delete(None);
+        }
+        Ok(None) => {}
+        Err(e) => eprintln!("warning: {e}"),
+    }
+
+    if wallet_accepts_passphrase(wallet, "")? {
+        return Ok(Zeroizing::new(String::new()));
+    }
+
+    if !io::stdin().is_terminal() {
+        return Err(CliError::InvalidArgs(
+            "wallet is passphrase-protected; set OWS_PASSPHRASE or run `ows wallet unlock --wallet <name>` interactively".into(),
+        ));
+    }
+
+    let passphrase = prompt_hidden("Vault passphrase: ")?;
+    ensure_wallet_passphrase(wallet, passphrase.as_str())?;
+    Ok(passphrase)
 }
 
 /// Look up a wallet by name or ID, decrypt it, and return the secret.
 /// Handles both mnemonic and private key wallets.
 pub fn resolve_wallet_secret(wallet_name: &str) -> Result<WalletSecret, CliError> {
     let wallet = vault::load_wallet_by_name_or_id(wallet_name)?;
-    let envelope: CryptoEnvelope = serde_json::from_value(wallet.crypto.clone())?;
-
-    // Try empty passphrase first, then prompt if it fails
-    let secret = match ows_signer::decrypt(&envelope, "") {
-        Ok(s) => s,
-        Err(_) => {
-            let passphrase = read_passphrase();
-            ows_signer::decrypt(&envelope, &passphrase)?
-        }
-    };
+    let passphrase = resolve_wallet_passphrase_for(&wallet)?;
+    let secret = ows_signer::decrypt(&wallet_envelope(&wallet)?, passphrase.as_str())?;
 
     match wallet.key_type {
         KeyType::Mnemonic => {

--- a/ows/crates/ows-cli/src/commands/wallet.rs
+++ b/ows/crates/ows-cli/src/commands/wallet.rs
@@ -7,7 +7,14 @@ use zeroize::Zeroize;
 pub fn create(name: &str, words: u32, show_mnemonic: bool) -> Result<(), CliError> {
     // Generate mnemonic, then import it to create the wallet
     let mut mnemonic_phrase = ows_lib::generate_mnemonic(words)?;
-    let info = ows_lib::import_wallet_mnemonic(name, &mnemonic_phrase, None, Some(0), None)?;
+    let passphrase = super::read_new_passphrase()?;
+    let info = ows_lib::import_wallet_mnemonic(
+        name,
+        &mnemonic_phrase,
+        Some(passphrase.as_str()),
+        Some(0),
+        None,
+    )?;
 
     audit::log_wallet_created(&info);
 
@@ -27,9 +34,16 @@ pub fn create(name: &str, words: u32, show_mnemonic: bool) -> Result<(), CliErro
         eprintln!("⚠️  Store it securely offline. It will NOT be shown again.");
         eprintln!();
         println!("{mnemonic_phrase}");
+    } else if passphrase.is_empty() {
+        eprintln!();
+        eprintln!("Wallet saved without a passphrase.");
+        eprintln!("Set OWS_PASSPHRASE when creating wallets to avoid accidental empty-passphrase storage.");
     } else {
         eprintln!();
         eprintln!("Mnemonic encrypted and saved to vault.");
+        eprintln!(
+            "Use `ows wallet unlock --wallet {name}` to cache the passphrase in your OS keyring."
+        );
         eprintln!("Use --show-mnemonic at creation time if you need a backup copy.");
     }
 
@@ -65,10 +79,17 @@ pub fn import(
                 .into(),
         ));
     }
+    let passphrase = super::read_new_passphrase()?;
 
     let info = if use_mnemonic {
         let phrase = super::read_mnemonic()?;
-        ows_lib::import_wallet_mnemonic(name, &phrase, None, Some(index), None)?
+        ows_lib::import_wallet_mnemonic(
+            name,
+            &phrase,
+            Some(passphrase.as_str()),
+            Some(index),
+            None,
+        )?
     } else {
         // Read from env/stdin only when both curve keys are not already provided
         let private_key_hex = if both_curve_keys {
@@ -80,7 +101,7 @@ pub fn import(
             name,
             &private_key_hex,
             chain,
-            None,
+            Some(passphrase.as_str()),
             None,
             secp256k1_key,
             ed25519_key,
@@ -109,14 +130,8 @@ pub fn export(wallet_name: &str) -> Result<(), CliError> {
         ));
     }
 
-    // Try empty passphrase first, then prompt if it fails
-    let mut exported = match ows_lib::export_wallet(wallet_name, None, None) {
-        Ok(s) => s,
-        Err(_) => {
-            let passphrase = super::read_passphrase();
-            ows_lib::export_wallet(wallet_name, Some(&passphrase), None)?
-        }
-    };
+    let passphrase = super::resolve_wallet_passphrase(wallet_name)?;
+    let mut exported = ows_lib::export_wallet(wallet_name, Some(passphrase.as_str()), None)?;
 
     let is_key_pair = exported.starts_with('{');
     eprintln!();
@@ -132,6 +147,44 @@ pub fn export(wallet_name: &str) -> Result<(), CliError> {
 
     let info = ows_lib::get_wallet(wallet_name, None)?;
     audit::log_wallet_exported(&info.id);
+    Ok(())
+}
+
+pub fn unlock(wallet_name: &str) -> Result<(), CliError> {
+    let wallet = crate::vault::load_wallet_by_name_or_id(wallet_name)?;
+
+    if super::wallet_accepts_passphrase(&wallet, "")? {
+        println!(
+            "Wallet '{}' uses an empty passphrase. Nothing was cached.",
+            wallet.name
+        );
+        return Ok(());
+    }
+
+    let passphrase = super::read_passphrase()?;
+    super::ensure_wallet_passphrase(&wallet, passphrase.as_str())?;
+    crate::passphrase_cache::store(passphrase.as_str(), None)?;
+
+    println!("Vault unlocked.");
+    println!("Passphrase cached in the OS keyring for interactive CLI workflows.");
+    Ok(())
+}
+
+pub fn lock() -> Result<(), CliError> {
+    if crate::passphrase_cache::delete(None)? {
+        println!("Cleared cached vault passphrase.");
+    } else {
+        println!("No cached vault passphrase found.");
+    }
+    Ok(())
+}
+
+pub fn status() -> Result<(), CliError> {
+    if crate::passphrase_cache::status(None)? {
+        println!("Vault status: unlocked (passphrase cached in OS keyring)");
+    } else {
+        println!("Vault status: locked");
+    }
     Ok(())
 }
 

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod audit;
 mod commands;
+mod passphrase_cache;
 mod vault;
 
 use clap::{Parser, Subcommand};
@@ -90,6 +91,16 @@ enum WalletCommands {
         #[arg(long)]
         wallet: String,
     },
+    /// Cache the current vault passphrase in the OS keyring
+    Unlock {
+        /// Wallet name or ID used to verify the passphrase
+        #[arg(long)]
+        wallet: String,
+    },
+    /// Remove any cached vault passphrase from the OS keyring
+    Lock,
+    /// Show whether a vault passphrase is currently cached
+    Status,
     /// Delete a wallet from the vault
     Delete {
         /// Wallet name or ID
@@ -224,6 +235,8 @@ enum CliError {
     Io(#[from] std::io::Error),
     #[error("{0}")]
     Json(#[from] serde_json::Error),
+    #[error("passphrase cache unavailable: {0}")]
+    PassphraseCache(String),
     #[error("{0}")]
     InvalidArgs(String),
 }
@@ -274,6 +287,9 @@ fn run(cli: Cli) -> Result<(), CliError> {
                 index,
             } => commands::wallet::import(&name, mnemonic, private_key, chain.as_deref(), index),
             WalletCommands::Export { wallet } => commands::wallet::export(&wallet),
+            WalletCommands::Unlock { wallet } => commands::wallet::unlock(&wallet),
+            WalletCommands::Lock => commands::wallet::lock(),
+            WalletCommands::Status => commands::wallet::status(),
             WalletCommands::Delete { wallet, confirm } => {
                 commands::wallet::delete(&wallet, confirm)
             }

--- a/ows/crates/ows-cli/src/passphrase_cache.rs
+++ b/ows/crates/ows-cli/src/passphrase_cache.rs
@@ -1,0 +1,123 @@
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+use crate::CliError;
+
+#[cfg_attr(test, allow(dead_code))]
+const SERVICE: &str = "ows-cli-passphrase-cache";
+
+fn cache_key(vault_path: Option<&Path>) -> String {
+    let resolved = ows_lib::vault::resolve_vault_path(vault_path);
+    let canonical = resolved.canonicalize().unwrap_or(resolved);
+    let digest = Sha256::digest(canonical.to_string_lossy().as_bytes());
+    format!("vault-passphrase:v1:{}", hex::encode(&digest[..8]))
+}
+
+pub fn store(passphrase: &str, vault_path: Option<&Path>) -> Result<(), CliError> {
+    write_secret(&cache_key(vault_path), passphrase)
+}
+
+pub fn load(vault_path: Option<&Path>) -> Result<Option<Zeroizing<String>>, CliError> {
+    read_secret(&cache_key(vault_path))
+}
+
+pub fn delete(vault_path: Option<&Path>) -> Result<bool, CliError> {
+    delete_secret(&cache_key(vault_path))
+}
+
+pub fn status(vault_path: Option<&Path>) -> Result<bool, CliError> {
+    Ok(load(vault_path)?.is_some())
+}
+
+#[cfg(not(test))]
+fn entry_for(key: &str) -> Result<keyring::Entry, CliError> {
+    keyring::Entry::new(SERVICE, key).map_err(|e| CliError::PassphraseCache(e.to_string()))
+}
+
+#[cfg(not(test))]
+fn write_secret(key: &str, passphrase: &str) -> Result<(), CliError> {
+    entry_for(key)?
+        .set_password(passphrase)
+        .map_err(|e| CliError::PassphraseCache(e.to_string()))
+}
+
+#[cfg(not(test))]
+fn read_secret(key: &str) -> Result<Option<Zeroizing<String>>, CliError> {
+    match entry_for(key)?.get_password() {
+        Ok(value) => Ok(Some(Zeroizing::new(value))),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(CliError::PassphraseCache(e.to_string())),
+    }
+}
+
+#[cfg(not(test))]
+fn delete_secret(key: &str) -> Result<bool, CliError> {
+    match entry_for(key)?.delete_credential() {
+        Ok(()) => Ok(true),
+        Err(keyring::Error::NoEntry) => Ok(false),
+        Err(e) => Err(CliError::PassphraseCache(e.to_string())),
+    }
+}
+
+#[cfg(test)]
+fn write_secret(key: &str, passphrase: &str) -> Result<(), CliError> {
+    let mut store = test_store()
+        .lock()
+        .map_err(|_| CliError::PassphraseCache("test store lock poisoned".into()))?;
+    store.insert(key.to_string(), passphrase.to_string());
+    Ok(())
+}
+
+#[cfg(test)]
+fn read_secret(key: &str) -> Result<Option<Zeroizing<String>>, CliError> {
+    let store = test_store()
+        .lock()
+        .map_err(|_| CliError::PassphraseCache("test store lock poisoned".into()))?;
+    Ok(store.get(key).cloned().map(Zeroizing::new))
+}
+
+#[cfg(test)]
+fn delete_secret(key: &str) -> Result<bool, CliError> {
+    let mut store = test_store()
+        .lock()
+        .map_err(|_| CliError::PassphraseCache("test store lock poisoned".into()))?;
+    Ok(store.remove(key).is_some())
+}
+
+#[cfg(test)]
+fn test_store() -> &'static std::sync::Mutex<std::collections::HashMap<String, String>> {
+    static STORE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<String, String>>> =
+        std::sync::OnceLock::new();
+    STORE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        assert!(!status(Some(&vault)).unwrap());
+
+        store("secret-passphrase", Some(&vault)).unwrap();
+        assert!(status(Some(&vault)).unwrap());
+
+        let cached = load(Some(&vault)).unwrap().unwrap();
+        assert_eq!(cached.as_str(), "secret-passphrase");
+
+        assert!(delete(Some(&vault)).unwrap());
+        assert!(!status(Some(&vault)).unwrap());
+        assert!(load(Some(&vault)).unwrap().is_none());
+    }
+
+    #[test]
+    fn delete_missing_entry_is_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        assert!(!delete(Some(&vault)).unwrap());
+    }
+}


### PR DESCRIPTION
## Summary

This PR keeps encrypted wallet files as the canonical storage format and tightens the CLI passphrase flow.

- `ows wallet create` and `ows wallet import` now read an explicit passphrase instead of silently defaulting to the empty string
- adds `ows wallet unlock`, `ows wallet lock`, and `ows wallet status` as a CLI-only OS keyring passphrase cache
- keeps `ows-lib`, Node, and Python passphrase-based APIs unchanged
- keeps the encrypted file keystore model unchanged; no wallet file format migration is required

## Notes

This is intentionally narrower than the earlier keyring-backed storage PR. The OS keyring is used only as an optional interactive CLI cache, not as the primary wallet secret store.

## Testing

- `cargo test --workspace`
- `cargo test -p ows-cli`
