### PR TITLE
fix: correct incorrect redirect causing 404 in docs

### DIFF
--- a/docs/01-storage-format.md
+++ b/docs/01-storage-format.md
@@ -94,7 +94,7 @@ Each wallet is stored as a single JSON file extending the Ethereum Keystore v3 s
 
 ## API Key File Format
 
-Each API key is stored as a JSON file in `~/.ows/keys/`. The key file contains metadata, policy attachments, and **encrypted copies of wallet secrets** re-encrypted under the API token (see [Policy Engine](03-policy-engine.md) for the full cryptographic design).
+Each API key is stored as a JSON file in `~/.ows/keys/`. The key file contains metadata, policy attachments, and **encrypted copies of wallet secrets** re-encrypted under the API token (see [Policy Engine](03-policy-engine) for the full cryptographic design).
 
 ```json
 {


### PR DESCRIPTION
ISSUE #111 
## Summary
Fixes a broken redirect in the documentation that was leading to a 404 (Not Found) page.

## Problem
The link:
https://docs.openwallet.sh/doc.html?slug=01-storage-format

Under "API Key File Format Policy Engine" redirects to:
https://docs.openwallet.sh/03-policy-engine.md

This results in a 404 error.

## Solution
Updated the redirect to point to the correct URL:
https://docs.openwallet.sh/doc.html?slug=03-policy-engine

## Changes
- Fixed incorrect redirect link in documentation

