### PR TITLE
feat: add Etherlink chain alias

### DIFF
--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -55,6 +55,7 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | Plasma | `eip155:9745` |
 | BSC | `eip155:56` |
 | Avalanche | `eip155:43114` |
+| Etherlink | `eip155:42793` |
 
 ### Non-EVM Networks
 
@@ -84,6 +85,7 @@ arbitrum  → eip155:42161
 optimism  → eip155:10
 bsc       → eip155:56
 avalanche → eip155:43114
+etherlink → eip155:42793
 solana    → solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp
 bitcoin   → bip122:000000000019d6689c085ae165831e93
 cosmos    → cosmos:cosmoshub-4

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -79,6 +79,11 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_id: "eip155:43114",
     },
     Chain {
+        name: "etherlink",
+        chain_type: ChainType::Evm,
+        chain_id: "eip155:42793",
+    },
+    Chain {
         name: "solana",
         chain_type: ChainType::Solana,
         chain_id: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
@@ -356,6 +361,14 @@ mod tests {
         assert_eq!(chain.name, "plasma");
         assert_eq!(chain.chain_type, ChainType::Evm);
         assert_eq!(chain.chain_id, "eip155:9745");
+    }
+
+    #[test]
+    fn test_parse_chain_etherlink_alias() {
+        let chain = parse_chain("etherlink").unwrap();
+        assert_eq!(chain.name, "etherlink");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+        assert_eq!(chain.chain_id, "eip155:42793");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `etherlink` as a known EVM chain alias mapped to `eip155:42793`
- document Etherlink in the supported networks and shorthand alias tables
- add a regression test for `parse_chain("etherlink")`

## Why
Issue #100 requests first-class Etherlink support. Etherlink uses the EVM signing path, so this change keeps the implementation small and makes the network discoverable via the existing alias registry.

## Testing
- cargo fmt --all
- cargo test -p ows-core
- cargo test -p ows-cli

Closes #100