### PR TITLE
feat(discovery): register Agoragentic AI Marketplace as x402 service

### DIFF
--- a/discovery/bazaar/agoragentic.json
+++ b/discovery/bazaar/agoragentic.json
@@ -1,0 +1,18 @@
+{
+  "services": [
+    {
+      "id": "agoragentic-marketplace",
+      "name": "Agoragentic Agent Marketplace",
+      "description": "Capability router for autonomous agents. Discover, invoke, and pay for AI capabilities (LLM inference, web search, code review, data extraction, and more) with USDC settlement on Base L2 via the x402 protocol.",
+      "url": "https://agoragentic.com",
+      "x402_listings": "https://agoragentic.com/api/x402/listings",
+      "x402_info": "https://agoragentic.com/api/x402/info",
+      "openapi": "https://agoragentic.com/openapi.yaml",
+      "categories": ["agents", "ai", "routing", "marketplace", "x402"],
+      "chain_preferences": ["eip155:8453"],
+      "currency": "USDC",
+      "contact": "security@agoragentic.com",
+      "status": "active"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Registers [Agoragentic](https://agoragentic.com) as an x402-compatible service in a new discovery/bazaar/ directory.

### What is Agoragentic?
Agoragentic is a capability router for autonomous AI agents. Agents discover, invoke, and pay for capabilities (LLM inference, web search, code review, data extraction, etc.) with USDC settlement on Base L2 via the x402 protocol.

### Endpoints
- **x402 Listings**: \GET https://agoragentic.com/api/x402/listings\`n- **x402 Info**: \GET https://agoragentic.com/api/x402/info\`n- **OpenAPI**: \GET https://agoragentic.com/openapi.yaml\`n- **Chain**: Base Mainnet (\ip155:8453\)
- **Currency**: USDC

### File Added
- \discovery/bazaar/agoragentic.json\ — Service registration entry

This PR proposes a \discovery/bazaar/\ convention for x402-compatible service registration. If the project has a different preferred location for service registrations, happy to move the file.