### PR TITLE
fix: set version script includes ows pay

### DIFF
--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -57,7 +57,7 @@ set_rust_version() {
   done
 
   # Update internal dependency version specifiers
-  for crate in ows-signer ows-lib ows-cli; do
+  for crate in ows-signer ows-lib ows-pay ows-cli; do
     sed -i.bak -E "s/(ows-(core|signer|lib|pay) = \{[^}]*version = \")=[^\"]*\"/\1=$VERSION\"/" \
       "$crates_dir/$crate/Cargo.toml"
     rm -f "$crates_dir/$crate/Cargo.toml.bak"


### PR DESCRIPTION
## What

Brief description of the change.

## Why

Why is this change needed? Link to related issue(s) if applicable.

Closes #

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` is clean
- [ ] `npm test` passes (if Node bindings changed)
- [ ] Tested manually with `ows` CLI

## Notes

Anything reviewers should know.
