### PR TITLE
fix: truncate respects UTF-8 char boundaries in discovery output

### DIFF
--- a/ows/crates/ows-pay/src/discovery.rs
+++ b/ows/crates/ows-pay/src/discovery.rs
@@ -215,7 +215,15 @@ pub(crate) fn format_usdc(amount_str: &str) -> String {
 fn truncate(s: &str, max: usize) -> String {
     let first_line = s.lines().next().unwrap_or("");
     if first_line.len() > max {
-        format!("{}...", &first_line[..max.saturating_sub(3)])
+        let cutoff = first_line
+            .char_indices()
+            .map(|(idx, _)| idx)
+            .chain(std::iter::once(first_line.len()))
+            .take_while(|&idx| idx <= max.saturating_sub(3))
+            .last()
+            .unwrap_or(0);
+
+        format!("{}...", &first_line[..cutoff])
     } else {
         first_line.to_string()
     }
@@ -284,6 +292,15 @@ mod tests {
         let result = truncate(&long, 20);
         assert!(result.len() <= 20);
         assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn truncate_long_utf8_string_respects_char_boundaries() {
+        let prefix = "a".repeat(76);
+        let input = format!("{prefix}“🙂 rest");
+        let result = truncate(&input, 80);
+
+        assert_eq!(result, format!("{prefix}..."));
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`ows pay discover --query <term>` panics when a service description contains multi-byte UTF-8 characters (e.g. smart quotes `"`, emoji) near the truncation boundary:

```
thread 'main' panicked at crates/ows-pay/src/discovery.rs:218:37:
byte index 77 is not a char boundary; it is inside '"' (bytes 76..79)
```


Live example: 

```
$ ows pay discover --query swarm

thread 'main' (5409753) panicked at crates/ows-pay/src/discovery.rs:218:37:
byte index 77 is not a char boundary; it is inside '”' (bytes 76..79) of `This swarm helps you spot “forgotten coins” or “left-for-dead projects” that may re-awaken in a bull market. By tracking relative changes in trading volume, it identifies early signs of insider activity before the coins resurface on the timeline. P`[...]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Root cause

`truncate()` was slicing at a raw byte index (`&first_line[..max.saturating_sub(3)]`), which panics when the cutoff lands inside a multi-byte character.

## Fix

Use `char_indices()` to walk to the last safe char boundary before the cutoff. Added a regression test with a string containing a multi-byte character at the boundary.