### PR TITLE
feat: add Nano (XNO) chain support

### DIFF
--- a/bindings/node/__test__/index.spec.mjs
+++ b/bindings/node/__test__/index.spec.mjs
@@ -201,7 +201,9 @@ describe('@open-wallet-standard/core', () => {
   it('signs messages on all chains', () => {
     createWallet('all-chain-signer', undefined, 12, vaultDir);
 
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano']) {
+    // XRPL and Nano are excluded here because their signers explicitly do not
+    // support generic off-chain message signing without a defined convention.
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin']) {
       const result = signMessage('all-chain-signer', chain, 'test', undefined, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);
     }

--- a/bindings/node/__test__/index.spec.mjs
+++ b/bindings/node/__test__/index.spec.mjs
@@ -51,7 +51,7 @@ describe('@open-wallet-standard/core', () => {
 
   it('derives addresses for all chains', () => {
     const phrase = generateMnemonic(12);
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl']) {
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano']) {
       const addr = deriveAddress(phrase, chain);
       assert.ok(addr.length > 0, `address should be non-empty for ${chain}`);
     }
@@ -59,10 +59,10 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Universal wallet lifecycle ----
 
-  it('creates a universal wallet with 9 accounts', () => {
+  it('creates a universal wallet with 10 accounts', () => {
     const wallet = createWallet('lifecycle-test', undefined, 12, vaultDir);
     assert.equal(wallet.name, 'lifecycle-test');
-    assert.equal(wallet.accounts.length, 9);
+    assert.equal(wallet.accounts.length, 10);
 
     const chainIds = wallet.accounts.map((a) => a.chainId);
     assert.ok(chainIds.some((c) => c.startsWith('eip155:')));
@@ -74,6 +74,7 @@ describe('@open-wallet-standard/core', () => {
     assert.ok(chainIds.some((c) => c.startsWith('ton:')));
     assert.ok(chainIds.some((c) => c.startsWith('fil:')));
     assert.ok(chainIds.some((c) => c.startsWith('xrpl:')));
+    assert.ok(chainIds.some((c) => c.startsWith('nano:')));
 
     // List
     const wallets = listWallets(vaultDir);
@@ -107,7 +108,7 @@ describe('@open-wallet-standard/core', () => {
 
     const wallet = importWalletMnemonic('mn-import', phrase, undefined, undefined, vaultDir);
     assert.equal(wallet.name, 'mn-import');
-    assert.equal(wallet.accounts.length, 9);
+    assert.equal(wallet.accounts.length, 10);
 
     const evmAcct = wallet.accounts.find((a) => a.chainId.startsWith('eip155:'));
     assert.equal(evmAcct.address, expectedEvm);
@@ -120,12 +121,12 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Private key import (secp256k1) ----
 
-  it('imports a secp256k1 private key with all 9 accounts', () => {
+  it('imports a secp256k1 private key with all 10 accounts', () => {
     const privkey = '4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318';
     const wallet = importWalletPrivateKey('pk-secp', privkey, undefined, vaultDir, 'evm');
 
     assert.equal(wallet.name, 'pk-secp');
-    assert.equal(wallet.accounts.length, 9, 'should have all 9 chain accounts');
+    assert.equal(wallet.accounts.length, 10, 'should have all 10 chain accounts');
 
     // Sign on EVM (provided key's curve)
     const evmSig = signMessage('pk-secp', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
@@ -145,11 +146,11 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Private key import (ed25519) ----
 
-  it('imports an ed25519 private key with all 9 accounts', () => {
+  it('imports an ed25519 private key with all 10 accounts', () => {
     const privkey = '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60';
     const wallet = importWalletPrivateKey('pk-ed', privkey, undefined, vaultDir, 'solana');
 
-    assert.equal(wallet.accounts.length, 9);
+    assert.equal(wallet.accounts.length, 10);
 
     // Sign on Solana (provided key)
     const solSig = signMessage('pk-ed', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
@@ -177,7 +178,7 @@ describe('@open-wallet-standard/core', () => {
     );
 
     assert.equal(wallet.name, 'pk-both');
-    assert.equal(wallet.accounts.length, 9, 'should have all 9 chain accounts');
+    assert.equal(wallet.accounts.length, 10, 'should have all 10 chain accounts');
 
     // Sign on EVM (secp256k1 key)
     const evmSig = signMessage('pk-both', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
@@ -200,7 +201,7 @@ describe('@open-wallet-standard/core', () => {
   it('signs messages on all chains', () => {
     createWallet('all-chain-signer', undefined, 12, vaultDir);
 
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin']) {
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano']) {
       const result = signMessage('all-chain-signer', chain, 'test', undefined, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);
     }
@@ -215,9 +216,24 @@ describe('@open-wallet-standard/core', () => {
     // [compact-u16 sig count][64-byte sig slots...][message...]
     // Build a minimal tx with 1 sig slot (0x01) + 64 zero bytes + a message.
     const solTxHex = '01' + '00'.repeat(64) + 'deadbeefdeadbeef';
+    // Nano state block: 176-byte canonical layout (preamble + account + previous
+    // + representative + balance + link).
+    // https://docs.nano.org/integration-guides/the-basics/#self-signed-blocks
+    const nanoTxHex =
+      `${'00'.repeat(31)}06` +
+      `${'01'.repeat(32)}` +
+      `${'00'.repeat(32)}` +
+      `${'02'.repeat(32)}` +
+      '00000000033b2e3c9fd0803ce8000000' +
+      `${'03'.repeat(32)}`;
 
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl']) {
-      const hex = chain === 'solana' ? solTxHex : txHex;
+    const txHexByChain = {
+      solana: solTxHex,
+      nano: nanoTxHex,
+    };
+
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano']) {
+      const hex = txHexByChain[chain] ?? txHex;
       const result = signTransaction('tx-signer', chain, hex, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);
     }

--- a/bindings/python/tests/test_bindings.py
+++ b/bindings/python/tests/test_bindings.py
@@ -40,7 +40,7 @@ def test_create_and_list_wallets(vault_dir):
     wallet = ows.create_wallet("test-wallet", vault_path_opt=vault_dir)
     assert wallet["name"] == "test-wallet"
     assert isinstance(wallet["accounts"], list)
-    assert len(wallet["accounts"]) == 9
+    assert len(wallet["accounts"]) == 10
 
     # Verify each chain family is present
     chain_ids = [a["chain_id"] for a in wallet["accounts"]]
@@ -53,6 +53,7 @@ def test_create_and_list_wallets(vault_dir):
     assert any(c.startswith("ton:") for c in chain_ids)
     assert any(c.startswith("fil:") for c in chain_ids)
     assert any(c.startswith("xrpl:") for c in chain_ids)
+    assert any(c.startswith("nano:") for c in chain_ids)
 
     wallets = ows.list_wallets(vault_path_opt=vault_dir)
     assert len(wallets) == 1
@@ -99,7 +100,7 @@ def test_import_wallet_mnemonic(vault_dir):
         "imported", phrase, vault_path_opt=vault_dir
     )
     assert wallet["name"] == "imported"
-    assert len(wallet["accounts"]) == 9
+    assert len(wallet["accounts"]) == 10
 
     # EVM account should match derived address
     evm_account = next(a for a in wallet["accounts"] if a["chain_id"].startswith("eip155:"))

--- a/bindings/python/tests/test_bindings.py
+++ b/bindings/python/tests/test_bindings.py
@@ -36,6 +36,13 @@ def test_derive_address_ethereum():
     assert len(address) == 42
 
 
+def test_derive_address_all_supported_chains():
+    phrase = ows.generate_mnemonic(12)
+    for chain in ["evm", "solana", "sui", "bitcoin", "cosmos", "tron", "ton", "filecoin", "nano"]:
+        address = ows.derive_address(phrase, chain)
+        assert len(address) > 0
+
+
 def test_create_and_list_wallets(vault_dir):
     wallet = ows.create_wallet("test-wallet", vault_path_opt=vault_dir)
     assert wallet["name"] == "test-wallet"

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -15,10 +15,11 @@ pub enum ChainType {
     Filecoin,
     Sui,
     Xrpl,
+    Nano,
 }
 
 /// All supported chain families, used for universal wallet derivation.
-pub const ALL_CHAIN_TYPES: [ChainType; 9] = [
+pub const ALL_CHAIN_TYPES: [ChainType; 10] = [
     ChainType::Evm,
     ChainType::Solana,
     ChainType::Bitcoin,
@@ -28,6 +29,7 @@ pub const ALL_CHAIN_TYPES: [ChainType; 9] = [
     ChainType::Filecoin,
     ChainType::Sui,
     ChainType::Xrpl,
+    ChainType::Nano,
 ];
 
 /// A specific chain (e.g. "ethereum", "arbitrum") with its family type and CAIP-2 ID.
@@ -140,6 +142,11 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_type: ChainType::Xrpl,
         chain_id: "xrpl:devnet",
     },
+    Chain {
+        name: "nano",
+        chain_type: ChainType::Nano,
+        chain_id: "nano:mainnet",
+    },
 ];
 
 /// Parse a chain string into a `Chain`. Accepts:
@@ -204,7 +211,7 @@ pub fn parse_chain(s: &str) -> Result<Chain, String> {
            EVM:     ethereum, base, arbitrum, optimism, polygon, bsc, avalanche, plasma, etherlink\n  \
            Solana:  solana\n  \
            Bitcoin: bitcoin\n  \
-           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl\n\n\
+           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl, nano\n\n\
          Or use a CAIP-2 ID (eip155:8453) or bare EVM chain ID (8453)"
     ))
 }
@@ -228,6 +235,7 @@ impl ChainType {
             ChainType::Filecoin => "fil",
             ChainType::Sui => "sui",
             ChainType::Xrpl => "xrpl",
+            ChainType::Nano => "nano",
         }
     }
 
@@ -244,6 +252,7 @@ impl ChainType {
             ChainType::Filecoin => 461,
             ChainType::Sui => 784,
             ChainType::Xrpl => 144,
+            ChainType::Nano => 165,
         }
     }
 
@@ -260,6 +269,7 @@ impl ChainType {
             "fil" => Some(ChainType::Filecoin),
             "sui" => Some(ChainType::Sui),
             "xrpl" => Some(ChainType::Xrpl),
+            "nano" => Some(ChainType::Nano),
             _ => None,
         }
     }
@@ -278,6 +288,7 @@ impl fmt::Display for ChainType {
             ChainType::Filecoin => "filecoin",
             ChainType::Sui => "sui",
             ChainType::Xrpl => "xrpl",
+            ChainType::Nano => "nano",
         };
         write!(f, "{}", s)
     }
@@ -298,6 +309,7 @@ impl FromStr for ChainType {
             "filecoin" => Ok(ChainType::Filecoin),
             "sui" => Ok(ChainType::Sui),
             "xrpl" => Ok(ChainType::Xrpl),
+            "nano" => Ok(ChainType::Nano),
             _ => Err(format!("unknown chain type: {}", s)),
         }
     }
@@ -329,6 +341,7 @@ mod tests {
             (ChainType::Filecoin, "\"filecoin\""),
             (ChainType::Sui, "\"sui\""),
             (ChainType::Xrpl, "\"xrpl\""),
+            (ChainType::Nano, "\"nano\""),
         ] {
             let json = serde_json::to_string(&chain).unwrap();
             assert_eq!(json, expected);
@@ -349,6 +362,7 @@ mod tests {
         assert_eq!(ChainType::Filecoin.namespace(), "fil");
         assert_eq!(ChainType::Sui.namespace(), "sui");
         assert_eq!(ChainType::Xrpl.namespace(), "xrpl");
+        assert_eq!(ChainType::Nano.namespace(), "nano");
     }
 
     #[test]
@@ -363,6 +377,7 @@ mod tests {
         assert_eq!(ChainType::Filecoin.default_coin_type(), 461);
         assert_eq!(ChainType::Sui.default_coin_type(), 784);
         assert_eq!(ChainType::Xrpl.default_coin_type(), 144);
+        assert_eq!(ChainType::Nano.default_coin_type(), 165);
     }
 
     #[test]
@@ -380,6 +395,7 @@ mod tests {
         assert_eq!(ChainType::from_namespace("fil"), Some(ChainType::Filecoin));
         assert_eq!(ChainType::from_namespace("sui"), Some(ChainType::Sui));
         assert_eq!(ChainType::from_namespace("xrpl"), Some(ChainType::Xrpl));
+        assert_eq!(ChainType::from_namespace("nano"), Some(ChainType::Nano));
         assert_eq!(ChainType::from_namespace("unknown"), None);
     }
 
@@ -507,7 +523,7 @@ mod tests {
 
     #[test]
     fn test_all_chain_types() {
-        assert_eq!(ALL_CHAIN_TYPES.len(), 9);
+        assert_eq!(ALL_CHAIN_TYPES.len(), 10);
     }
 
     #[test]

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -254,7 +254,7 @@ mod tests {
     fn test_load_or_default_nonexistent() {
         let config = Config::load_or_default_from(std::path::Path::new("/nonexistent/config.json"));
         // Should have all default RPCs
-        assert_eq!(config.rpc.len(), 18);
+        assert_eq!(config.rpc.len(), 19);
         assert_eq!(config.rpc_url("eip155:1"), Some("https://eth.llamarpc.com"));
     }
 

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -73,6 +73,7 @@ impl Config {
             "xrpl:devnet".into(),
             "https://s.devnet.rippletest.net:51234".into(),
         );
+        rpc.insert("nano:mainnet".into(), "https://nanoslo.0x.no/proxy".into());
         rpc
     }
 }

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -73,7 +73,7 @@ impl Config {
             "xrpl:devnet".into(),
             "https://s.devnet.rippletest.net:51234".into(),
         );
-        rpc.insert("nano:mainnet".into(), "https://nanoslo.0x.no/proxy".into());
+        rpc.insert("nano:mainnet".into(), "https://rpc.nano.to".into());
         rpc
     }
 }

--- a/ows/crates/ows-lib/src/lib.rs
+++ b/ows/crates/ows-lib/src/lib.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod key_ops;
 pub mod key_store;
 pub mod migrate;
+pub mod nano_rpc;
 pub mod ops;
 pub mod policy_engine;
 pub mod policy_store;

--- a/ows/crates/ows-lib/src/nano_rpc.rs
+++ b/ows/crates/ows-lib/src/nano_rpc.rs
@@ -1,0 +1,193 @@
+//! Nano RPC helpers (account_info, work_generate, process).
+//!
+//! Uses `curl` for HTTP, consistent with the rest of ows-lib (no added HTTP deps).
+
+use crate::error::OwsLibError;
+use std::process::Command;
+
+/// Call a Nano RPC action via curl and return the parsed JSON response.
+fn nano_rpc_call(
+    rpc_url: &str,
+    body: &serde_json::Value,
+) -> Result<serde_json::Value, OwsLibError> {
+    let body_str = body.to_string();
+    let output = Command::new("curl")
+        .args([
+            "-fsSL",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            &body_str,
+            rpc_url,
+        ])
+        .output()
+        .map_err(|e| OwsLibError::BroadcastFailed(format!("failed to run curl: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(OwsLibError::BroadcastFailed(format!(
+            "Nano RPC call failed: {stderr}"
+        )));
+    }
+
+    let resp_str = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&resp_str)?;
+
+    // Check for Nano RPC error field
+    if let Some(error) = parsed.get("error") {
+        let msg = error.as_str().unwrap_or("unknown error");
+        return Err(OwsLibError::BroadcastFailed(format!(
+            "Nano RPC error: {msg}"
+        )));
+    }
+
+    Ok(parsed)
+}
+
+/// Account info from the Nano network.
+#[derive(Debug, Clone)]
+pub struct NanoAccountInfo {
+    /// Current frontier (head block hash), hex-encoded.
+    pub frontier: String,
+    /// Current balance in raw (decimal string).
+    pub balance: String,
+    /// Representative nano_ address.
+    pub representative: String,
+}
+
+/// Query `account_info` for a Nano account.
+///
+/// Returns `None` if the account is not yet opened (no blocks published).
+pub fn account_info(rpc_url: &str, account: &str) -> Result<Option<NanoAccountInfo>, OwsLibError> {
+    let body = serde_json::json!({
+        "action": "account_info",
+        "account": account,
+        "representative": "true"
+    });
+
+    match nano_rpc_call(rpc_url, &body) {
+        Ok(resp) => {
+            let frontier = resp["frontier"]
+                .as_str()
+                .ok_or_else(|| {
+                    OwsLibError::BroadcastFailed("no frontier in account_info response".into())
+                })?
+                .to_string();
+            let balance = resp["balance"]
+                .as_str()
+                .ok_or_else(|| {
+                    OwsLibError::BroadcastFailed("no balance in account_info response".into())
+                })?
+                .to_string();
+            let representative = resp["representative"]
+                .as_str()
+                .ok_or_else(|| {
+                    OwsLibError::BroadcastFailed(
+                        "no representative in account_info response".into(),
+                    )
+                })?
+                .to_string();
+
+            Ok(Some(NanoAccountInfo {
+                frontier,
+                balance,
+                representative,
+            }))
+        }
+        Err(OwsLibError::BroadcastFailed(msg)) if msg.contains("Account not found") => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Request proof-of-work from a single RPC endpoint.
+fn work_generate_single(
+    rpc_url: &str,
+    hash: &str,
+    difficulty: &str,
+) -> Result<String, OwsLibError> {
+    let body = serde_json::json!({
+        "action": "work_generate",
+        "hash": hash,
+        "difficulty": difficulty
+    });
+
+    let resp = nano_rpc_call(rpc_url, &body)?;
+
+    resp["work"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| OwsLibError::BroadcastFailed("no work in work_generate response".into()))
+}
+
+/// Default PoW fallback endpoint, tried when the primary RPC fails work_generate.
+const FALLBACK_WORK_PEER: &str = "https://rpc.nano.to";
+
+/// Request proof-of-work with multi-endpoint fallback.
+///
+/// Tries endpoints in order:
+/// 1. The primary `rpc_url`
+/// 2. Peers from `NANO_WORK_PEERS` env var (semicolon-separated URLs)
+/// 3. Built-in fallback endpoint
+///
+/// All remote errors are collected and logged to stderr. If every remote fails
+/// and `NANO_CPU_POW=1` is set, a future CPU fallback would go here.
+pub fn work_generate(rpc_url: &str, hash: &str, difficulty: &str) -> Result<String, OwsLibError> {
+    let mut endpoints: Vec<String> = vec![rpc_url.to_string()];
+
+    if let Ok(peers) = std::env::var("NANO_WORK_PEERS") {
+        for peer in peers.split(';') {
+            let peer = peer.trim();
+            if !peer.is_empty() && peer != rpc_url {
+                endpoints.push(peer.to_string());
+            }
+        }
+    }
+
+    if !endpoints.iter().any(|e| e == FALLBACK_WORK_PEER) {
+        endpoints.push(FALLBACK_WORK_PEER.to_string());
+    }
+
+    let mut last_error = None;
+
+    for endpoint in &endpoints {
+        match work_generate_single(endpoint, hash, difficulty) {
+            Ok(work) => return Ok(work),
+            Err(e) => {
+                eprintln!("  PoW failed on {endpoint}: {e}");
+                last_error = Some(e);
+            }
+        }
+    }
+
+    Err(last_error
+        .unwrap_or_else(|| OwsLibError::BroadcastFailed("no PoW endpoints available".into())))
+}
+
+/// Publish a block to the Nano network via `process` RPC.
+///
+/// Returns the block hash on success.
+pub fn process_block(
+    rpc_url: &str,
+    block_json: &serde_json::Value,
+    subtype: &str,
+) -> Result<String, OwsLibError> {
+    let body = serde_json::json!({
+        "action": "process",
+        "json_block": "true",
+        "subtype": subtype,
+        "block": block_json
+    });
+
+    let resp = nano_rpc_call(rpc_url, &body)?;
+
+    resp["hash"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| OwsLibError::BroadcastFailed(format!("no hash in process response: {resp}")))
+}
+
+/// PoW difficulty thresholds (as hex strings for work_generate RPC).
+pub const SEND_DIFFICULTY: &str = "fffffff800000000";
+pub const RECEIVE_DIFFICULTY: &str = "fffffe0000000000";

--- a/ows/crates/ows-lib/src/nano_rpc.rs
+++ b/ows/crates/ows-lib/src/nano_rpc.rs
@@ -122,13 +122,13 @@ fn work_generate_single(
 }
 
 /// Default PoW fallback endpoint, tried when the primary RPC fails work_generate.
-const FALLBACK_WORK_PEER: &str = "https://rpc.nano.to";
+const FALLBACK_WORK_URL: &str = "https://rpc.nano.to";
 
 /// Request proof-of-work with multi-endpoint fallback.
 ///
 /// Tries endpoints in order:
 /// 1. The primary `rpc_url`
-/// 2. Peers from `NANO_WORK_PEERS` env var (semicolon-separated URLs)
+/// 2. URLs from `NANO_WORK_URL` env var (semicolon-separated URLs)
 /// 3. Built-in fallback endpoint
 ///
 /// All remote errors are collected and logged to stderr. If every remote fails
@@ -136,17 +136,17 @@ const FALLBACK_WORK_PEER: &str = "https://rpc.nano.to";
 pub fn work_generate(rpc_url: &str, hash: &str, difficulty: &str) -> Result<String, OwsLibError> {
     let mut endpoints: Vec<String> = vec![rpc_url.to_string()];
 
-    if let Ok(peers) = std::env::var("NANO_WORK_PEERS") {
-        for peer in peers.split(';') {
-            let peer = peer.trim();
-            if !peer.is_empty() && peer != rpc_url {
-                endpoints.push(peer.to_string());
+    if let Ok(urls) = std::env::var("NANO_WORK_URL") {
+        for url in urls.split(';') {
+            let url = url.trim();
+            if !url.is_empty() && url != rpc_url {
+                endpoints.push(url.to_string());
             }
         }
     }
 
-    if !endpoints.iter().any(|e| e == FALLBACK_WORK_PEER) {
-        endpoints.push(FALLBACK_WORK_PEER.to_string());
+    if !endpoints.iter().any(|e| e == FALLBACK_WORK_URL) {
+        endpoints.push(FALLBACK_WORK_URL.to_string());
     }
 
     let mut last_error = None;

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -698,6 +698,7 @@ fn broadcast(chain: ChainType, rpc_url: &str, signed_bytes: &[u8]) -> Result<Str
         )),
         ChainType::Sui => broadcast_sui(rpc_url, signed_bytes),
         ChainType::Xrpl => broadcast_xrpl(rpc_url, signed_bytes),
+        ChainType::Nano => broadcast_nano(rpc_url, signed_bytes),
     }
 }
 
@@ -842,6 +843,87 @@ fn broadcast_sui(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibErr
     let sig_part = &signed_bytes[split..];
 
     crate::sui_grpc::execute_transaction(rpc_url, tx_part, sig_part)
+}
+
+fn broadcast_nano(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibError> {
+    const STATE_BLOCK_LEN: usize = 176;
+    const SIGNATURE_LEN: usize = 64;
+    const SIGNED_BLOCK_LEN: usize = STATE_BLOCK_LEN + SIGNATURE_LEN;
+
+    if signed_bytes.len() != SIGNED_BLOCK_LEN {
+        return Err(OwsLibError::InvalidInput(format!(
+            "Nano signed block must be {} bytes ({} block + {} sig), got {}",
+            SIGNED_BLOCK_LEN,
+            STATE_BLOCK_LEN,
+            SIGNATURE_LEN,
+            signed_bytes.len()
+        )));
+    }
+
+    let block_bytes = &signed_bytes[..STATE_BLOCK_LEN];
+    let signature = &signed_bytes[STATE_BLOCK_LEN..SIGNED_BLOCK_LEN];
+
+    // Extract fields from the 176-byte canonical block
+    let account: [u8; 32] = block_bytes[32..64]
+        .try_into()
+        .map_err(|_| OwsLibError::InvalidInput("invalid account bytes in block".into()))?;
+    let previous = &block_bytes[64..96];
+    let representative: [u8; 32] = block_bytes[96..128]
+        .try_into()
+        .map_err(|_| OwsLibError::InvalidInput("invalid representative bytes in block".into()))?;
+    let balance_bytes: [u8; 16] = block_bytes[128..144]
+        .try_into()
+        .map_err(|_| OwsLibError::InvalidInput("invalid balance bytes in block".into()))?;
+    let balance = u128::from_be_bytes(balance_bytes);
+    let link = &block_bytes[144..STATE_BLOCK_LEN];
+
+    let previous_is_zero = previous == [0u8; 32];
+
+    let account_address = ows_signer::chains::nano::nano_address(&account);
+
+    // Determine block subtype by querying current account balance
+    let subtype = if previous_is_zero {
+        "open"
+    } else {
+        match crate::nano_rpc::account_info(rpc_url, &account_address)? {
+            Some(info) => {
+                let prev_balance: u128 = info.balance.parse().unwrap_or(0);
+                if balance < prev_balance {
+                    "send"
+                } else {
+                    "receive"
+                }
+            }
+            None => "open",
+        }
+    };
+
+    let difficulty = match subtype {
+        "send" => crate::nano_rpc::SEND_DIFFICULTY,
+        _ => crate::nano_rpc::RECEIVE_DIFFICULTY,
+    };
+
+    // PoW root: for open blocks, use account pubkey; otherwise use previous hash
+    let work_root = if previous_is_zero {
+        hex::encode(account)
+    } else {
+        hex::encode(previous)
+    };
+
+    let work = crate::nano_rpc::work_generate(rpc_url, &work_root, difficulty)?;
+
+    let block_json = serde_json::json!({
+        "type": "state",
+        "account": account_address,
+        "previous": hex::encode(previous),
+        "representative": ows_signer::chains::nano::nano_address(&representative),
+        "balance": balance.to_string(),
+        "link": hex::encode(link),
+        "signature": hex::encode(signature),
+        "work": work
+    });
+
+    crate::nano_rpc::process_block(rpc_url, &block_json, subtype)
 }
 
 fn curl_post_json(url: &str, body: &str) -> Result<String, OwsLibError> {

--- a/ows/crates/ows-pay/src/discovery.rs
+++ b/ows/crates/ows-pay/src/discovery.rs
@@ -321,7 +321,10 @@ mod tests {
     #[test]
     fn format_price_dispatches() {
         assert_eq!(format_price("10000", "eip155:8453"), "$0.01");
-        assert_eq!(format_price("1000000000000000000000000000000", "nano:mainnet"), "1 NANO");
+        assert_eq!(
+            format_price("1000000000000000000000000000000", "nano:mainnet"),
+            "1 NANO"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/ows/crates/ows-pay/src/discovery.rs
+++ b/ows/crates/ows-pay/src/discovery.rs
@@ -148,7 +148,7 @@ fn filter_services(
             name: svc.resource.clone(),
             url: svc.resource,
             description: truncate(desc, 80),
-            price: format_usdc(&accept.amount),
+            price: format_price(&accept.amount, &accept.network),
             network: accept.network.clone(),
             tags: vec![],
         });
@@ -202,6 +202,14 @@ async fn fetch_x402(limit: u64, offset: u64) -> Result<FetchResult, PayError> {
 // Formatting helpers
 // ===========================================================================
 
+pub(crate) fn format_price(amount_str: &str, network: &str) -> String {
+    let chain_type = crate::chains::resolve_chain_type(network);
+    match chain_type {
+        Some(ows_core::ChainType::Nano) => format_nano(amount_str),
+        _ => format_usdc(amount_str),
+    }
+}
+
 pub(crate) fn format_usdc(amount_str: &str) -> String {
     let amount: u128 = amount_str.parse().unwrap_or(0);
     let whole = amount / 1_000_000;
@@ -210,6 +218,20 @@ pub(crate) fn format_usdc(amount_str: &str) -> String {
     let trimmed = frac_str.trim_end_matches('0');
     let trimmed = if trimmed.is_empty() { "00" } else { trimmed };
     format!("${whole}.{trimmed}")
+}
+
+pub(crate) fn format_nano(amount_str: &str) -> String {
+    let amount: u128 = amount_str.parse().unwrap_or(0);
+    let divisor = 1_000_000_000_000_000_000_000_000_000_000u128;
+    let whole = amount / divisor;
+    let frac = amount % divisor;
+    if frac == 0 {
+        format!("{whole} NANO")
+    } else {
+        let frac_str = format!("{frac:030}");
+        let trimmed = frac_str.trim_end_matches('0');
+        format!("{whole}.{trimmed} NANO")
+    }
 }
 
 fn truncate(s: &str, max: usize) -> String {
@@ -275,6 +297,31 @@ mod tests {
     #[test]
     fn format_usdc_empty() {
         assert_eq!(format_usdc(""), "$0.00");
+    }
+
+    // -----------------------------------------------------------------------
+    // format_nano
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_nano_whole() {
+        assert_eq!(format_nano("1000000000000000000000000000000"), "1 NANO");
+    }
+
+    #[test]
+    fn format_nano_fractional() {
+        assert_eq!(format_nano("1500000000000000000000000000000"), "1.5 NANO");
+    }
+
+    #[test]
+    fn format_nano_very_small() {
+        assert_eq!(format_nano("1"), "0.000000000000000000000000000001 NANO");
+    }
+
+    #[test]
+    fn format_price_dispatches() {
+        assert_eq!(format_price("10000", "eip155:8453"), "$0.01");
+        assert_eq!(format_price("1000000000000000000000000000000", "nano:mainnet"), "1 NANO");
     }
 
     // -----------------------------------------------------------------------

--- a/ows/crates/ows-pay/src/discovery.rs
+++ b/ows/crates/ows-pay/src/discovery.rs
@@ -226,11 +226,11 @@ pub(crate) fn format_nano(amount_str: &str) -> String {
     let whole = amount / divisor;
     let frac = amount % divisor;
     if frac == 0 {
-        format!("{whole} NANO")
+        format!("{whole} XNO")
     } else {
         let frac_str = format!("{frac:030}");
         let trimmed = frac_str.trim_end_matches('0');
-        format!("{whole}.{trimmed} NANO")
+        format!("{whole}.{trimmed} XNO")
     }
 }
 
@@ -305,17 +305,17 @@ mod tests {
 
     #[test]
     fn format_nano_whole() {
-        assert_eq!(format_nano("1000000000000000000000000000000"), "1 NANO");
+        assert_eq!(format_nano("1000000000000000000000000000000"), "1 XNO");
     }
 
     #[test]
     fn format_nano_fractional() {
-        assert_eq!(format_nano("1500000000000000000000000000000"), "1.5 NANO");
+        assert_eq!(format_nano("1500000000000000000000000000000"), "1.5 XNO");
     }
 
     #[test]
     fn format_nano_very_small() {
-        assert_eq!(format_nano("1"), "0.000000000000000000000000000001 NANO");
+        assert_eq!(format_nano("1"), "0.000000000000000000000000000001 XNO");
     }
 
     #[test]
@@ -323,7 +323,7 @@ mod tests {
         assert_eq!(format_price("10000", "eip155:8453"), "$0.01");
         assert_eq!(
             format_price("1000000000000000000000000000000", "nano:mainnet"),
-            "1 NANO"
+            "1 XNO"
         );
     }
 

--- a/ows/crates/ows-signer/src/chains/mod.rs
+++ b/ows/crates/ows-signer/src/chains/mod.rs
@@ -2,6 +2,7 @@ pub mod bitcoin;
 pub mod cosmos;
 pub mod evm;
 pub mod filecoin;
+pub mod nano;
 pub mod solana;
 pub mod spark;
 pub mod sui;
@@ -13,6 +14,7 @@ pub use self::bitcoin::BitcoinSigner;
 pub use self::cosmos::CosmosSigner;
 pub use self::evm::EvmSigner;
 pub use self::filecoin::FilecoinSigner;
+pub use self::nano::NanoSigner;
 pub use self::solana::SolanaSigner;
 pub use self::spark::SparkSigner;
 pub use self::sui::SuiSigner;
@@ -36,5 +38,6 @@ pub fn signer_for_chain(chain: ChainType) -> Box<dyn ChainSigner> {
         ChainType::Filecoin => Box::new(FilecoinSigner),
         ChainType::Sui => Box::new(SuiSigner),
         ChainType::Xrpl => Box::new(XrplSigner),
+        ChainType::Nano => Box::new(NanoSigner),
     }
 }

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -288,9 +288,16 @@ impl ChainSigner for NanoSigner {
         self.sign(private_key, &block_hash)
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
-        // Nano doesn't define a special message-signing prefix.
-        self.sign(private_key, message)
+    fn sign_message(
+        &self,
+        _private_key: &[u8],
+        _message: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        Err(SignerError::SigningFailed(
+            "Nano off-chain message signing is not supported: no canonical standard exists. \
+             Define an ecosystem convention before enabling this."
+                .into(),
+        ))
     }
 
     fn encode_signed_transaction(
@@ -478,13 +485,16 @@ mod tests {
     }
 
     #[test]
-    fn test_sign_message_same_as_sign() {
+    fn test_sign_message_unsupported() {
         let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
         let signer = NanoSigner;
         let message = b"hello nano";
-        let sig1 = signer.sign(&key, message).unwrap();
-        let sig2 = signer.sign_message(&key, message).unwrap();
-        assert_eq!(sig1.signature, sig2.signature);
+        let result = signer.sign_message(&key, message);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Nano off-chain message signing is not supported"));
     }
 
     #[test]

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -1,0 +1,648 @@
+//! Nano (XNO) chain signer (Ed25519 with blake2b-512).
+//!
+//! Nano uses Ed25519 but replaces SHA-512 with blake2b-512 for key expansion
+//! and signing. This requires the `hazmat` API from `ed25519-dalek`.
+//!
+//! Address format: `nano_` + 52 base32 chars (pubkey) + 8 base32 chars (checksum).
+//! State block hash: blake2b-256 over 176-byte canonical block representation.
+
+use crate::curve::Curve;
+use crate::traits::{ChainSigner, SignOutput, SignerError};
+use blake2::digest::{consts::U32, consts::U5, Digest};
+use blake2::{Blake2b, Blake2b512};
+use ed25519_dalek::hazmat::{raw_sign, ExpandedSecretKey};
+use ed25519_dalek::VerifyingKey;
+use ows_core::ChainType;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Nano base32 address encoding
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Nano's custom base32 alphabet (32 chars, no 0, 2, l, v).
+const NANO_ALPHABET: &[u8; 32] = b"13456789abcdefghijkmnopqrstuwxyz";
+
+/// Reverse lookup table: ASCII byte -> base32 value (255 = invalid).
+const DECODE_TABLE: [u8; 128] = {
+    let mut table = [255u8; 128];
+    let mut i = 0u8;
+    while i < 32 {
+        table[NANO_ALPHABET[i as usize] as usize] = i;
+        i += 1;
+    }
+    table
+};
+
+/// Encode a 32-byte public key as a Nano address (`nano_...`).
+///
+/// Format: `nano_` + 52 base32 chars (260-bit padded pubkey) + 8 base32 chars (checksum).
+pub fn nano_address(pubkey: &[u8; 32]) -> String {
+    // Base32 encodes 5 bits per char. 52 chars x 5 = 260 bits.
+    // We pad the 256-bit pubkey with 4 leading zero bits (260 - 256 = 4).
+    let encoded_key = encode_nano_base32(pubkey, 52);
+
+    // Checksum: blake2b-40 (5-byte digest) of the public key, bytes reversed.
+    let checksum = nano_checksum(pubkey);
+    let encoded_checksum = encode_nano_base32(&checksum, 8);
+
+    format!("nano_{}{}", encoded_key, encoded_checksum)
+}
+
+/// Decode a Nano address back to a 32-byte public key.
+///
+/// Returns `None` if the address is malformed or the checksum doesn't match.
+pub fn nano_pubkey_from_address(address: &str) -> Option<[u8; 32]> {
+    let body = address.strip_prefix("nano_")?;
+    if body.len() != 60 {
+        return None;
+    }
+
+    let key_part = &body[..52];
+    let checksum_part = &body[52..];
+
+    // Decode key (52 base32 chars -> 260 bits -> 32 bytes with 4-bit padding)
+    let pubkey = decode_nano_base32(key_part, 32)?;
+
+    // Verify checksum
+    let expected_checksum = nano_checksum(&pubkey);
+    let expected_encoded = encode_nano_base32(&expected_checksum, 8);
+    if checksum_part != expected_encoded {
+        return None;
+    }
+
+    Some(pubkey)
+}
+
+/// Compute the Nano checksum: blake2b-40 of pubkey, bytes reversed.
+fn nano_checksum(pubkey: &[u8; 32]) -> [u8; 5] {
+    let mut hasher = Blake2b::<U5>::new();
+    hasher.update(pubkey);
+    let hash = hasher.finalize();
+    let mut checksum = [0u8; 5];
+    checksum.copy_from_slice(&hash);
+    checksum.reverse();
+    checksum
+}
+
+/// Encode arbitrary bytes as Nano base32 with exactly `char_count` output chars.
+///
+/// Bits are taken MSB-first, padded with leading zeros on the left to fill
+/// `char_count * 5` bits.
+fn encode_nano_base32(data: &[u8], char_count: usize) -> String {
+    let total_bits = char_count * 5;
+    let data_bits = data.len() * 8;
+    let padding_bits = total_bits - data_bits;
+
+    let mut result = String::with_capacity(char_count);
+
+    for i in 0..char_count {
+        let bit_offset = i * 5;
+        let mut value = 0u8;
+
+        for b in 0..5 {
+            let global_bit = bit_offset + b;
+            if global_bit < padding_bits {
+                // Zero padding bit
+                continue;
+            }
+            let data_bit = global_bit - padding_bits;
+            let byte_idx = data_bit / 8;
+            let bit_idx = 7 - (data_bit % 8);
+            if (data[byte_idx] >> bit_idx) & 1 == 1 {
+                value |= 1 << (4 - b);
+            }
+        }
+
+        result.push(NANO_ALPHABET[value as usize] as char);
+    }
+
+    result
+}
+
+/// Decode Nano base32 string to bytes. Returns `None` on invalid characters.
+///
+/// Reverses the encoding: `char_count * 5` bits -> `byte_count` bytes,
+/// stripping leading padding bits.
+fn decode_nano_base32(s: &str, byte_count: usize) -> Option<[u8; 32]> {
+    if byte_count != 32 {
+        return None; // only support 32-byte decode for now
+    }
+
+    let char_count = s.len();
+    let total_bits = char_count * 5;
+    let data_bits = byte_count * 8;
+    let padding_bits = total_bits - data_bits;
+
+    let mut output = [0u8; 32];
+
+    for (i, ch) in s.bytes().enumerate() {
+        if ch >= 128 {
+            return None;
+        }
+        let value = DECODE_TABLE[ch as usize];
+        if value == 255 {
+            return None;
+        }
+
+        for b in 0..5 {
+            let global_bit = i * 5 + b;
+            if global_bit < padding_bits {
+                continue;
+            }
+            let data_bit = global_bit - padding_bits;
+            let byte_idx = data_bit / 8;
+            let bit_idx = 7 - (data_bit % 8);
+            if (value >> (4 - b)) & 1 == 1 {
+                output[byte_idx] |= 1 << bit_idx;
+            }
+        }
+    }
+
+    Some(output)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Nano state block hashing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The state block preamble: 31 zero bytes followed by 0x06.
+const STATE_BLOCK_PREAMBLE: [u8; 32] = {
+    let mut p = [0u8; 32];
+    p[31] = 0x06;
+    p
+};
+
+/// Hash a Nano state block, returning the 32-byte blake2b-256 digest.
+///
+/// `tx_bytes` must be exactly 176 bytes:
+///   preamble (32) + account (32) + previous (32) + representative (32)
+///   + balance (16, big-endian u128) + link (32)
+pub fn hash_state_block(tx_bytes: &[u8]) -> Result<[u8; 32], SignerError> {
+    if tx_bytes.len() != 176 {
+        return Err(SignerError::InvalidTransaction(format!(
+            "state block must be 176 bytes, got {}",
+            tx_bytes.len()
+        )));
+    }
+
+    // Verify preamble
+    if tx_bytes[..32] != STATE_BLOCK_PREAMBLE {
+        return Err(SignerError::InvalidTransaction(
+            "invalid state block preamble (first 32 bytes must be 0x00...06)".into(),
+        ));
+    }
+
+    let mut hasher = Blake2b::<U32>::new();
+    hasher.update(tx_bytes);
+    let hash = hasher.finalize();
+    let mut result = [0u8; 32];
+    result.copy_from_slice(&hash);
+    Ok(result)
+}
+
+/// Build the 176-byte state block payload from individual fields.
+pub fn build_state_block(
+    account: &[u8; 32],
+    previous: &[u8; 32],
+    representative: &[u8; 32],
+    balance: u128,
+    link: &[u8; 32],
+) -> [u8; 176] {
+    let mut block = [0u8; 176];
+    block[..32].copy_from_slice(&STATE_BLOCK_PREAMBLE);
+    block[32..64].copy_from_slice(account);
+    block[64..96].copy_from_slice(previous);
+    block[96..128].copy_from_slice(representative);
+    block[128..144].copy_from_slice(&balance.to_be_bytes());
+    block[144..176].copy_from_slice(link);
+    block
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NanoSigner
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Nano chain signer (Ed25519 with blake2b-512).
+pub struct NanoSigner;
+
+impl NanoSigner {
+    /// Expand a 32-byte seed into an [`ExpandedSecretKey`] using blake2b-512.
+    ///
+    /// Standard Ed25519 uses SHA-512 here; Nano uses blake2b-512.
+    fn expand_secret_key(private_key: &[u8]) -> Result<ExpandedSecretKey, SignerError> {
+        let key_bytes: [u8; 32] = private_key.try_into().map_err(|_| {
+            SignerError::InvalidPrivateKey(format!("expected 32 bytes, got {}", private_key.len()))
+        })?;
+
+        let mut hasher = Blake2b512::new();
+        hasher.update(key_bytes);
+        let hash: [u8; 64] = hasher.finalize().into();
+
+        Ok(ExpandedSecretKey::from_bytes(&hash))
+    }
+
+    /// Derive the [`VerifyingKey`] (public key) from a private key via blake2b-512 expansion.
+    fn verifying_key(private_key: &[u8]) -> Result<VerifyingKey, SignerError> {
+        let esk = Self::expand_secret_key(private_key)?;
+        Ok(VerifyingKey::from(&esk))
+    }
+}
+
+impl ChainSigner for NanoSigner {
+    fn chain_type(&self) -> ChainType {
+        ChainType::Nano
+    }
+
+    fn curve(&self) -> Curve {
+        Curve::Ed25519
+    }
+
+    fn coin_type(&self) -> u32 {
+        165
+    }
+
+    fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError> {
+        let vk = Self::verifying_key(private_key)?;
+        let pubkey_bytes: [u8; 32] = vk.to_bytes();
+        Ok(nano_address(&pubkey_bytes))
+    }
+
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        let esk = Self::expand_secret_key(private_key)?;
+        let vk = VerifyingKey::from(&esk);
+        let signature = raw_sign::<Blake2b512>(&esk, message, &vk);
+
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: Some(vk.to_bytes().to_vec()),
+        })
+    }
+
+    fn sign_transaction(
+        &self,
+        private_key: &[u8],
+        tx_bytes: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        // Nano state blocks: blake2b-256 hash the 176-byte block, then sign the hash.
+        let block_hash = hash_state_block(tx_bytes)?;
+        self.sign(private_key, &block_hash)
+    }
+
+    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        // Nano doesn't define a special message-signing prefix.
+        self.sign(private_key, message)
+    }
+
+    fn encode_signed_transaction(
+        &self,
+        tx_bytes: &[u8],
+        signature: &SignOutput,
+    ) -> Result<Vec<u8>, SignerError> {
+        // Nano wire format: 176-byte state block + 64-byte signature = 240 bytes.
+        // Work bytes (8 bytes) are added separately by the RPC/broadcast layer.
+        if signature.signature.len() != 64 {
+            return Err(SignerError::InvalidTransaction(
+                "expected 64-byte Ed25519 signature".into(),
+            ));
+        }
+        if tx_bytes.len() != 176 {
+            return Err(SignerError::InvalidTransaction(format!(
+                "expected 176-byte state block, got {}",
+                tx_bytes.len()
+            )));
+        }
+
+        let mut signed = Vec::with_capacity(176 + 64);
+        signed.extend_from_slice(tx_bytes);
+        signed.extend_from_slice(&signature.signature);
+        Ok(signed)
+    }
+
+    fn default_derivation_path(&self, index: u32) -> String {
+        format!("m/44'/165'/{}'", index)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::curve::Curve;
+    use crate::hd::HdDeriver;
+    use crate::mnemonic::Mnemonic;
+    use ed25519_dalek::hazmat::raw_verify;
+
+    // 24-word test vector
+    const MNEMONIC_24: &str = "edge defense waste choose enrich upon flee junk siren film clown finish luggage leader kid quick brick print evidence swap drill paddle truly occur";
+    const PASSPHRASE_24: &str = "some password";
+
+    // 12-word test vector
+    const MNEMONIC_12: &str =
+        "company public remove bread fashion tortoise ahead shrimp onion prefer waste blade";
+
+    /// Helper: derive a Nano private key from a mnemonic phrase and path.
+    fn derive_key(phrase: &str, passphrase: &str, path: &str) -> Vec<u8> {
+        let mnemonic = Mnemonic::from_phrase(phrase).expect("valid mnemonic");
+        let key = HdDeriver::derive_from_mnemonic(&mnemonic, passphrase, path, Curve::Ed25519)
+            .expect("derivation succeeded");
+        key.expose().to_vec()
+    }
+
+    // ─── chain properties ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_chain_properties() {
+        let signer = NanoSigner;
+        assert_eq!(signer.chain_type(), ChainType::Nano);
+        assert_eq!(signer.curve(), Curve::Ed25519);
+        assert_eq!(signer.coin_type(), 165);
+    }
+
+    #[test]
+    fn test_derivation_path() {
+        let signer = NanoSigner;
+        assert_eq!(signer.default_derivation_path(0), "m/44'/165'/0'");
+        assert_eq!(signer.default_derivation_path(1), "m/44'/165'/1'");
+        assert_eq!(signer.default_derivation_path(99), "m/44'/165'/99'");
+    }
+
+    // ─── known address vectors ────────────────────────────────────────────────
+
+    #[test]
+    fn test_derive_address_24word_index_0() {
+        let key = derive_key(MNEMONIC_24, PASSPHRASE_24, "m/44'/165'/0'");
+        let signer = NanoSigner;
+        let address = signer.derive_address(&key).unwrap();
+        assert_eq!(
+            address,
+            "nano_1pu7p5n3ghq1i1p4rhmek41f5add1uh34xpb94nkbxe8g4a6x1p69emk8y1d"
+        );
+    }
+
+    #[test]
+    fn test_pubkey_hex_24word_index_0() {
+        let key = derive_key(MNEMONIC_24, PASSPHRASE_24, "m/44'/165'/0'");
+        let vk = NanoSigner::verifying_key(&key).unwrap();
+        let pubkey_hex = hex::encode(vk.to_bytes());
+        assert_eq!(
+            pubkey_hex,
+            "5b65b0e8173ee0802c2c3e6c9080d1a16b06de1176c938a924f58670904e82c4"
+        );
+    }
+
+    #[test]
+    fn test_derive_address_12word_index_0() {
+        let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
+        let signer = NanoSigner;
+        let address = signer.derive_address(&key).unwrap();
+        assert_eq!(
+            address,
+            "nano_16tfkg33dxndscjt3sdnzqjkdz4d5cxfmhbxf87zxycp8gtnzytqmcosi3zr"
+        );
+    }
+
+    // ─── address encode/decode roundtrip ─────────────────────────────────────
+
+    #[test]
+    fn test_address_encode_decode_roundtrip() {
+        let pubkey_hex = "5b65b0e8173ee0802c2c3e6c9080d1a16b06de1176c938a924f58670904e82c4";
+        let pubkey: [u8; 32] = hex::decode(pubkey_hex).unwrap().try_into().unwrap();
+
+        let address = nano_address(&pubkey);
+        assert_eq!(
+            address,
+            "nano_1pu7p5n3ghq1i1p4rhmek41f5add1uh34xpb94nkbxe8g4a6x1p69emk8y1d"
+        );
+
+        let decoded = nano_pubkey_from_address(&address).expect("should decode");
+        assert_eq!(decoded, pubkey);
+    }
+
+    #[test]
+    fn test_address_invalid_checksum() {
+        // Valid address with last char flipped
+        let bad = "nano_1pu7p5n3ghq1i1p4rhmek41f5add1uh34xpb94nkbxe8g4a6x1p69emk8y1e";
+        assert!(nano_pubkey_from_address(bad).is_none());
+    }
+
+    #[test]
+    fn test_address_wrong_prefix() {
+        let bad = "xrb_1pu7p5n3ghq1i1p4rhmek41f5add1uh34xpb94nkbxe8g4a6x1p69emk8y1d";
+        assert!(nano_pubkey_from_address(bad).is_none());
+    }
+
+    #[test]
+    fn test_address_wrong_length() {
+        assert!(nano_pubkey_from_address("nano_abc").is_none());
+    }
+
+    #[test]
+    fn test_address_invalid_chars() {
+        // 'l' and 'v' are not in the Nano alphabet
+        let bad = "nano_llllllllllllllllllllllllllllllllllllllllllllllllllllllllllll";
+        assert!(nano_pubkey_from_address(bad).is_none());
+    }
+
+    // ─── sign / verify roundtrip ──────────────────────────────────────────────
+
+    #[test]
+    fn test_sign_verify_roundtrip() {
+        let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
+        let signer = NanoSigner;
+
+        let message = b"test message for nano";
+        let result = signer.sign(&key, message).unwrap();
+
+        assert_eq!(result.signature.len(), 64);
+        assert!(result.recovery_id.is_none());
+        assert!(result.public_key.is_some());
+
+        // Verify using blake2b-512 (Nano's Ed25519 variant)
+        let vk = NanoSigner::verifying_key(&key).unwrap();
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        raw_verify::<Blake2b512>(&vk, message, &sig).expect("should verify");
+    }
+
+    #[test]
+    fn test_deterministic_signature() {
+        let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
+        let signer = NanoSigner;
+        let message = b"hello nano";
+
+        let sig1 = signer.sign(&key, message).unwrap();
+        let sig2 = signer.sign(&key, message).unwrap();
+        assert_eq!(sig1.signature, sig2.signature);
+    }
+
+    #[test]
+    fn test_sign_message_same_as_sign() {
+        let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
+        let signer = NanoSigner;
+        let message = b"hello nano";
+        let sig1 = signer.sign(&key, message).unwrap();
+        let sig2 = signer.sign_message(&key, message).unwrap();
+        assert_eq!(sig1.signature, sig2.signature);
+    }
+
+    #[test]
+    fn test_public_key_in_sign_output() {
+        let key = derive_key(MNEMONIC_24, PASSPHRASE_24, "m/44'/165'/0'");
+        let signer = NanoSigner;
+
+        let result = signer.sign(&key, b"msg").unwrap();
+        let expected_pubkey =
+            hex::decode("5b65b0e8173ee0802c2c3e6c9080d1a16b06de1176c938a924f58670904e82c4")
+                .unwrap();
+        assert_eq!(result.public_key.unwrap(), expected_pubkey);
+    }
+
+    #[test]
+    fn test_invalid_key() {
+        let signer = NanoSigner;
+        let bad_key = vec![0u8; 16];
+        assert!(signer.derive_address(&bad_key).is_err());
+        assert!(signer.sign(&bad_key, b"msg").is_err());
+    }
+
+    // ─── state block / transaction signing ───────────────────────────────────
+
+    #[test]
+    fn test_sign_transaction_state_block() {
+        let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
+        let signer = NanoSigner;
+
+        let vk = NanoSigner::verifying_key(&key).unwrap();
+        let account = vk.to_bytes();
+
+        let block = build_state_block(
+            &account,
+            &[0u8; 32],                                    // open block (no previous)
+            &[2u8; 32],                                    // representative
+            1_000_000_000_000_000_000_000_000_000_000u128, // 1 XNO in raw
+            &[3u8; 32],                                    // link
+        );
+
+        let result = signer.sign_transaction(&key, &block).unwrap();
+        assert_eq!(result.signature.len(), 64);
+
+        // Verify: signature must be over the block hash, not raw block bytes
+        let block_hash = hash_state_block(&block).unwrap();
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        raw_verify::<Blake2b512>(&vk, &block_hash, &sig).expect("should verify against block hash");
+    }
+
+    #[test]
+    fn test_sign_transaction_wrong_length() {
+        let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
+        let signer = NanoSigner;
+        // Not 176 bytes
+        assert!(signer.sign_transaction(&key, &[0u8; 100]).is_err());
+        assert!(signer.sign_transaction(&key, &[0u8; 177]).is_err());
+    }
+
+    #[test]
+    fn test_sign_transaction_wrong_preamble() {
+        let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
+        let signer = NanoSigner;
+        let mut block = [0u8; 176];
+        block[31] = 0x05; // wrong preamble byte
+        assert!(signer.sign_transaction(&key, &block).is_err());
+    }
+
+    // ─── encode_signed_transaction ────────────────────────────────────────────
+
+    #[test]
+    fn test_encode_signed_transaction() {
+        let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
+        let signer = NanoSigner;
+
+        let vk = NanoSigner::verifying_key(&key).unwrap();
+        let account = vk.to_bytes();
+
+        let block = build_state_block(
+            &account,
+            &[0u8; 32],
+            &[2u8; 32],
+            1_000_000_000_000_000_000_000_000_000_000u128,
+            &[3u8; 32],
+        );
+
+        let result = signer.sign_transaction(&key, &block).unwrap();
+        let signed = signer.encode_signed_transaction(&block, &result).unwrap();
+
+        // 176-byte block + 64-byte signature = 240 bytes
+        assert_eq!(signed.len(), 240);
+        assert_eq!(&signed[..176], &block[..]);
+        assert_eq!(&signed[176..], &result.signature[..]);
+    }
+
+    #[test]
+    fn test_encode_signed_transaction_wrong_sig_len() {
+        let signer = NanoSigner;
+        let block = {
+            let mut b = [0u8; 176];
+            b[31] = 0x06;
+            b
+        };
+        let bad_sig = SignOutput {
+            signature: vec![0u8; 32], // wrong: should be 64
+            recovery_id: None,
+            public_key: None,
+        };
+        assert!(signer.encode_signed_transaction(&block, &bad_sig).is_err());
+    }
+
+    #[test]
+    fn test_encode_signed_transaction_wrong_block_len() {
+        let signer = NanoSigner;
+        let bad_block = vec![0u8; 100]; // wrong length
+        let sig = SignOutput {
+            signature: vec![0u8; 64],
+            recovery_id: None,
+            public_key: None,
+        };
+        assert!(signer.encode_signed_transaction(&bad_block, &sig).is_err());
+    }
+
+    // ─── full end-to-end pipeline ─────────────────────────────────────────────
+
+    #[test]
+    fn test_full_pipeline_mnemonic_to_sign_to_verify() {
+        // Mnemonic -> derive key -> derive address -> build block -> sign -> encode -> verify
+        let key = derive_key(MNEMONIC_24, PASSPHRASE_24, "m/44'/165'/0'");
+        let signer = NanoSigner;
+
+        // Verify known address
+        let address = signer.derive_address(&key).unwrap();
+        assert_eq!(
+            address,
+            "nano_1pu7p5n3ghq1i1p4rhmek41f5add1uh34xpb94nkbxe8g4a6x1p69emk8y1d"
+        );
+
+        let vk = NanoSigner::verifying_key(&key).unwrap();
+        let account = vk.to_bytes();
+
+        // Build a send block
+        let block = build_state_block(
+            &account,
+            &[0xABu8; 32],                               // previous
+            &account,                                    // self as representative
+            500_000_000_000_000_000_000_000_000_000u128, // 0.5 XNO remaining
+            &[0xCDu8; 32],                               // destination link
+        );
+
+        // sign_transaction hashes first, then signs
+        let result = signer.sign_transaction(&key, &block).unwrap();
+        let signed = signer.encode_signed_transaction(&block, &result).unwrap();
+        assert_eq!(signed.len(), 240);
+
+        // Verify signature over the block hash
+        let block_hash = hash_state_block(&block).unwrap();
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        raw_verify::<Blake2b512>(&vk, &block_hash, &sig)
+            .expect("end-to-end signature should verify");
+    }
+}

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -430,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_address_wrong_prefix() {
-        let bad = "xrb_1pu7p5n3ghq1i1p4rhmek41f5add1uh34xpb94nkbxe8g4a6x1p69emk8y1d";
+        let bad = "nanox_1pu7p5n3ghq1i1p4rhmek41f5add1uh34xpb94nkbxe8g4a6x1p69emk8y1d";
         assert!(nano_pubkey_from_address(bad).is_none());
     }
 


### PR DESCRIPTION
## Summary

Add **Nano (XNO)** as a supported chain in OWS. Same pattern as existing Ed25519 chains (Solana, Sui, TON) — no new CLI commands, no new dependencies.

- Enables `ows sign message/tx/send-tx --chain nano`
- Includes Nano addresses in `ows wallet create` and `ows mnemonic derive`
- Broadcasts via Nano RPC `process` action

## How Nano differs from existing chains

If you're coming from Bitcoin or EVM, here's what makes Nano unusual:

**No global blockchain.** Nano uses a "block lattice" — every account has its own chain of blocks. A transfer requires only one *send* block on the sender's chain (debits their balance) to settle, but also a *receive* block on the receiver's chain later on in order to become spendable (credits the amount). Each block is a "state block" containing the account's full current state (balance, representative, link to previous block).

**What this means for OWS:**

| | EVM / Solana / Bitcoin | Nano |
|---|---|---|
| Transaction input | Fully self-contained unsigned tx | 176-byte state block (account, previous, representative, balance, link) |
| What the signer does | Sign the bytes | Hash the state block (blake2b-256), sign the hash |
| Broadcast | Send signed blob to RPC | Query account state to determine subtype (send/receive/open), generate Proof of Work, then publish |
| Proof of Work | Paid via gas/fees | Per-block PoW (~1s remote, no fees). Delegated to RPC endpoints |
| Receiving funds | Automatic (miner includes it) | Explicit: receiver must publish a receive block |

The **signing path** is standard OWS — `sign tx` and `sign message` work identically to other Ed25519 chains. The **broadcast path** (`send-tx`) does more work than other chains because it must query account state and generate PoW before publishing. This is inherent to the block lattice model, not an implementation choice.

## Chain details

| Property | Value |
|---|---|
| CAIP-2 | `nano:mainnet` |
| BIP-44 coin type | 165 |
| Curve | Ed25519 (blake2b-512 instead of SHA-512) |
| Address format | `nano_` + 52-char custom base32 + 8-char checksum |
| Native asset | XNO (1 XNO = 10³⁰ raw) |
| Default RPC | `https://nanoslo.0x.no/proxy` |

## Files changed (7 files, ~950 lines)

**ows-core** — chain registration:
- `chain.rs` — `ChainType::Nano` in enum, `ALL_CHAIN_TYPES`, `KNOWN_CHAINS`, namespace/coin_type dispatch
- `config.rs` — `nano:mainnet` → default RPC endpoint

**ows-signer** — signing (648 lines, 20 unit tests):
- `chains/nano.rs` — Ed25519-blake2b signing via `hazmat` API, custom base32 address encoding, state block hashing
- `chains/mod.rs` — register `NanoSigner` in `signer_for_chain()` dispatch

**ows-lib** — broadcast:
- `nano_rpc.rs` — Nano RPC helpers (`account_info`, `work_generate` with multi-endpoint fallback, `process`)
- `ops.rs` — `ChainType::Nano` broadcast arm: decodes signed state block, queries state, generates PoW, publishes
- `lib.rs` — register `nano_rpc` module

## Technical notes

- **No new crypto dependencies** — reuses `ed25519-dalek` (hazmat already enabled), `blake2`, `hex`
- **Ed25519 with blake2b-512** — Nano's non-standard Ed25519 variant. Uses `raw_sign::<Blake2b512>()` / `raw_verify::<Blake2b512>()` from ed25519-dalek's hazmat API
- **PoW is remote-only** — delegated to RPC endpoints (primary → `NANO_WORK_PEERS` → built-in fallback). No CPU/GPU PoW in this PR
- **Standalone development crate** — [OpenRai/ows-nano](https://github.com/OpenRai/ows-nano) was used to develop and test the Nano implementation independently (68 unit tests + mainnet E2E roundtrip), then integrated here

## Testing

- 20 unit tests in `nano.rs` (address encoding, key derivation with 12/24-word vectors, signing, verification, state block hashing, roundtrips)
- All 458 workspace tests pass
- Clippy clean (`-D warnings`)
- Manually verified: `ows mnemonic derive --chain nano`, `ows sign message --chain nano`, `ows sign tx --chain nano`, `ows wallet create`

## A note on higher-level commands

This PR adds Nano to OWS's existing primitives: derive, sign, broadcast. It does *not* add commands like `ows send --to <address> --amount <xno>` or `ows balance --chain nano` — and to be honest, we're not sure whether that kind of higher-level, chain-aware command is something OWS wants to include, or whether it falls outside the standard's intended scope. OWS today is consistently "bring your own unsigned transaction" across all chains, and there may be good reasons to keep it that way.

If the maintainers see value in a generic `send`/`balance` layer, Nano could be a good candidate to pilot it (the block lattice makes it particularly useful — constructing a state block by hand is painful). But we'd rather ask than assume.

## Related

- Standalone crate: [OpenRai/ows-nano](https://github.com/OpenRai/ows-nano)
- Issue #101 — similar scope (Ed25519 chain addition)