### PR TITLE
feat: add Tempo and Hyperliquid chain aliases

### DIFF
--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -57,6 +57,8 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | BSC | `eip155:56` |
 | Avalanche | `eip155:43114` |
 | Etherlink | `eip155:42793` |
+| Tempo | `eip155:4217` |
+| Hyperliquid | `eip155:999` |
 
 ### Non-EVM Networks
 
@@ -88,6 +90,8 @@ optimism  → eip155:10
 bsc       → eip155:56
 avalanche → eip155:43114
 etherlink → eip155:42793
+tempo       → eip155:4217
+hyperliquid → eip155:999
 solana    → solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp
 bitcoin   → bip122:000000000019d6689c085ae165831e93
 cosmos    → cosmos:cosmoshub-4

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -180,6 +180,16 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_type: ChainType::Nano,
         chain_id: "nano:mainnet",
     },
+    Chain {
+        name: "tempo",
+        chain_type: ChainType::Evm,
+        chain_id: "eip155:4217",
+    },
+    Chain {
+        name: "hyperliquid",
+        chain_type: ChainType::Evm,
+        chain_id: "eip155:999",
+    },
 ];
 
 /// Parse a chain string into a `Chain`. Accepts:
@@ -573,6 +583,38 @@ mod tests {
     #[test]
     fn test_parse_chain_unknown() {
         assert!(parse_chain("unknown_chain").is_err());
+    }
+
+    #[test]
+    fn test_parse_chain_tempo_alias() {
+        let chain = parse_chain("tempo").unwrap();
+        assert_eq!(chain.name, "tempo");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+        assert_eq!(chain.chain_id, "eip155:4217");
+    }
+
+    #[test]
+    fn test_parse_chain_tempo_caip2() {
+        let chain = parse_chain("eip155:4217").unwrap();
+        assert_eq!(chain.name, "tempo");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+        assert_eq!(chain.chain_id, "eip155:4217");
+    }
+
+    #[test]
+    fn test_parse_chain_hyperliquid_alias() {
+        let chain = parse_chain("hyperliquid").unwrap();
+        assert_eq!(chain.name, "hyperliquid");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+        assert_eq!(chain.chain_id, "eip155:999");
+    }
+
+    #[test]
+    fn test_parse_chain_hyperliquid_caip2() {
+        let chain = parse_chain("eip155:999").unwrap();
+        assert_eq!(chain.name, "hyperliquid");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+        assert_eq!(chain.chain_id, "eip155:999");
     }
 
     #[test]

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -217,10 +217,7 @@ mod tests {
             config.rpc_url("ton:mainnet"),
             Some("https://toncenter.com/api/v2")
         );
-        assert_eq!(
-            config.rpc_url("eip155:4217"),
-            Some("https://rpc.tempo.xyz")
-        );
+        assert_eq!(config.rpc_url("eip155:4217"), Some("https://rpc.tempo.xyz"));
         assert_eq!(
             config.rpc_url("eip155:999"),
             Some("https://rpc.hyperliquid.xyz/evm")

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -74,6 +74,11 @@ impl Config {
             "https://s.devnet.rippletest.net:51234".into(),
         );
         rpc.insert("nano:mainnet".into(), "https://rpc.nano.to".into());
+        rpc.insert("eip155:4217".into(), "https://rpc.tempo.xyz".into());
+        rpc.insert(
+            "eip155:999".into(),
+            "https://rpc.hyperliquid.xyz/evm".into(),
+        );
         rpc
     }
 }
@@ -212,12 +217,20 @@ mod tests {
             config.rpc_url("ton:mainnet"),
             Some("https://toncenter.com/api/v2")
         );
+        assert_eq!(
+            config.rpc_url("eip155:4217"),
+            Some("https://rpc.tempo.xyz")
+        );
+        assert_eq!(
+            config.rpc_url("eip155:999"),
+            Some("https://rpc.hyperliquid.xyz/evm")
+        );
     }
 
     #[test]
     fn test_rpc_lookup_miss() {
         let config = Config::default();
-        assert_eq!(config.rpc_url("eip155:999"), None);
+        assert_eq!(config.rpc_url("eip155:99999"), None);
     }
 
     #[test]
@@ -254,7 +267,7 @@ mod tests {
     fn test_load_or_default_nonexistent() {
         let config = Config::load_or_default_from(std::path::Path::new("/nonexistent/config.json"));
         // Should have all default RPCs
-        assert_eq!(config.rpc.len(), 19);
+        assert_eq!(config.rpc.len(), 21);
         assert_eq!(config.rpc_url("eip155:1"), Some("https://eth.llamarpc.com"));
     }
 


### PR DESCRIPTION
## Summary
- Add Tempo (`eip155:4217`) and Hyperliquid (`eip155:999`) to `KNOWN_CHAINS` registry as EVM chains
- Add default RPC endpoints (`rpc.tempo.xyz`, `rpc.hyperliquid.xyz/evm`)
- Update supported chains docs with new entries and shorthand aliases

## Test plan
- [x] `cargo test -p ows-core` — 71 tests pass
- [x] Full `cargo build` compiles cleanly
- [x] Alias resolution tests for both friendly names and CAIP-2 IDs
- [x] RPC endpoint lookup tests for both chains