### PR TITLE
fix: printing mistake while executing x402 payments

### DIFF
--- a/ows/crates/ows-cli/src/commands/pay.rs
+++ b/ows/crates/ows-cli/src/commands/pay.rs
@@ -105,20 +105,20 @@ pub fn run(
 
     let result = rt.block_on(ows_pay::pay(&wallet, url, method, body))?;
 
-    if let Some(ref payment) = result.payment {
-        if !payment.amount.is_empty() {
-            eprintln!(
-                "Paid {} on {} via {}",
-                payment.amount, payment.network, result.protocol
-            );
-        } else {
-            eprintln!("Paid via {}", result.protocol);
-        }
-    }
-
-    if result.status >= 400 {
-        eprintln!("HTTP {}", result.status);
-    }
+    if result.status < 400 {
+      if let Some(ref payment) = result.payment {
+          if !payment.amount.is_empty() {
+              eprintln!(
+                  "Paid {} on {} via {}",
+                  payment.amount, payment.network, result.protocol
+              );
+          } else {
+              eprintln!("Paid via {}", result.protocol);
+          }
+      }
+  } else {
+      eprintln!("HTTP {}", result.status);
+  }
 
     println!("{}", result.body);
     Ok(())

--- a/ows/crates/ows-cli/src/commands/pay.rs
+++ b/ows/crates/ows-cli/src/commands/pay.rs
@@ -106,19 +106,19 @@ pub fn run(
     let result = rt.block_on(ows_pay::pay(&wallet, url, method, body))?;
 
     if result.status < 400 {
-      if let Some(ref payment) = result.payment {
-          if !payment.amount.is_empty() {
-              eprintln!(
-                  "Paid {} on {} via {}",
-                  payment.amount, payment.network, result.protocol
-              );
-          } else {
-              eprintln!("Paid via {}", result.protocol);
-          }
-      }
-  } else {
-      eprintln!("HTTP {}", result.status);
-  }
+        if let Some(ref payment) = result.payment {
+            if !payment.amount.is_empty() {
+                eprintln!(
+                    "Paid {} on {} via {}",
+                    payment.amount, payment.network, result.protocol
+                );
+            } else {
+                eprintln!("Paid via {}", result.protocol);
+            }
+        }
+    } else {
+        eprintln!("HTTP {}", result.status);
+    }
 
     println!("{}", result.body);
     Ok(())


### PR DESCRIPTION
Issue #129 
## Problem

  `ows pay request` prints "Paid $X on <network> via x402" immediately after
  signing and submitting the payment — before checking whether the server
  actually accepted it. If the server rejects with HTTP 402 (e.g. insufficient
  balance), the user sees both "Paid" and an error, which is misleading.

<img width="1901" height="140" alt="Screenshot 2026-03-25 231703" src="https://github.com/user-attachments/assets/69869121-66fe-44a9-bef9-7a56a5ba9db9" />

  ## Fix

  Move the "Paid" message inside a `result.status < 400` check so it only
  prints when the server confirms the payment was accepted. Error responses
  now only show `HTTP <status>` and the response body.

<img width="1892" height="122" alt="Screenshot 2026-03-25 231957" src="https://github.com/user-attachments/assets/4ba679da-e969-4027-bebb-9fd691f85d04" />


  ## Reproduction

  1. Run `ows pay request <x402-url> --wallet empty_wallet_name`
  2. Before: prints "Paid $0.001 on base via x402" then "HTTP 402"
  3. After: only prints "HTTP 402" and the error body