### PR TITLE
fix: gate fast-kdf feature to debug builds only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: npm install
 
       - name: Build native addon
-        run: npx napi build --platform --release --features fast-kdf
+        run: npx napi build --platform --features fast-kdf
 
       - name: Run tests
         run: npm test

--- a/ows/crates/ows-signer/src/crypto.rs
+++ b/ows/crates/ows-signer/src/crypto.rs
@@ -62,6 +62,13 @@ pub enum CryptoError {
     InvalidParams(String),
 }
 
+// Prevent fast-kdf from being used in release builds — weak KDF is test-only.
+#[cfg(all(feature = "fast-kdf", not(debug_assertions)))]
+compile_error!(
+    "The `fast-kdf` feature reduces scrypt to 2^10 iterations and must not be used in release builds. \
+     Use dev-dependencies to enable it for tests only."
+);
+
 // Production: log_n=16 (~5s per call, down from ~20s at log_n=18)
 // Tests: log_n=10 (<10ms per call)
 #[cfg(any(test, feature = "fast-kdf"))]


### PR DESCRIPTION
## Summary

The `fast-kdf` feature drops scrypt from 2^16 to 2^10 iterations for test speed, but nothing prevents it from compiling into a release binary. This is a supply chain risk — a PR slipping `fast-kdf` into a `Cargo.toml` or CI config produces a production build with trivially brute-forceable vault encryption, and code review alone can't reliably catch it.

- Add `compile_error!` in `crypto.rs` gated on `fast-kdf` + release mode — `rustc` rejects the build
- Drop `--release` from CI node binding test build so it compiles under the new guard

## Test plan

- [x] `cargo check --release --features fast-kdf` fails with compile error
- [x] `cargo test --workspace` passes (fast-kdf active via dev-dependencies)
- [x] CI node/python binding jobs pass