### PR TITLE
feat: add Plasma chain alias and RPC default

### DIFF
--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -52,6 +52,7 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | Arbitrum | `eip155:42161` |
 | Optimism | `eip155:10` |
 | Base | `eip155:8453` |
+| Plasma | `eip155:9745` |
 | BSC | `eip155:56` |
 | Avalanche | `eip155:43114` |
 
@@ -77,6 +78,7 @@ Implementations MAY support shorthand aliases in CLI contexts:
 ```
 ethereum  → eip155:1
 base      → eip155:8453
+plasma    → eip155:9745
 polygon   → eip155:137
 arbitrum  → eip155:42161
 optimism  → eip155:10

--- a/docs/sdk-cli.md
+++ b/docs/sdk-cli.md
@@ -273,7 +273,7 @@ ows sign tx --wallet "my-wallet" --chain evm --tx "02f8..."
 | Flag | Description |
 |------|-------------|
 | `--wallet <NAME>` | Wallet name or ID |
-| `--chain <CHAIN>` | Chain family |
+| `--chain <CHAIN>` | Chain family or supported alias / CAIP-2 ID |
 | `--tx <HEX>` | Hex-encoded transaction bytes |
 | `--json` | Output structured JSON |
 

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -138,7 +138,7 @@ enum WalletCommands {
 enum SignCommands {
     /// Sign a message with chain-specific formatting (EIP-191, Bitcoin message signing, etc.)
     Message {
-        /// Chain (ethereum, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
+        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
         #[arg(long)]
         chain: String,
         /// Wallet name or ID (uses stored encrypted mnemonic)
@@ -162,7 +162,7 @@ enum SignCommands {
     },
     /// Sign a transaction (accepts hex-encoded unsigned transaction bytes)
     Tx {
-        /// Chain (ethereum, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
+        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
         #[arg(long)]
         chain: String,
         /// Wallet name or ID (uses stored encrypted mnemonic)
@@ -180,7 +180,7 @@ enum SignCommands {
     },
     /// Sign and broadcast a transaction
     SendTx {
-        /// Chain (ethereum, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
+        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
         #[arg(long)]
         chain: String,
         /// Wallet name or ID (uses stored encrypted mnemonic)
@@ -211,7 +211,7 @@ enum MnemonicCommands {
     },
     /// Derive an address from a mnemonic (reads from OWS_MNEMONIC env or stdin)
     Derive {
-        /// Chain (ethereum, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID). If omitted, derives all chains.
+        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID). If omitted, derives all chains.
         #[arg(long)]
         chain: Option<String>,
         /// Account index

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -64,6 +64,11 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_id: "eip155:8453",
     },
     Chain {
+        name: "plasma",
+        chain_type: ChainType::Evm,
+        chain_id: "eip155:9745",
+    },
+    Chain {
         name: "bsc",
         chain_type: ChainType::Evm,
         chain_id: "eip155:56",
@@ -346,10 +351,34 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_chain_plasma_alias() {
+        let chain = parse_chain("plasma").unwrap();
+        assert_eq!(chain.name, "plasma");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+        assert_eq!(chain.chain_id, "eip155:9745");
+    }
+
+    #[test]
     fn test_parse_chain_caip2() {
         let chain = parse_chain("eip155:42161").unwrap();
         assert_eq!(chain.name, "arbitrum");
         assert_eq!(chain.chain_type, ChainType::Evm);
+    }
+
+    #[test]
+    fn test_parse_chain_plasma_caip2() {
+        let chain = parse_chain("eip155:9745").unwrap();
+        assert_eq!(chain.name, "plasma");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+        assert_eq!(chain.chain_id, "eip155:9745");
+    }
+
+    #[test]
+    fn test_parse_chain_unknown_evm_caip2() {
+        let chain = parse_chain("eip155:9746").unwrap();
+        assert_eq!(chain.name, "eip155:9746");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+        assert_eq!(chain.chain_id, "eip155:9746");
     }
 
     #[test]

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -33,6 +33,7 @@ impl Config {
         rpc.insert("eip155:42161".into(), "https://arb1.arbitrum.io/rpc".into());
         rpc.insert("eip155:10".into(), "https://mainnet.optimism.io".into());
         rpc.insert("eip155:8453".into(), "https://mainnet.base.org".into());
+        rpc.insert("eip155:9745".into(), "https://rpc.plasma.to".into());
         rpc.insert(
             "eip155:56".into(),
             "https://bsc-dataseed.binance.org".into(),
@@ -180,6 +181,7 @@ mod tests {
             config.rpc_url("eip155:137"),
             Some("https://polygon-rpc.com")
         );
+        assert_eq!(config.rpc_url("eip155:9745"), Some("https://rpc.plasma.to"));
         assert_eq!(
             config.rpc_url("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"),
             Some("https://api.mainnet-beta.solana.com")
@@ -242,7 +244,7 @@ mod tests {
     fn test_load_or_default_nonexistent() {
         let config = Config::load_or_default_from(std::path::Path::new("/nonexistent/config.json"));
         // Should have all default RPCs
-        assert_eq!(config.rpc.len(), 14);
+        assert_eq!(config.rpc.len(), 15);
         assert_eq!(config.rpc_url("eip155:1"), Some("https://eth.llamarpc.com"));
     }
 


### PR DESCRIPTION
## What

  Add first-class Plasma mainnet support to OWS by:
  - adding the `plasma` alias for `eip155:9745`
  - adding a built-in default RPC for `eip155:9745`
  - updating CLI help text to reflect supported aliases / CAIP-2 IDs
  - documenting Plasma in the supported chains reference

  ## Why

  Plasma uses a standard EVM chain ID (`eip155:9745`), so it can use the existing generic EVM signing flow without any signer changes. This PR makes OWS discoverable and ergonomic for Plasma builders.

  Closes #

  ## Testing

  - [x] `cargo test --workspace` passes
  - [x] `cargo clippy --workspace -- -D warnings` is clean
  - [ ] `npm test` passes (if Node bindings changed)
  - [x] Tested manually with `ows` CLI