### PR TITLE
feat: add Bitcoin PSBT signing

### DIFF
--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -62,6 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +166,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +204,55 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bitcoin"
+version = "0.32.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+dependencies = [
+ "base58ck",
+ "base64 0.21.7",
+ "bech32 0.11.1",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "hex_lit",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -750,6 +815,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1246,7 @@ dependencies = [
  "aes-gcm",
  "base64 0.22.1",
  "bech32 0.11.1",
+ "bitcoin",
  "blake2",
  "bs58",
  "coins-bip32",
@@ -1528,6 +1609,25 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -46,6 +46,9 @@ ows sign message --wallet agent-treasury --chain evm --message "hello"
 
 # Sign a transaction
 ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
+
+# Sign a Bitcoin PSBT
+ows sign psbt --wallet agent-treasury --psbt "cHNidP8BA..."
 ```
 
 ## Supported Chains
@@ -71,6 +74,7 @@ ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
 | `ows wallet info` | Show vault path and supported chains |
 | `ows sign message` | Sign a message with chain-specific formatting |
 | `ows sign tx` | Sign a raw transaction |
+| `ows sign psbt` | Sign a Bitcoin PSBT |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
 | `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -53,6 +53,13 @@ pub struct SignResult {
     pub recovery_id: Option<u32>,
 }
 
+/// Result from a Bitcoin PSBT signing operation.
+#[napi(object)]
+pub struct PsbtSignResult {
+    pub psbt: String,
+    pub signed_inputs: u32,
+}
+
 /// Result from a sign-and-send operation.
 #[napi(object)]
 pub struct SendResult {
@@ -217,6 +224,29 @@ pub fn sign_transaction(
     .map_err(map_err)
 }
 
+/// Sign a Bitcoin PSBT. Returns an updated base64-encoded PSBT.
+#[napi]
+pub fn sign_psbt(
+    wallet: String,
+    psbt_base64: String,
+    passphrase: Option<String>,
+    index: Option<u32>,
+    vault_path_opt: Option<String>,
+) -> Result<PsbtSignResult> {
+    ows_lib::sign_psbt(
+        &wallet,
+        &psbt_base64,
+        passphrase.as_deref(),
+        index,
+        vault_path(vault_path_opt).as_deref(),
+    )
+    .map(|r| PsbtSignResult {
+        psbt: r.psbt,
+        signed_inputs: r.signed_inputs,
+    })
+    .map_err(map_err)
+}
+
 /// Sign a message. Returns hex-encoded signature.
 #[napi]
 pub fn sign_message(
@@ -285,9 +315,8 @@ pub fn create_policy(policy_json: String, vault_path_opt: Option<String>) -> Res
 /// List all registered policies.
 #[napi]
 pub fn list_policies(vault_path_opt: Option<String>) -> Result<Vec<serde_json::Value>> {
-    let policies =
-        ows_lib::policy_store::list_policies(vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let policies = ows_lib::policy_store::list_policies(vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     policies
         .iter()
         .map(|p| serde_json::to_value(p).map_err(|e| napi::Error::from_reason(e.to_string())))
@@ -297,9 +326,8 @@ pub fn list_policies(vault_path_opt: Option<String>) -> Result<Vec<serde_json::V
 /// Get a single policy by ID.
 #[napi]
 pub fn get_policy(id: String, vault_path_opt: Option<String>) -> Result<serde_json::Value> {
-    let policy =
-        ows_lib::policy_store::load_policy(&id, vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let policy = ows_lib::policy_store::load_policy(&id, vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     serde_json::to_value(&policy).map_err(|e| napi::Error::from_reason(e.to_string()))
 }
 
@@ -355,14 +383,13 @@ pub fn create_api_key(
 /// List all API keys (tokens are never returned).
 #[napi]
 pub fn list_api_keys(vault_path_opt: Option<String>) -> Result<Vec<serde_json::Value>> {
-    let keys =
-        ows_lib::key_store::list_api_keys(vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let keys = ows_lib::key_store::list_api_keys(vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     keys.iter()
         .map(|k| {
             // Strip wallet_secrets from the output — never expose encrypted material
-            let mut v = serde_json::to_value(k)
-                .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+            let mut v =
+                serde_json::to_value(k).map_err(|e| napi::Error::from_reason(e.to_string()))?;
             v.as_object_mut().map(|m| m.remove("wallet_secrets"));
             Ok(v)
         })
@@ -372,8 +399,7 @@ pub fn list_api_keys(vault_path_opt: Option<String>) -> Result<Vec<serde_json::V
 /// Revoke (delete) an API key by ID.
 #[napi]
 pub fn revoke_api_key(id: String, vault_path_opt: Option<String>) -> Result<()> {
-    ows_lib::key_store::delete_api_key(&id, vault_path(vault_path_opt).as_deref())
-        .map_err(map_err)
+    ows_lib::key_store::delete_api_key(&id, vault_path(vault_path_opt).as_deref()).map_err(map_err)
 }
 
 /// Sign and broadcast a transaction. Returns the transaction hash.

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -53,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +157,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +195,55 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bitcoin"
+version = "0.32.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+dependencies = [
+ "base58ck",
+ "base64 0.21.7",
+ "bech32 0.11.1",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "hex_lit",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -722,6 +787,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1165,7 @@ dependencies = [
  "aes-gcm",
  "base64 0.22.1",
  "bech32 0.11.1",
+ "bitcoin",
  "blake2",
  "bs58",
  "coins-bip32",
@@ -1493,6 +1574,25 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -49,6 +49,7 @@ print(sig["signature"])
 | `sign_message(wallet, chain, message, passphrase?, encoding?, index?, vault_path?)` | Sign a message with chain-specific formatting |
 | `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, vault_path?)` | Sign EIP-712 typed data (EVM only) |
 | `sign_transaction(wallet, chain, tx_hex, passphrase?, index?, vault_path?)` | Sign a raw transaction |
+| `sign_psbt(wallet, psbt_base64, passphrase?, index?, vault_path?)` | Sign a Bitcoin PSBT |
 | `sign_and_send(wallet, chain, tx_hex, passphrase?, index?, rpc_url?, vault_path?)` | Sign and broadcast a transaction |
 | `generate_mnemonic(words?)` | Generate a BIP-39 mnemonic phrase |
 | `derive_address(mnemonic, chain, index?)` | Derive an address from a mnemonic |

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -174,6 +174,33 @@ fn sign_transaction(
     })
 }
 
+/// Sign a Bitcoin PSBT.
+#[pyfunction]
+#[pyo3(signature = (wallet, psbt_base64, passphrase=None, index=None, vault_path_opt=None))]
+fn sign_psbt(
+    wallet: &str,
+    psbt_base64: &str,
+    passphrase: Option<&str>,
+    index: Option<u32>,
+    vault_path_opt: Option<String>,
+) -> PyResult<PyObject> {
+    let result = ows_lib::sign_psbt(
+        wallet,
+        psbt_base64,
+        passphrase,
+        index,
+        vault_path(vault_path_opt).as_deref(),
+    )
+    .map_err(map_err)?;
+
+    Python::with_gil(|py| {
+        let dict = pyo3::types::PyDict::new(py);
+        dict.set_item("psbt", &result.psbt)?;
+        dict.set_item("signed_inputs", result.signed_inputs)?;
+        Ok(dict.unbind().into())
+    })
+}
+
 /// Sign a message.
 #[pyfunction]
 #[pyo3(signature = (wallet, chain, message, passphrase=None, encoding=None, index=None, vault_path_opt=None))]
@@ -272,8 +299,8 @@ fn sign_and_send(
 #[pyfunction]
 #[pyo3(signature = (policy_json, vault_path_opt=None))]
 fn create_policy(policy_json: &str, vault_path_opt: Option<String>) -> PyResult<()> {
-    let policy: ows_core::Policy =
-        serde_json::from_str(policy_json).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    let policy: ows_core::Policy = serde_json::from_str(policy_json)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
     ows_lib::policy_store::save_policy(&policy, vault_path(vault_path_opt).as_deref())
         .map_err(map_err)
 }
@@ -282,14 +309,15 @@ fn create_policy(policy_json: &str, vault_path_opt: Option<String>) -> PyResult<
 #[pyfunction]
 #[pyo3(signature = (vault_path_opt=None))]
 fn list_policies(vault_path_opt: Option<String>) -> PyResult<PyObject> {
-    let policies =
-        ows_lib::policy_store::list_policies(vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let policies = ows_lib::policy_store::list_policies(vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     let json_str =
         serde_json::to_string(&policies).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     Python::with_gil(|py| {
         let json_mod = py.import("json")?;
-        json_mod.call_method1("loads", (json_str,)).map(|o| o.unbind())
+        json_mod
+            .call_method1("loads", (json_str,))
+            .map(|o| o.unbind())
     })
 }
 
@@ -297,14 +325,15 @@ fn list_policies(vault_path_opt: Option<String>) -> PyResult<PyObject> {
 #[pyfunction]
 #[pyo3(signature = (id, vault_path_opt=None))]
 fn get_policy(id: &str, vault_path_opt: Option<String>) -> PyResult<PyObject> {
-    let policy =
-        ows_lib::policy_store::load_policy(id, vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let policy = ows_lib::policy_store::load_policy(id, vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     let json_str =
         serde_json::to_string(&policy).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     Python::with_gil(|py| {
         let json_mod = py.import("json")?;
-        json_mod.call_method1("loads", (json_str,)).map(|o| o.unbind())
+        json_mod
+            .call_method1("loads", (json_str,))
+            .map(|o| o.unbind())
     })
 }
 
@@ -312,8 +341,7 @@ fn get_policy(id: &str, vault_path_opt: Option<String>) -> PyResult<PyObject> {
 #[pyfunction]
 #[pyo3(signature = (id, vault_path_opt=None))]
 fn delete_policy(id: &str, vault_path_opt: Option<String>) -> PyResult<()> {
-    ows_lib::policy_store::delete_policy(id, vault_path(vault_path_opt).as_deref())
-        .map_err(map_err)
+    ows_lib::policy_store::delete_policy(id, vault_path(vault_path_opt).as_deref()).map_err(map_err)
 }
 
 // ---------------------------------------------------------------------------
@@ -355,9 +383,8 @@ fn create_api_key(
 #[pyfunction]
 #[pyo3(signature = (vault_path_opt=None))]
 fn list_api_keys(vault_path_opt: Option<String>) -> PyResult<PyObject> {
-    let keys =
-        ows_lib::key_store::list_api_keys(vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let keys = ows_lib::key_store::list_api_keys(vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     // Strip wallet_secrets from output
     let sanitized: Vec<serde_json::Value> = keys
         .iter()
@@ -367,11 +394,13 @@ fn list_api_keys(vault_path_opt: Option<String>) -> PyResult<PyObject> {
             v
         })
         .collect();
-    let json_str = serde_json::to_string(&sanitized)
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    let json_str =
+        serde_json::to_string(&sanitized).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     Python::with_gil(|py| {
         let json_mod = py.import("json")?;
-        json_mod.call_method1("loads", (json_str,)).map(|o| o.unbind())
+        json_mod
+            .call_method1("loads", (json_str,))
+            .map(|o| o.unbind())
     })
 }
 
@@ -379,8 +408,7 @@ fn list_api_keys(vault_path_opt: Option<String>) -> PyResult<PyObject> {
 #[pyfunction]
 #[pyo3(signature = (id, vault_path_opt=None))]
 fn revoke_api_key(id: &str, vault_path_opt: Option<String>) -> PyResult<()> {
-    ows_lib::key_store::delete_api_key(id, vault_path(vault_path_opt).as_deref())
-        .map_err(map_err)
+    ows_lib::key_store::delete_api_key(id, vault_path(vault_path_opt).as_deref()).map_err(map_err)
 }
 
 fn wallet_info_to_dict(py: Python<'_>, info: &ows_lib::WalletInfo) -> PyResult<PyObject> {
@@ -424,6 +452,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(export_wallet, m)?)?;
     m.add_function(wrap_pyfunction!(rename_wallet, m)?)?;
     m.add_function(wrap_pyfunction!(sign_transaction, m)?)?;
+    m.add_function(wrap_pyfunction!(sign_psbt, m)?)?;
     m.add_function(wrap_pyfunction!(sign_message, m)?)?;
     m.add_function(wrap_pyfunction!(sign_typed_data, m)?)?;
     m.add_function(wrap_pyfunction!(sign_and_send, m)?)?;

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -80,6 +80,9 @@ ows sign message --wallet agent-treasury --chain evm --message "hello"
 
 # Sign a transaction
 ows sign tx --wallet agent-treasury --chain solana --tx "deadbeef..."
+
+# Sign a Bitcoin PSBT (owner mode, P2WPKH inputs only)
+ows sign psbt --wallet agent-treasury --psbt "cHNidP8BA..."
 ```
 
 ## Use in code
@@ -87,7 +90,7 @@ ows sign tx --wallet agent-treasury --chain solana --tx "deadbeef..."
 ### Node.js
 
 ```javascript
-import { createWallet, signMessage, signTransaction } from "@open-wallet-standard/core";
+import { createWallet, signMessage, signPsbt, signTransaction } from "@open-wallet-standard/core";
 
 // Create a wallet (once)
 const wallet = createWallet("agent-treasury");
@@ -99,12 +102,16 @@ console.log(sig.signature);
 // Sign a transaction
 const tx = signTransaction("agent-treasury", "evm", "02f8...");
 console.log(tx.signature);
+
+// Sign a Bitcoin PSBT
+const psbt = signPsbt("agent-treasury", "cHNidP8BA...");
+console.log(psbt.signedInputs);
 ```
 
 ### Python
 
 ```python
-from open_wallet_standard import create_wallet, sign_message, sign_transaction
+from open_wallet_standard import create_wallet, sign_message, sign_psbt, sign_transaction
 
 # Create a wallet (once)
 wallet = create_wallet("agent-treasury")
@@ -116,6 +123,10 @@ print(sig["signature"])
 # Sign a transaction
 tx = sign_transaction("agent-treasury", "evm", "02f8...")
 print(tx["signature"])
+
+# Sign a Bitcoin PSBT
+psbt = sign_psbt("agent-treasury", "cHNidP8BA...")
+print(psbt["signed_inputs"])
 ```
 
 ## Set up agent access

--- a/docs/sdk-cli.md
+++ b/docs/sdk-cli.md
@@ -279,6 +279,26 @@ ows sign tx --wallet "my-wallet" --chain evm --tx "02f8..."
 
 Passphrases and API tokens are supplied via `OWS_PASSPHRASE` or an interactive prompt, not a dedicated `--passphrase` flag.
 
+### `ows sign psbt`
+
+Sign a Bitcoin PSBT and return an updated base64-encoded PSBT.
+
+Current implementations support owner-mode signing for native SegWit P2WPKH inputs that belong to the wallet. API-token PSBT signing is not yet supported.
+
+```bash
+ows sign psbt --wallet "my-wallet" --psbt "cHNidP8BA..."
+ows sign psbt --wallet "my-wallet" --psbt "cHNidP8BA..." --json
+```
+
+| Flag | Description |
+|------|-------------|
+| `--wallet <NAME>` | Wallet name or ID |
+| `--psbt <BASE64>` | Base64-encoded PSBT |
+| `--index <N>` | Account index (default: 0) |
+| `--json` | Output structured JSON with `psbt` and `signed_inputs` |
+
+Passphrases are supplied via `OWS_PASSPHRASE` or an interactive prompt. API tokens are currently rejected for PSBT signing.
+
 ## Mnemonic Commands
 
 ### `ows mnemonic generate`

--- a/docs/sdk-node.md
+++ b/docs/sdk-node.md
@@ -55,6 +55,11 @@ interface SignResult {
   recoveryId?: number;    // EVM/Tron recovery ID (v value)
 }
 
+interface PsbtSignResult {
+  psbt: string;           // Updated base64-encoded PSBT
+  signedInputs: number;   // Number of inputs signed by this wallet
+}
+
 interface SendResult {
   txHash: string;         // Transaction hash
 }
@@ -309,6 +314,28 @@ console.log(result.signature);
 ```
 
 **Returns:** `SignResult`
+
+#### `signPsbt(wallet, psbtBase64, passphrase?, index?, vaultPath?)`
+
+Sign a Bitcoin PSBT and return an updated base64-encoded PSBT.
+
+Current implementations support owner-mode signing for native SegWit P2WPKH inputs that belong to the wallet. API-token PSBT signing is not yet supported.
+
+```javascript
+const result = signPsbt("agent-treasury", "cHNidP8BA...");
+console.log(result.psbt);
+console.log(result.signedInputs); // number of inputs signed
+```
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `wallet` | `string` | &mdash; | Wallet name or ID |
+| `psbtBase64` | `string` | &mdash; | Base64-encoded PSBT |
+| `passphrase` | `string` | `undefined` | Decryption passphrase |
+| `index` | `number` | `0` | Account index |
+| `vaultPath` | `string` | `~/.ows` | Custom vault directory root |
+
+**Returns:** `PsbtSignResult`
 
 #### `signAndSend(wallet, chain, txHex, passphrase?, index?, rpcUrl?, vaultPath?)`
 

--- a/docs/sdk-python.md
+++ b/docs/sdk-python.md
@@ -60,6 +60,12 @@ All functions return Python dicts. Wallet functions return:
     "recovery_id": 0,                 # EVM/Tron only (None for others)
 }
 
+# PsbtSignResult
+{
+    "psbt": "cHNidP8BA...",           # Updated base64-encoded PSBT
+    "signed_inputs": 1,               # Number of inputs signed by this wallet
+}
+
 # SendResult
 {
     "tx_hash": "0xabc...",
@@ -255,6 +261,18 @@ Sign a raw transaction (hex-encoded bytes).
 ```python
 result = sign_transaction("agent-treasury", "evm", "02f8...")
 print(result["signature"])
+```
+
+#### `sign_psbt(wallet, psbt_base64, passphrase=None, index=None, vault_path=None)`
+
+Sign a Bitcoin PSBT and return an updated base64-encoded PSBT.
+
+Current implementations support owner-mode signing for native SegWit P2WPKH inputs that belong to the wallet. API-token PSBT signing is not yet supported.
+
+```python
+result = sign_psbt("agent-treasury", "cHNidP8BA...")
+print(result["psbt"])
+print(result["signed_inputs"])
 ```
 
 #### `sign_and_send(wallet, chain, tx_hex, passphrase=None, index=None, rpc_url=None, vault_path=None)`

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -103,6 +103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +245,55 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bitcoin"
+version = "0.32.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+dependencies = [
+ "base58ck",
+ "base64 0.21.7",
+ "bech32 0.11.1",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "hex_lit",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -854,6 +919,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1435,7 @@ name = "ows-lib"
 version = "1.1.2"
 dependencies = [
  "base64 0.22.1",
+ "bitcoin",
  "bs58",
  "chrono",
  "ed25519-dalek",
@@ -1399,6 +1480,7 @@ dependencies = [
  "aes-gcm",
  "base64 0.22.1",
  "bech32 0.11.1",
+ "bitcoin",
  "blake2",
  "bs58",
  "coins-bip32",
@@ -1935,6 +2017,25 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0453232ace82dee0dd0b4c87a59bd90f7b53b314f3e0f61fe2ee7c8a16482289"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +893,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1406,6 +1421,7 @@ dependencies = [
  "clap",
  "hex",
  "ows-core",
+ "ows-guardian",
  "ows-lib",
  "ows-pay",
  "ows-signer",
@@ -1428,6 +1444,25 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "ows-guardian"
+version = "1.1.2"
+dependencies = [
+ "chrono",
+ "hex",
+ "ows-core",
+ "ows-signer",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sharks",
+ "tempfile",
+ "thiserror 2.0.18",
+ "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -2118,6 +2153,17 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
+]
+
+[[package]]
+name = "sharks"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902b1e955f8a2e429fb1bad49f83fb952e6195d3c360ac547ff00fb826388753"
+dependencies = [
+ "hashbrown 0.9.1",
+ "rand 0.8.5",
+ "zeroize",
 ]
 
 [[package]]

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "ows-guardian"
-version = "1.1.2"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "hex",

--- a/ows/Cargo.toml
+++ b/ows/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["crates/ows-core", "crates/ows-signer", "crates/ows-lib", "crates/ows-pay", "crates/ows-cli"]
+members = ["crates/ows-core", "crates/ows-signer", "crates/ows-lib", "crates/ows-pay", "crates/ows-cli", "crates/ows-guardian"]

--- a/ows/README.md
+++ b/ows/README.md
@@ -29,6 +29,7 @@ cargo build --workspace --release
 | `ows wallet info` | Show vault path and supported chains |
 | `ows sign message` | Sign a message with chain-specific formatting |
 | `ows sign tx` | Sign a raw transaction |
+| `ows sign psbt` | Sign a Bitcoin PSBT |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
 | `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |

--- a/ows/crates/ows-cli/Cargo.toml
+++ b/ows/crates/ows-cli/Cargo.toml
@@ -26,6 +26,7 @@ rpassword = "7"
 serde = { version = "1", features = ["derive"] }
 zeroize = "1"
 ows-pay = { path = "../ows-pay", version = "=1.1.2" }
+ows-guardian = { path = "../ows-guardian", version = "=1.1.2" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]

--- a/ows/crates/ows-cli/README.md
+++ b/ows/crates/ows-cli/README.md
@@ -29,6 +29,7 @@ cargo build --workspace --release
 | `ows wallet info` | Show vault path and supported chains |
 | `ows sign message` | Sign a message with chain-specific formatting |
 | `ows sign tx` | Sign a raw transaction |
+| `ows sign psbt` | Sign a Bitcoin PSBT |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
 | `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |

--- a/ows/crates/ows-cli/src/commands/guardian.rs
+++ b/ows/crates/ows-cli/src/commands/guardian.rs
@@ -1,0 +1,223 @@
+use crate::CliError;
+use ows_guardian::types::GuardianInput;
+use std::io::{self, BufRead, IsTerminal, Write};
+
+pub fn setup(
+    wallet_name: &str,
+    threshold: u8,
+    guardians_file: &str,
+    time_lock_hours: u64,
+) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    let contents = std::fs::read_to_string(guardians_file).map_err(|e| CliError::Io(e))?;
+    let guardian_inputs: Vec<GuardianInput> =
+        serde_json::from_str(&contents).map_err(|e| CliError::Json(e))?;
+
+    let encrypted = ows_lib::vault::load_wallet_by_name_or_id(wallet_name, None)
+        .map_err(|e| CliError::Lib(e))?;
+
+    let passphrase = super::read_passphrase();
+
+    let config = ows_guardian::setup_guardians(
+        &wallet.id,
+        &wallet.name,
+        &encrypted.crypto,
+        &passphrase,
+        threshold,
+        &guardian_inputs,
+        time_lock_hours,
+        None,
+    )
+    .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    print_setup_result(&config);
+    Ok(())
+}
+
+fn print_setup_result(config: &ows_guardian::GuardianConfig) {
+    println!(
+        "Guardian recovery configured for wallet: {}",
+        config.wallet_name
+    );
+    println!(
+        "Threshold: {}-of-{}",
+        config.threshold, config.total_guardians
+    );
+    println!();
+    for g in &config.guardians {
+        let freeze_label = if g.can_freeze { " [can freeze]" } else { "" };
+        println!("  {} ({}): shard encrypted{}", g.id, g.name, freeze_label);
+    }
+}
+
+pub fn status(wallet_name: &str) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    let config = ows_guardian::guardian_status(&wallet.id, None)
+        .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    println!("Wallet:     {} ({})", config.wallet_name, config.wallet_id);
+    println!(
+        "Threshold:  {}-of-{}",
+        config.threshold, config.total_guardians
+    );
+    println!("Created:    {}", config.created_at);
+    println!();
+    for g in &config.guardians {
+        let freeze = if g.can_freeze { " [freeze]" } else { "" };
+        println!("  {} {}{}", g.id, g.name, freeze);
+    }
+
+    if let Some(ref dms) = config.dead_mans_switch {
+        println!();
+        println!("Dead Man's Switch:");
+        println!("  Inactivity: {} days", dms.inactivity_days);
+        println!("  Last heartbeat: {}", dms.last_heartbeat);
+        for b in &dms.beneficiaries {
+            println!("  Beneficiary: {} ({})", b.name, b.guardian_id);
+        }
+    }
+
+    Ok(())
+}
+
+pub fn recover_init(
+    wallet_name: &str,
+    guardian_id: &str,
+    time_lock_hours: u64,
+) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    let request = ows_guardian::initiate_recovery(&wallet.id, guardian_id, time_lock_hours, None)
+        .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    println!("Recovery initiated for wallet: {}", wallet_name);
+    println!("Time lock until: {}", request.time_lock_until);
+    println!("Shards needed: {}", request.threshold);
+    Ok(())
+}
+
+fn read_guardian_passphrase() -> String {
+    let stdin = io::stdin();
+    if stdin.is_terminal() {
+        eprint!("Guardian passphrase: ");
+        io::stderr().flush().ok();
+        let mut line = String::new();
+        stdin.lock().read_line(&mut line).unwrap_or(0);
+        line.trim().to_string()
+    } else {
+        std::env::var("OWS_GUARDIAN_PASSPHRASE").unwrap_or_default()
+    }
+}
+
+pub fn recover_submit(wallet_name: &str, guardian_id: &str) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    let passphrase = read_guardian_passphrase();
+
+    let request = ows_guardian::submit_shard(&wallet.id, guardian_id, &passphrase, None)
+        .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    let have = request.submitted_shards.len();
+    let need = request.threshold as usize;
+    println!("Shard {}/{} submitted from {}", have, need, guardian_id);
+    if have >= need {
+        println!("Threshold met! Run `ows guardian recover complete` to finish.");
+    }
+    Ok(())
+}
+
+pub fn recover_complete(wallet_name: &str, new_name: &str) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    let secret = ows_guardian::complete_recovery(&wallet.id, None)
+        .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    let secret_str = String::from_utf8_lossy(&secret);
+
+    let info = ows_lib::import_wallet_mnemonic(new_name, &secret_str, None, Some(0), None)
+        .map_err(|e| CliError::Lib(e))?;
+
+    println!("Secret reconstructed and verified!");
+    println!("Wallet imported as: {} ({})", new_name, info.id);
+    println!();
+    for acct in &info.accounts {
+        println!("  {} -> {}", acct.chain_id, acct.address);
+    }
+    Ok(())
+}
+
+pub fn recover_cancel(wallet_name: &str) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    ows_guardian::cancel_recovery(&wallet.id, None)
+        .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    println!("Recovery cancelled for wallet: {}", wallet_name);
+    Ok(())
+}
+
+pub fn recover_freeze(wallet_name: &str, guardian_id: &str) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    let passphrase = read_guardian_passphrase();
+
+    ows_guardian::freeze_recovery(&wallet.id, guardian_id, &passphrase, None)
+        .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    println!("Recovery FROZEN by {}", guardian_id);
+    Ok(())
+}
+
+pub fn recover_status(wallet_name: &str) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    let request = ows_guardian::recovery_status(&wallet.id, None)
+        .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    println!("Wallet:      {}", wallet_name);
+    println!("Status:      {:?}", request.status);
+    println!("Initiated:   {}", request.initiated_at);
+    println!("Time lock:   {}", request.time_lock_until);
+    println!(
+        "Shards:      {}/{}",
+        request.submitted_shards.len(),
+        request.threshold
+    );
+    for s in &request.submitted_shards {
+        println!("  {} at {}", s.guardian_id, s.submitted_at);
+    }
+    Ok(())
+}
+
+pub fn heartbeat(wallet_name: &str) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    ows_guardian::record_heartbeat(&wallet.id, None)
+        .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    println!("Heartbeat recorded for wallet: {}", wallet_name);
+    Ok(())
+}
+
+pub fn dead_switch(
+    wallet_name: &str,
+    inactivity_days: u64,
+    beneficiaries_file: &str,
+) -> Result<(), CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None).map_err(|e| CliError::Lib(e))?;
+
+    let contents = std::fs::read_to_string(beneficiaries_file).map_err(|e| CliError::Io(e))?;
+    let beneficiaries: Vec<ows_guardian::Beneficiary> =
+        serde_json::from_str(&contents).map_err(|e| CliError::Json(e))?;
+
+    ows_guardian::configure_dead_mans_switch(&wallet.id, inactivity_days, beneficiaries, None)
+        .map_err(|e| CliError::InvalidArgs(e.to_string()))?;
+
+    println!(
+        "Dead man's switch configured: {} day inactivity trigger",
+        inactivity_days
+    );
+    Ok(())
+}

--- a/ows/crates/ows-cli/src/commands/mod.rs
+++ b/ows/crates/ows-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod pay;
 pub mod policy;
 pub mod send_transaction;
 pub mod sign_message;
+pub mod sign_psbt;
 pub mod sign_transaction;
 pub mod uninstall;
 pub mod update;

--- a/ows/crates/ows-cli/src/commands/mod.rs
+++ b/ows/crates/ows-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod derive;
 pub mod fund;
 pub mod generate;
+pub mod guardian;
 pub mod info;
 pub mod key;
 pub mod pay;

--- a/ows/crates/ows-cli/src/commands/sign_psbt.rs
+++ b/ows/crates/ows-cli/src/commands/sign_psbt.rs
@@ -1,0 +1,38 @@
+use crate::CliError;
+
+pub fn run(
+    wallet_name: &str,
+    psbt_base64: &str,
+    index: u32,
+    json_output: bool,
+) -> Result<(), CliError> {
+    let passphrase = super::peek_passphrase();
+    if passphrase
+        .as_deref()
+        .is_some_and(|p| p.starts_with(ows_lib::key_store::TOKEN_PREFIX))
+    {
+        return Err(CliError::InvalidArgs(
+            "Bitcoin PSBT signing via API key is not yet supported".into(),
+        ));
+    }
+
+    let result = ows_lib::sign_psbt(
+        wallet_name,
+        psbt_base64,
+        passphrase.as_deref(),
+        Some(index),
+        None,
+    )?;
+
+    if json_output {
+        let obj = serde_json::json!({
+            "psbt": result.psbt,
+            "signed_inputs": result.signed_inputs,
+        });
+        println!("{}", serde_json::to_string_pretty(&obj)?);
+    } else {
+        println!("{}", result.psbt);
+    }
+
+    Ok(())
+}

--- a/ows/crates/ows-cli/src/commands/sign_transaction.rs
+++ b/ows/crates/ows-cli/src/commands/sign_transaction.rs
@@ -5,11 +5,61 @@ use crate::{parse_chain, CliError};
 pub fn run(
     chain_str: &str,
     wallet_name: &str,
+    tx_data: &str,
+    index: u32,
+    json_output: bool,
+) -> Result<(), CliError> {
+    let chain = parse_chain(chain_str)?;
+
+    if chain.chain_type == ows_core::ChainType::Bitcoin {
+        if let Some(result) = try_sign_psbt(wallet_name, tx_data, index)? {
+            return print_result(&result.signature, result.recovery_id, json_output);
+        }
+    }
+
+    sign_regular_transaction(&chain, wallet_name, tx_data, index, json_output)
+}
+
+fn try_sign_psbt(
+    wallet_name: &str,
+    tx_data: &str,
+    index: u32,
+) -> Result<Option<ows_lib::types::SignResult>, CliError> {
+    let passphrase = super::peek_passphrase();
+    if passphrase
+        .as_deref()
+        .is_some_and(|p| p.starts_with(ows_lib::key_store::TOKEN_PREFIX))
+    {
+        return Ok(None);
+    }
+
+    let key = match super::resolve_signing_key(wallet_name, ows_core::ChainType::Bitcoin, index) {
+        Ok(k) => k,
+        Err(_) => return Ok(None),
+    };
+
+    let signer = signer_for_chain(ows_core::ChainType::Bitcoin);
+
+    match signer.sign_psbt(key.expose(), tx_data.as_bytes()) {
+        Ok(signed_psbt) => {
+            use base64::Engine;
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&signed_psbt);
+            Ok(Some(ows_lib::types::SignResult {
+                signature: b64,
+                recovery_id: None,
+            }))
+        }
+        Err(_) => Ok(None),
+    }
+}
+
+fn sign_regular_transaction(
+    chain: &ows_core::Chain,
+    wallet_name: &str,
     tx_hex: &str,
     index: u32,
     json_output: bool,
 ) -> Result<(), CliError> {
-    // Check for API token in passphrase — route through library for policy enforcement
     let passphrase = super::peek_passphrase();
     if passphrase
         .as_deref()
@@ -17,7 +67,7 @@ pub fn run(
     {
         let result = ows_lib::sign_transaction(
             wallet_name,
-            chain_str,
+            &chain.chain_id,
             tx_hex,
             passphrase.as_deref(),
             Some(index),
@@ -26,13 +76,11 @@ pub fn run(
         return print_result(&result.signature, result.recovery_id, json_output);
     }
 
-    // Owner mode: resolve key directly (existing behavior)
-    let chain = parse_chain(chain_str)?;
     let key = super::resolve_signing_key(wallet_name, chain.chain_type, index)?;
 
     let tx_hex_clean = tx_hex.strip_prefix("0x").unwrap_or(tx_hex);
     let tx_bytes = hex::decode(tx_hex_clean)
-        .map_err(|e| CliError::InvalidArgs(format!("invalid hex transaction: {e}")))?;
+        .map_err(|e| CliError::InvalidArgs(format!("invalid hex: {e}")))?;
 
     let signer = signer_for_chain(chain.chain_type);
     let signable = signer.extract_signable_bytes(&tx_bytes)?;

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -178,6 +178,21 @@ enum SignCommands {
         #[arg(long)]
         json: bool,
     },
+    /// Sign a Bitcoin PSBT (P2WPKH inputs only) and return an updated PSBT
+    Psbt {
+        /// Wallet name or ID (uses stored encrypted mnemonic)
+        #[arg(long, env = "OWS_WALLET")]
+        wallet: String,
+        /// Base64-encoded PSBT
+        #[arg(long)]
+        psbt: String,
+        /// Account index
+        #[arg(long, default_value = "0")]
+        index: u32,
+        /// Output structured JSON instead of raw PSBT
+        #[arg(long)]
+        json: bool,
+    },
     /// Sign and broadcast a transaction
     SendTx {
         /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
@@ -445,6 +460,12 @@ fn run(cli: Cli) -> Result<(), CliError> {
                 index,
                 json,
             } => commands::sign_transaction::run(&chain, &wallet, &tx, index, json),
+            SignCommands::Psbt {
+                wallet,
+                psbt,
+                index,
+                json,
+            } => commands::sign_psbt::run(&wallet, &psbt, index, json),
             SignCommands::SendTx {
                 chain,
                 wallet,

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -70,6 +70,11 @@ enum Commands {
         #[arg(long)]
         purge: bool,
     },
+    /// Social recovery and dead man's switch for wallets
+    Guardian {
+        #[command(subcommand)]
+        subcommand: GuardianCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -356,6 +361,109 @@ enum ConfigCommands {
     Show,
 }
 
+#[derive(Subcommand)]
+enum GuardianCommands {
+    /// Set up guardian recovery for a wallet
+    Setup {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+        /// Minimum shards needed to recover (e.g. 2 for 2-of-3)
+        #[arg(long)]
+        threshold: u8,
+        /// JSON file with guardian definitions
+        #[arg(long)]
+        guardians_file: String,
+        /// Hours before recovery can complete (default 24)
+        #[arg(long, default_value = "24")]
+        time_lock_hours: u64,
+    },
+    /// Show guardian setup status for a wallet
+    Status {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+    },
+    /// Recovery operations
+    Recover {
+        #[command(subcommand)]
+        subcommand: RecoverCommands,
+    },
+    /// Record a heartbeat (proves owner is alive)
+    Heartbeat {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+    },
+    /// Configure dead man's switch
+    DeadSwitch {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+        /// Days of inactivity before switch triggers
+        #[arg(long)]
+        inactivity_days: u64,
+        /// JSON file with beneficiary definitions
+        #[arg(long)]
+        beneficiaries_file: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum RecoverCommands {
+    /// Initiate wallet recovery
+    Init {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+        /// Your guardian ID
+        #[arg(long)]
+        guardian_id: String,
+        /// Time lock hours (default 24)
+        #[arg(long, default_value = "24")]
+        time_lock_hours: u64,
+    },
+    /// Submit a recovery shard
+    Submit {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+        /// Your guardian ID
+        #[arg(long)]
+        guardian_id: String,
+    },
+    /// Complete recovery (after time lock + threshold met)
+    Complete {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+        /// Name for the recovered wallet
+        #[arg(long)]
+        new_name: String,
+    },
+    /// Cancel an active recovery
+    Cancel {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+    },
+    /// Emergency freeze (guardian with freeze permission)
+    Freeze {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+        /// Your guardian ID
+        #[arg(long)]
+        guardian_id: String,
+    },
+    /// Check recovery status
+    Status {
+        /// Wallet name or ID
+        #[arg(long)]
+        wallet: String,
+    },
+}
+
 #[derive(Debug, thiserror::Error)]
 enum CliError {
     #[error("{0}")]
@@ -533,5 +641,40 @@ fn run(cli: Cli) -> Result<(), CliError> {
         },
         Commands::Update { force } => commands::update::run(force),
         Commands::Uninstall { purge } => commands::uninstall::run(purge),
+        Commands::Guardian { subcommand } => match subcommand {
+            GuardianCommands::Setup {
+                wallet,
+                threshold,
+                guardians_file,
+                time_lock_hours,
+            } => commands::guardian::setup(&wallet, threshold, &guardians_file, time_lock_hours),
+            GuardianCommands::Status { wallet } => commands::guardian::status(&wallet),
+            GuardianCommands::Recover { subcommand } => match subcommand {
+                RecoverCommands::Init {
+                    wallet,
+                    guardian_id,
+                    time_lock_hours,
+                } => commands::guardian::recover_init(&wallet, &guardian_id, time_lock_hours),
+                RecoverCommands::Submit {
+                    wallet,
+                    guardian_id,
+                } => commands::guardian::recover_submit(&wallet, &guardian_id),
+                RecoverCommands::Complete { wallet, new_name } => {
+                    commands::guardian::recover_complete(&wallet, &new_name)
+                }
+                RecoverCommands::Cancel { wallet } => commands::guardian::recover_cancel(&wallet),
+                RecoverCommands::Freeze {
+                    wallet,
+                    guardian_id,
+                } => commands::guardian::recover_freeze(&wallet, &guardian_id),
+                RecoverCommands::Status { wallet } => commands::guardian::recover_status(&wallet),
+            },
+            GuardianCommands::Heartbeat { wallet } => commands::guardian::heartbeat(&wallet),
+            GuardianCommands::DeadSwitch {
+                wallet,
+                inactivity_days,
+                beneficiaries_file,
+            } => commands::guardian::dead_switch(&wallet, inactivity_days, &beneficiaries_file),
+        },
     }
 }

--- a/ows/crates/ows-core/README.md
+++ b/ows/crates/ows-core/README.md
@@ -29,6 +29,7 @@ cargo build --workspace --release
 | `ows wallet info` | Show vault path and supported chains |
 | `ows sign message` | Sign a message with chain-specific formatting |
 | `ows sign tx` | Sign a raw transaction |
+| `ows sign psbt` | Sign a Bitcoin PSBT |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
 | `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |

--- a/ows/crates/ows-guardian/Cargo.toml
+++ b/ows/crates/ows-guardian/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ows-guardian"
+version = "1.1.2"
+edition = "2021"
+license = "MIT"
+description = "Social recovery and dead man's switch for OWS wallets"
+repository = "https://github.com/open-wallet-standard/core"
+
+[features]
+default = []
+fast-kdf = ["ows-signer/fast-kdf"]
+
+[dependencies]
+ows-core = { path = "../ows-core", version = "=1.1.2" }
+ows-signer = { path = "../ows-signer", version = "=1.1.2" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+thiserror = "2"
+uuid = { version = "1", features = ["v4"] }
+hex = "0.4"
+zeroize = "1"
+sha2 = "0.10"
+rand = "0.8"
+sharks = "0.5"
+
+[dev-dependencies]
+tempfile = "3"
+ows-signer = { path = "../ows-signer", version = "=1.1.2", features = ["fast-kdf"] }

--- a/ows/crates/ows-guardian/src/error.rs
+++ b/ows/crates/ows-guardian/src/error.rs
@@ -1,0 +1,52 @@
+use ows_signer::CryptoError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum GuardianError {
+    #[error("guardian config not found for wallet: '{0}'")]
+    ConfigNotFound(String),
+
+    #[error("recovery not found for wallet: '{0}'")]
+    RecoveryNotFound(String),
+
+    #[error("recovery already active for wallet: '{0}'")]
+    RecoveryAlreadyActive(String),
+
+    #[error("recovery is frozen for wallet: '{0}'")]
+    RecoveryFrozen(String),
+
+    #[error("recovery is time locked until {0}")]
+    TimeLocked(String),
+
+    #[error("guardian not found: '{0}'")]
+    GuardianNotFound(String),
+
+    #[error("duplicate shard from guardian: '{0}'")]
+    DuplicateShard(String),
+
+    #[error("threshold not met: have {have}, need {need}")]
+    ThresholdNotMet { have: usize, need: usize },
+
+    #[error("secret hash mismatch after reconstruction")]
+    SecretHashMismatch,
+
+    #[error("shamir split failed: {0}")]
+    ShamirSplitFailed(String),
+
+    #[error("shamir reconstruct failed: {0}")]
+    ShamirReconstructFailed(String),
+
+    #[error("invalid threshold: {0}")]
+    InvalidThreshold(String),
+
+    #[error("heartbeat expired for wallet: '{0}'")]
+    HeartbeatExpired(String),
+
+    #[error("{0}")]
+    Crypto(#[from] CryptoError),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/ows/crates/ows-guardian/src/guardian_store.rs
+++ b/ows/crates/ows-guardian/src/guardian_store.rs
@@ -1,0 +1,105 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::GuardianError;
+use crate::types::GuardianConfig;
+
+#[cfg(unix)]
+fn set_dir_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = fs::Permissions::from_mode(0o700);
+    let _ = fs::set_permissions(path, perms);
+}
+
+#[cfg(not(unix))]
+fn set_dir_permissions(_path: &Path) {}
+
+#[cfg(unix)]
+fn set_file_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = fs::Permissions::from_mode(0o600);
+    let _ = fs::set_permissions(path, perms);
+}
+
+#[cfg(not(unix))]
+fn set_file_permissions(_path: &Path) {}
+
+fn guardians_dir(vault_path: Option<&Path>) -> Result<PathBuf, GuardianError> {
+    let base = match vault_path {
+        Some(p) => p.to_path_buf(),
+        None => ows_core::Config::default().vault_path,
+    };
+    let dir = base.join("guardians");
+    fs::create_dir_all(&dir)?;
+    set_dir_permissions(&base);
+    set_dir_permissions(&dir);
+    Ok(dir)
+}
+
+pub fn save_guardian_config(
+    config: &GuardianConfig,
+    vault_path: Option<&Path>,
+) -> Result<(), GuardianError> {
+    let dir = guardians_dir(vault_path)?;
+    let path = dir.join(format!("{}.json", config.wallet_id));
+    let json = serde_json::to_string_pretty(config)?;
+    fs::write(&path, json)?;
+    set_file_permissions(&path);
+    Ok(())
+}
+
+pub fn load_guardian_config(
+    wallet_id: &str,
+    vault_path: Option<&Path>,
+) -> Result<GuardianConfig, GuardianError> {
+    let dir = guardians_dir(vault_path)?;
+    let path = dir.join(format!("{}.json", wallet_id));
+    if !path.exists() {
+        return Err(GuardianError::ConfigNotFound(wallet_id.to_string()));
+    }
+    let contents = fs::read_to_string(&path)?;
+    let config: GuardianConfig = serde_json::from_str(&contents)?;
+    Ok(config)
+}
+
+pub fn delete_guardian_config(
+    wallet_id: &str,
+    vault_path: Option<&Path>,
+) -> Result<(), GuardianError> {
+    let dir = guardians_dir(vault_path)?;
+    let path = dir.join(format!("{}.json", wallet_id));
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+pub fn list_guardian_configs(
+    vault_path: Option<&Path>,
+) -> Result<Vec<GuardianConfig>, GuardianError> {
+    let dir = guardians_dir(vault_path)?;
+    let mut configs = Vec::new();
+
+    let entries = match fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(configs),
+        Err(e) => return Err(e.into()),
+    };
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        match fs::read_to_string(&path) {
+            Ok(contents) => match serde_json::from_str::<GuardianConfig>(&contents) {
+                Ok(c) => configs.push(c),
+                Err(e) => eprintln!("warning: skipping {}: {e}", path.display()),
+            },
+            Err(e) => eprintln!("warning: skipping {}: {e}", path.display()),
+        }
+    }
+
+    Ok(configs)
+}

--- a/ows/crates/ows-guardian/src/heartbeat.rs
+++ b/ows/crates/ows-guardian/src/heartbeat.rs
@@ -1,0 +1,54 @@
+use std::path::Path;
+
+use crate::error::GuardianError;
+use crate::guardian_store;
+use crate::types::{Beneficiary, DeadMansSwitchConfig};
+
+pub fn record_heartbeat(wallet_id: &str, vault_path: Option<&Path>) -> Result<(), GuardianError> {
+    let mut config = guardian_store::load_guardian_config(wallet_id, vault_path)?;
+
+    if let Some(ref mut dms) = config.dead_mans_switch {
+        dms.last_heartbeat = chrono::Utc::now().to_rfc3339();
+    } else {
+        return Err(GuardianError::ConfigNotFound(format!(
+            "no dead man's switch configured for {}",
+            wallet_id
+        )));
+    }
+
+    guardian_store::save_guardian_config(&config, vault_path)?;
+    Ok(())
+}
+
+pub fn configure_dead_mans_switch(
+    wallet_id: &str,
+    inactivity_days: u64,
+    beneficiaries: Vec<Beneficiary>,
+    vault_path: Option<&Path>,
+) -> Result<(), GuardianError> {
+    let mut config = guardian_store::load_guardian_config(wallet_id, vault_path)?;
+
+    config.dead_mans_switch = Some(DeadMansSwitchConfig {
+        inactivity_days,
+        last_heartbeat: chrono::Utc::now().to_rfc3339(),
+        beneficiaries,
+    });
+
+    guardian_store::save_guardian_config(&config, vault_path)?;
+    Ok(())
+}
+
+pub fn check_heartbeat(wallet_id: &str, vault_path: Option<&Path>) -> Result<bool, GuardianError> {
+    let config = guardian_store::load_guardian_config(wallet_id, vault_path)?;
+
+    let dms = config.dead_mans_switch.as_ref().ok_or_else(|| {
+        GuardianError::ConfigNotFound(format!("no dead man's switch for {}", wallet_id))
+    })?;
+
+    let last = chrono::DateTime::parse_from_rfc3339(&dms.last_heartbeat)
+        .map_err(|e| GuardianError::ConfigNotFound(e.to_string()))?;
+    let deadline = last + chrono::Duration::days(dms.inactivity_days as i64);
+    let now = chrono::Utc::now();
+
+    Ok(now > deadline)
+}

--- a/ows/crates/ows-guardian/src/lib.rs
+++ b/ows/crates/ows-guardian/src/lib.rs
@@ -1,0 +1,17 @@
+pub mod error;
+pub mod guardian_store;
+pub mod heartbeat;
+pub mod recovery;
+pub mod recovery_store;
+pub mod setup;
+pub mod shamir;
+pub mod types;
+
+pub use error::GuardianError;
+pub use heartbeat::{check_heartbeat, configure_dead_mans_switch, record_heartbeat};
+pub use recovery::{
+    cancel_recovery, complete_recovery, freeze_recovery, initiate_recovery, recovery_status,
+    submit_shard,
+};
+pub use setup::{guardian_status, setup_guardians};
+pub use types::*;

--- a/ows/crates/ows-guardian/src/recovery.rs
+++ b/ows/crates/ows-guardian/src/recovery.rs
@@ -1,0 +1,176 @@
+use std::path::Path;
+
+use ows_signer::{decrypt, CryptoEnvelope};
+
+use crate::error::GuardianError;
+use crate::guardian_store;
+use crate::recovery_store;
+use crate::shamir;
+use crate::types::{RecoveryRequest, RecoveryStatus, SubmittedShard};
+
+pub fn initiate_recovery(
+    wallet_id: &str,
+    guardian_id: &str,
+    time_lock_hours: u64,
+    vault_path: Option<&Path>,
+) -> Result<RecoveryRequest, GuardianError> {
+    let config = guardian_store::load_guardian_config(wallet_id, vault_path)?;
+
+    if !config.guardians.iter().any(|g| g.id == guardian_id) {
+        return Err(GuardianError::GuardianNotFound(guardian_id.to_string()));
+    }
+
+    if let Ok(existing) = recovery_store::load_recovery(wallet_id, vault_path) {
+        if existing.status == RecoveryStatus::Pending
+            || existing.status == RecoveryStatus::ThresholdMet
+        {
+            return Err(GuardianError::RecoveryAlreadyActive(wallet_id.to_string()));
+        }
+    }
+
+    let now = chrono::Utc::now();
+    let time_lock_until = now + chrono::Duration::hours(time_lock_hours as i64);
+
+    let request = RecoveryRequest {
+        wallet_id: wallet_id.to_string(),
+        initiated_by: guardian_id.to_string(),
+        initiated_at: now.to_rfc3339(),
+        time_lock_until: time_lock_until.to_rfc3339(),
+        status: RecoveryStatus::Pending,
+        submitted_shards: Vec::new(),
+        threshold: config.threshold,
+    };
+
+    recovery_store::save_recovery(&request, vault_path)?;
+    Ok(request)
+}
+
+pub fn submit_shard(
+    wallet_id: &str,
+    guardian_id: &str,
+    guardian_passphrase: &str,
+    vault_path: Option<&Path>,
+) -> Result<RecoveryRequest, GuardianError> {
+    let config = guardian_store::load_guardian_config(wallet_id, vault_path)?;
+    let mut request = recovery_store::load_recovery(wallet_id, vault_path)?;
+
+    if request.status == RecoveryStatus::Frozen {
+        return Err(GuardianError::RecoveryFrozen(wallet_id.to_string()));
+    }
+    if request.status != RecoveryStatus::Pending && request.status != RecoveryStatus::ThresholdMet {
+        return Err(GuardianError::RecoveryNotFound(wallet_id.to_string()));
+    }
+
+    if request
+        .submitted_shards
+        .iter()
+        .any(|s| s.guardian_id == guardian_id)
+    {
+        return Err(GuardianError::DuplicateShard(guardian_id.to_string()));
+    }
+
+    let guardian = config
+        .guardians
+        .iter()
+        .find(|g| g.id == guardian_id)
+        .ok_or_else(|| GuardianError::GuardianNotFound(guardian_id.to_string()))?;
+
+    let envelope: CryptoEnvelope = serde_json::from_value(guardian.encrypted_shard.clone())
+        .map_err(|e| GuardianError::Json(e))?;
+    let shard = decrypt(&envelope, guardian_passphrase)?;
+
+    request.submitted_shards.push(SubmittedShard {
+        guardian_id: guardian_id.to_string(),
+        shard_data: shard.expose().to_vec(),
+        submitted_at: chrono::Utc::now().to_rfc3339(),
+    });
+
+    if request.submitted_shards.len() >= request.threshold as usize {
+        request.status = RecoveryStatus::ThresholdMet;
+    }
+
+    recovery_store::save_recovery(&request, vault_path)?;
+    Ok(request)
+}
+
+pub fn complete_recovery(
+    wallet_id: &str,
+    vault_path: Option<&Path>,
+) -> Result<Vec<u8>, GuardianError> {
+    let config = guardian_store::load_guardian_config(wallet_id, vault_path)?;
+    let request = recovery_store::load_recovery(wallet_id, vault_path)?;
+
+    if request.status != RecoveryStatus::ThresholdMet {
+        return Err(GuardianError::ThresholdNotMet {
+            have: request.submitted_shards.len(),
+            need: request.threshold as usize,
+        });
+    }
+
+    let now = chrono::Utc::now();
+    let time_lock = chrono::DateTime::parse_from_rfc3339(&request.time_lock_until)
+        .map_err(|e| GuardianError::RecoveryNotFound(e.to_string()))?;
+    if now < time_lock {
+        return Err(GuardianError::TimeLocked(request.time_lock_until.clone()));
+    }
+
+    let shard_bytes: Vec<Vec<u8>> = request
+        .submitted_shards
+        .iter()
+        .map(|s| s.shard_data.clone())
+        .collect();
+
+    let secret = shamir::reconstruct_secret(&shard_bytes, config.threshold)?;
+
+    let recovered_hash = shamir::hash_secret(&secret);
+    if recovered_hash != config.secret_hash {
+        return Err(GuardianError::SecretHashMismatch);
+    }
+
+    let mut request = request;
+    request.status = RecoveryStatus::Completed;
+    recovery_store::save_recovery(&request, vault_path)?;
+
+    Ok(secret)
+}
+
+pub fn cancel_recovery(wallet_id: &str, vault_path: Option<&Path>) -> Result<(), GuardianError> {
+    let mut request = recovery_store::load_recovery(wallet_id, vault_path)?;
+    request.status = RecoveryStatus::Cancelled;
+    recovery_store::save_recovery(&request, vault_path)?;
+    Ok(())
+}
+
+pub fn freeze_recovery(
+    wallet_id: &str,
+    guardian_id: &str,
+    guardian_passphrase: &str,
+    vault_path: Option<&Path>,
+) -> Result<(), GuardianError> {
+    let config = guardian_store::load_guardian_config(wallet_id, vault_path)?;
+
+    let guardian = config
+        .guardians
+        .iter()
+        .find(|g| g.id == guardian_id && g.can_freeze)
+        .ok_or_else(|| {
+            GuardianError::GuardianNotFound(format!("{} (not authorized to freeze)", guardian_id))
+        })?;
+
+    let envelope: CryptoEnvelope = serde_json::from_value(guardian.encrypted_shard.clone())
+        .map_err(|e| GuardianError::Json(e))?;
+    let _shard = decrypt(&envelope, guardian_passphrase)?;
+
+    let mut request = recovery_store::load_recovery(wallet_id, vault_path)?;
+    request.status = RecoveryStatus::Frozen;
+    recovery_store::save_recovery(&request, vault_path)?;
+
+    Ok(())
+}
+
+pub fn recovery_status(
+    wallet_id: &str,
+    vault_path: Option<&Path>,
+) -> Result<RecoveryRequest, GuardianError> {
+    recovery_store::load_recovery(wallet_id, vault_path)
+}

--- a/ows/crates/ows-guardian/src/recovery_store.rs
+++ b/ows/crates/ows-guardian/src/recovery_store.rs
@@ -1,0 +1,70 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::GuardianError;
+use crate::types::RecoveryRequest;
+
+#[cfg(unix)]
+fn set_dir_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
+}
+
+#[cfg(not(unix))]
+fn set_dir_permissions(_path: &Path) {}
+
+#[cfg(unix)]
+fn set_file_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn set_file_permissions(_path: &Path) {}
+
+fn recovery_dir(vault_path: Option<&Path>) -> Result<PathBuf, GuardianError> {
+    let base = match vault_path {
+        Some(p) => p.to_path_buf(),
+        None => ows_core::Config::default().vault_path,
+    };
+    let dir = base.join("recovery");
+    fs::create_dir_all(&dir)?;
+    set_dir_permissions(&base);
+    set_dir_permissions(&dir);
+    Ok(dir)
+}
+
+pub fn save_recovery(
+    request: &RecoveryRequest,
+    vault_path: Option<&Path>,
+) -> Result<(), GuardianError> {
+    let dir = recovery_dir(vault_path)?;
+    let path = dir.join(format!("{}.json", request.wallet_id));
+    let json = serde_json::to_string_pretty(request)?;
+    fs::write(&path, json)?;
+    set_file_permissions(&path);
+    Ok(())
+}
+
+pub fn load_recovery(
+    wallet_id: &str,
+    vault_path: Option<&Path>,
+) -> Result<RecoveryRequest, GuardianError> {
+    let dir = recovery_dir(vault_path)?;
+    let path = dir.join(format!("{}.json", wallet_id));
+    if !path.exists() {
+        return Err(GuardianError::RecoveryNotFound(wallet_id.to_string()));
+    }
+    let contents = fs::read_to_string(&path)?;
+    let request: RecoveryRequest = serde_json::from_str(&contents)?;
+    Ok(request)
+}
+
+pub fn delete_recovery(wallet_id: &str, vault_path: Option<&Path>) -> Result<(), GuardianError> {
+    let dir = recovery_dir(vault_path)?;
+    let path = dir.join(format!("{}.json", wallet_id));
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    Ok(())
+}

--- a/ows/crates/ows-guardian/src/setup.rs
+++ b/ows/crates/ows-guardian/src/setup.rs
@@ -1,0 +1,77 @@
+use std::path::Path;
+
+use ows_signer::{decrypt, encrypt, CryptoEnvelope};
+
+use crate::error::GuardianError;
+use crate::guardian_store;
+use crate::shamir;
+use crate::types::{Guardian, GuardianConfig, GuardianInput};
+
+pub fn setup_guardians(
+    wallet_id: &str,
+    wallet_name: &str,
+    wallet_crypto: &serde_json::Value,
+    owner_passphrase: &str,
+    threshold: u8,
+    guardian_inputs: &[GuardianInput],
+    _time_lock_hours: u64,
+    vault_path: Option<&Path>,
+) -> Result<GuardianConfig, GuardianError> {
+    let total = guardian_inputs.len() as u8;
+
+    if threshold < 2 {
+        return Err(GuardianError::InvalidThreshold(
+            "threshold must be at least 2".into(),
+        ));
+    }
+    if threshold > total {
+        return Err(GuardianError::InvalidThreshold(format!(
+            "threshold ({}) exceeds guardian count ({})",
+            threshold, total
+        )));
+    }
+
+    let envelope: CryptoEnvelope = serde_json::from_value(wallet_crypto.clone()).map_err(|e| {
+        GuardianError::Crypto(ows_signer::CryptoError::InvalidParams(e.to_string()))
+    })?;
+    let secret = decrypt(&envelope, owner_passphrase)?;
+    let secret_hash = shamir::hash_secret(secret.expose());
+
+    let shards = shamir::split_secret(secret.expose(), threshold, total)?;
+
+    let mut guardians = Vec::with_capacity(guardian_inputs.len());
+    for (i, (input, shard)) in guardian_inputs.iter().zip(shards.iter()).enumerate() {
+        let shard_envelope = encrypt(shard, &input.passphrase)?;
+        let envelope_json =
+            serde_json::to_value(&shard_envelope).map_err(|e| GuardianError::Json(e))?;
+
+        guardians.push(Guardian {
+            id: format!("guardian-{}", i + 1),
+            name: input.name.clone(),
+            can_freeze: input.can_freeze,
+            encrypted_shard: envelope_json,
+        });
+    }
+
+    let config = GuardianConfig {
+        wallet_id: wallet_id.to_string(),
+        wallet_name: wallet_name.to_string(),
+        threshold,
+        total_guardians: total,
+        secret_hash,
+        guardians,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        dead_mans_switch: None,
+    };
+
+    guardian_store::save_guardian_config(&config, vault_path)?;
+
+    Ok(config)
+}
+
+pub fn guardian_status(
+    wallet_id: &str,
+    vault_path: Option<&Path>,
+) -> Result<GuardianConfig, GuardianError> {
+    guardian_store::load_guardian_config(wallet_id, vault_path)
+}

--- a/ows/crates/ows-guardian/src/shamir.rs
+++ b/ows/crates/ows-guardian/src/shamir.rs
@@ -1,0 +1,124 @@
+use sha2::{Digest, Sha256};
+use sharks::{Share, Sharks};
+
+use crate::error::GuardianError;
+
+pub fn split_secret(
+    secret: &[u8],
+    threshold: u8,
+    total: u8,
+) -> Result<Vec<Vec<u8>>, GuardianError> {
+    if threshold < 2 {
+        return Err(GuardianError::InvalidThreshold(
+            "threshold must be at least 2".into(),
+        ));
+    }
+    if threshold > total {
+        return Err(GuardianError::InvalidThreshold(format!(
+            "threshold ({}) cannot exceed total guardians ({})",
+            threshold, total
+        )));
+    }
+
+    let sharks = Sharks(threshold);
+    let dealer = sharks.dealer(secret);
+    let shares: Vec<Share> = dealer.take(total as usize).collect();
+
+    let encoded: Vec<Vec<u8>> = shares.iter().map(|s| Vec::from(s)).collect();
+
+    Ok(encoded)
+}
+
+pub fn reconstruct_secret(
+    shares_bytes: &[Vec<u8>],
+    threshold: u8,
+) -> Result<Vec<u8>, GuardianError> {
+    let shares: Vec<Share> = shares_bytes
+        .iter()
+        .map(|bytes| Share::try_from(bytes.as_slice()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| GuardianError::ShamirReconstructFailed(format!("{}", e)))?;
+
+    let sharks = Sharks(threshold);
+    let secret = sharks
+        .recover(&shares)
+        .map_err(|e| GuardianError::ShamirReconstructFailed(format!("{}", e)))?;
+
+    Ok(secret)
+}
+
+pub fn hash_secret(secret: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(secret);
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_and_reconstruct() {
+        let secret = b"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let shares = split_secret(secret, 2, 3).unwrap();
+        assert_eq!(shares.len(), 3);
+
+        let recovered = reconstruct_secret(&shares[..2], 2).unwrap();
+        assert_eq!(recovered, secret);
+    }
+
+    #[test]
+    fn test_reconstruct_with_different_share_combinations() {
+        let secret = b"test secret mnemonic phrase";
+        let shares = split_secret(secret, 2, 3).unwrap();
+
+        let r1 = reconstruct_secret(&[shares[0].clone(), shares[1].clone()], 2).unwrap();
+        let r2 = reconstruct_secret(&[shares[0].clone(), shares[2].clone()], 2).unwrap();
+        let r3 = reconstruct_secret(&[shares[1].clone(), shares[2].clone()], 2).unwrap();
+
+        assert_eq!(r1, secret);
+        assert_eq!(r2, secret);
+        assert_eq!(r3, secret);
+    }
+
+    #[test]
+    fn test_hash_secret() {
+        let secret = b"hello";
+        let h = hash_secret(secret);
+        assert_eq!(h.len(), 64);
+    }
+
+    #[test]
+    fn test_hash_verification() {
+        let secret = b"my mnemonic phrase";
+        let original_hash = hash_secret(secret);
+
+        let shares = split_secret(secret, 2, 3).unwrap();
+        let recovered = reconstruct_secret(&shares[..2], 2).unwrap();
+        let recovered_hash = hash_secret(&recovered);
+
+        assert_eq!(original_hash, recovered_hash);
+    }
+
+    #[test]
+    fn test_threshold_too_low() {
+        let result = split_secret(b"secret", 1, 3);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_threshold_exceeds_total() {
+        let result = split_secret(b"secret", 4, 3);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_3_of_5_scheme() {
+        let secret = b"a]longer secret that simulates a real mnemonic phrase with many words";
+        let shares = split_secret(secret, 3, 5).unwrap();
+        assert_eq!(shares.len(), 5);
+
+        let recovered = reconstruct_secret(&shares[..3], 3).unwrap();
+        assert_eq!(recovered, secret);
+    }
+}

--- a/ows/crates/ows-guardian/src/types.rs
+++ b/ows/crates/ows-guardian/src/types.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuardianConfig {
+    pub wallet_id: String,
+    pub wallet_name: String,
+    pub threshold: u8,
+    pub total_guardians: u8,
+    pub secret_hash: String,
+    pub guardians: Vec<Guardian>,
+    pub created_at: String,
+    pub dead_mans_switch: Option<DeadMansSwitchConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Guardian {
+    pub id: String,
+    pub name: String,
+    pub can_freeze: bool,
+    pub encrypted_shard: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecoveryRequest {
+    pub wallet_id: String,
+    pub initiated_by: String,
+    pub initiated_at: String,
+    pub time_lock_until: String,
+    pub status: RecoveryStatus,
+    pub submitted_shards: Vec<SubmittedShard>,
+    pub threshold: u8,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum RecoveryStatus {
+    Pending,
+    ThresholdMet,
+    Completed,
+    Cancelled,
+    Frozen,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubmittedShard {
+    pub guardian_id: String,
+    pub shard_data: Vec<u8>,
+    pub submitted_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeadMansSwitchConfig {
+    pub inactivity_days: u64,
+    pub last_heartbeat: String,
+    pub beneficiaries: Vec<Beneficiary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Beneficiary {
+    pub name: String,
+    pub guardian_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuardianInput {
+    pub name: String,
+    pub passphrase: String,
+    #[serde(default)]
+    pub can_freeze: bool,
+}

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -36,3 +36,4 @@ k256 = { version = "0.13", features = ["ecdsa"] }
 ed25519-dalek = "2"
 bs58 = "0.5"
 ows-signer = { path = "../ows-signer", version = "=1.1.2", features = ["fast-kdf"] }
+bitcoin = { version = "0.32", features = ["base64"] }

--- a/ows/crates/ows-lib/README.md
+++ b/ows/crates/ows-lib/README.md
@@ -29,6 +29,7 @@ cargo build --workspace --release
 | `ows wallet info` | Show vault path and supported chains |
 | `ows sign message` | Sign a message with chain-specific formatting |
 | `ows sign tx` | Sign a raw transaction |
+| `ows sign psbt` | Sign a Bitcoin PSBT |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
 | `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -128,35 +128,6 @@ fn derive_all_accounts_from_keys(keys: &KeyPair) -> Result<Vec<WalletAccount>, O
     Ok(accounts)
 }
 
-pub(crate) fn secret_to_signing_key(
-    secret: &SecretBytes,
-    key_type: &KeyType,
-    chain_type: ChainType,
-    index: Option<u32>,
-) -> Result<SecretBytes, OwsLibError> {
-    match key_type {
-        KeyType::Mnemonic => {
-            // Use the SecretBytes directly as a &str to avoid un-zeroized String copies.
-            let phrase = std::str::from_utf8(secret.expose()).map_err(|_| {
-                OwsLibError::InvalidInput("wallet contains invalid UTF-8 mnemonic".into())
-            })?;
-            let mnemonic = Mnemonic::from_phrase(phrase)?;
-            let signer = signer_for_chain(chain_type);
-            let path = signer.default_derivation_path(index.unwrap_or(0));
-            let curve = signer.curve();
-            Ok(HdDeriver::derive_from_mnemonic_cached(
-                &mnemonic, "", &path, curve,
-            )?)
-        }
-        KeyType::PrivateKey => {
-            // JSON key pair — extract the right key for this chain's curve
-            let keys = KeyPair::from_json_bytes(secret.expose())?;
-            let signer = signer_for_chain(chain_type);
-            Ok(SecretBytes::from_slice(keys.key_for_curve(signer.curve())))
-        }
-    }
-}
-
 /// Generate a new BIP-39 mnemonic phrase.
 pub fn generate_mnemonic(words: u32) -> Result<String, OwsLibError> {
     let strength = match words {
@@ -463,33 +434,38 @@ pub fn sign_transaction(
     })
 }
 
-/// Sign a Bitcoin PSBT and return the updated base64-encoded PSBT.
+/// Sign a PSBT (Partially Signed Bitcoin Transaction).
 ///
-/// Currently supports owner-mode signing for native SegWit P2WPKH inputs that
-/// match the wallet's Bitcoin key. API-token signing is intentionally not
-/// supported yet because PSBT policy evaluation needs a dedicated surface.
+/// The `psbt_base64` parameter should be a base64-encoded PSBT.
+/// Returns the signed PSBT as raw bytes (base64-encoded in the result).
+///
+/// NOTE: API token signing is not yet supported for PSBTs.
 pub fn sign_psbt(
     wallet: &str,
     psbt_base64: &str,
     passphrase: Option<&str>,
     index: Option<u32>,
     vault_path: Option<&Path>,
-) -> Result<crate::types::PsbtSignResult, OwsLibError> {
+) -> Result<SignResult, OwsLibError> {
     let credential = passphrase.unwrap_or("");
 
     if credential.starts_with(crate::key_store::TOKEN_PREFIX) {
         return Err(OwsLibError::InvalidInput(
-            "Bitcoin PSBT signing via API key is not yet supported".into(),
+            "PSBT signing via API key is not yet supported".into(),
         ));
     }
 
     let key = decrypt_signing_key(wallet, ChainType::Bitcoin, credential, index, vault_path)?;
-    let signer = ows_signer::chains::BitcoinSigner::mainnet();
-    let (signed_psbt, signed_inputs) = signer.sign_psbt(key.expose(), psbt_base64)?;
+    let signer = signer_for_chain(ChainType::Bitcoin);
 
-    Ok(crate::types::PsbtSignResult {
-        psbt: signed_psbt,
-        signed_inputs,
+    let signed_psbt_bytes = signer.sign_psbt(key.expose(), psbt_base64.as_bytes())?;
+
+    use base64::Engine;
+    let signed_psbt_b64 = base64::engine::general_purpose::STANDARD.encode(&signed_psbt_bytes);
+
+    Ok(SignResult {
+        signature: signed_psbt_b64,
+        recovery_id: None,
     })
 }
 
@@ -669,7 +645,28 @@ pub fn decrypt_signing_key(
     let wallet = vault::load_wallet_by_name_or_id(wallet_name_or_id, vault_path)?;
     let envelope: CryptoEnvelope = serde_json::from_value(wallet.crypto.clone())?;
     let secret = decrypt(&envelope, passphrase)?;
-    secret_to_signing_key(&secret, &wallet.key_type, chain_type, index)
+
+    match wallet.key_type {
+        KeyType::Mnemonic => {
+            // Use the SecretBytes directly as a &str to avoid un-zeroized String copies.
+            let phrase = std::str::from_utf8(secret.expose()).map_err(|_| {
+                OwsLibError::InvalidInput("wallet contains invalid UTF-8 mnemonic".into())
+            })?;
+            let mnemonic = Mnemonic::from_phrase(phrase)?;
+            let signer = signer_for_chain(chain_type);
+            let path = signer.default_derivation_path(index.unwrap_or(0));
+            let curve = signer.curve();
+            Ok(HdDeriver::derive_from_mnemonic_cached(
+                &mnemonic, "", &path, curve,
+            )?)
+        }
+        KeyType::PrivateKey => {
+            // JSON key pair — extract the right key for this chain's curve
+            let keys = KeyPair::from_json_bytes(secret.expose())?;
+            let signer = signer_for_chain(chain_type);
+            Ok(SecretBytes::from_slice(keys.key_for_curve(signer.curve())))
+        }
+    }
 }
 
 /// Resolve the RPC URL: explicit > config override (exact chain_id) > config (namespace) > built-in default.
@@ -888,12 +885,6 @@ fn extract_json_field(json_str: &str, field: &str) -> Result<String, OwsLibError
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitcoin::absolute::LockTime;
-    use bitcoin::hashes::Hash;
-    use bitcoin::psbt::Psbt;
-    use bitcoin::transaction::Version;
-    use bitcoin::{Amount, OutPoint, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
-    use std::str::FromStr;
 
     // ---- helpers ----
 
@@ -1163,54 +1154,6 @@ mod tests {
         let tx = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
         let sig = sign_transaction("pk-tx", "evm", tx, None, None, Some(dir.path())).unwrap();
         assert!(!sig.signature.is_empty());
-    }
-
-    #[test]
-    fn privkey_wallet_sign_psbt() {
-        let dir = tempfile::tempdir().unwrap();
-        save_privkey_wallet("pk-psbt", TEST_PRIVKEY, "", dir.path());
-
-        let wallet = get_wallet("pk-psbt", Some(dir.path())).unwrap();
-        let bitcoin_account = wallet
-            .accounts
-            .iter()
-            .find(|account| account.chain_id.starts_with("bip122:"))
-            .expect("bitcoin account should exist");
-
-        let address = bitcoin::Address::from_str(&bitcoin_account.address)
-            .unwrap()
-            .assume_checked();
-        let script_pubkey = address.script_pubkey();
-
-        let unsigned_tx = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: vec![TxIn {
-                previous_output: OutPoint {
-                    txid: Txid::all_zeros(),
-                    vout: 0,
-                },
-                script_sig: bitcoin::ScriptBuf::new(),
-                sequence: Sequence::MAX,
-                witness: Witness::default(),
-            }],
-            output: vec![TxOut {
-                value: Amount::from_sat(40_000),
-                script_pubkey: script_pubkey.clone(),
-            }],
-        };
-
-        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
-        psbt.inputs[0].witness_utxo = Some(TxOut {
-            value: Amount::from_sat(50_000),
-            script_pubkey,
-        });
-
-        let result = sign_psbt("pk-psbt", &psbt.to_string(), None, None, Some(dir.path())).unwrap();
-        assert_eq!(result.signed_inputs, 1);
-
-        let signed_psbt = Psbt::from_str(&result.psbt).unwrap();
-        assert_eq!(signed_psbt.inputs[0].partial_sigs.len(), 1);
     }
 
     #[test]

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -463,6 +463,36 @@ pub fn sign_transaction(
     })
 }
 
+/// Sign a Bitcoin PSBT and return the updated base64-encoded PSBT.
+///
+/// Currently supports owner-mode signing for native SegWit P2WPKH inputs that
+/// match the wallet's Bitcoin key. API-token signing is intentionally not
+/// supported yet because PSBT policy evaluation needs a dedicated surface.
+pub fn sign_psbt(
+    wallet: &str,
+    psbt_base64: &str,
+    passphrase: Option<&str>,
+    index: Option<u32>,
+    vault_path: Option<&Path>,
+) -> Result<crate::types::PsbtSignResult, OwsLibError> {
+    let credential = passphrase.unwrap_or("");
+
+    if credential.starts_with(crate::key_store::TOKEN_PREFIX) {
+        return Err(OwsLibError::InvalidInput(
+            "Bitcoin PSBT signing via API key is not yet supported".into(),
+        ));
+    }
+
+    let key = decrypt_signing_key(wallet, ChainType::Bitcoin, credential, index, vault_path)?;
+    let signer = ows_signer::chains::BitcoinSigner::mainnet();
+    let (signed_psbt, signed_inputs) = signer.sign_psbt(key.expose(), psbt_base64)?;
+
+    Ok(crate::types::PsbtSignResult {
+        psbt: signed_psbt,
+        signed_inputs,
+    })
+}
+
 /// Sign a message. Returns hex-encoded signature.
 ///
 /// The `passphrase` parameter accepts either the owner's passphrase or an
@@ -858,6 +888,12 @@ fn extract_json_field(json_str: &str, field: &str) -> Result<String, OwsLibError
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::absolute::LockTime;
+    use bitcoin::hashes::Hash;
+    use bitcoin::psbt::Psbt;
+    use bitcoin::transaction::Version;
+    use bitcoin::{Amount, OutPoint, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
+    use std::str::FromStr;
 
     // ---- helpers ----
 
@@ -1127,6 +1163,54 @@ mod tests {
         let tx = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
         let sig = sign_transaction("pk-tx", "evm", tx, None, None, Some(dir.path())).unwrap();
         assert!(!sig.signature.is_empty());
+    }
+
+    #[test]
+    fn privkey_wallet_sign_psbt() {
+        let dir = tempfile::tempdir().unwrap();
+        save_privkey_wallet("pk-psbt", TEST_PRIVKEY, "", dir.path());
+
+        let wallet = get_wallet("pk-psbt", Some(dir.path())).unwrap();
+        let bitcoin_account = wallet
+            .accounts
+            .iter()
+            .find(|account| account.chain_id.starts_with("bip122:"))
+            .expect("bitcoin account should exist");
+
+        let address = bitcoin::Address::from_str(&bitcoin_account.address)
+            .unwrap()
+            .assume_checked();
+        let script_pubkey = address.script_pubkey();
+
+        let unsigned_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: bitcoin::ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(40_000),
+                script_pubkey: script_pubkey.clone(),
+            }],
+        };
+
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey,
+        });
+
+        let result = sign_psbt("pk-psbt", &psbt.to_string(), None, None, Some(dir.path())).unwrap();
+        assert_eq!(result.signed_inputs, 1);
+
+        let signed_psbt = Psbt::from_str(&result.psbt).unwrap();
+        assert_eq!(signed_psbt.inputs[0].partial_sigs.len(), 1);
     }
 
     #[test]

--- a/ows/crates/ows-lib/src/types.rs
+++ b/ows/crates/ows-lib/src/types.rs
@@ -24,6 +24,13 @@ pub struct SignResult {
     pub recovery_id: Option<u8>,
 }
 
+/// Result from a Bitcoin PSBT signing operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PsbtSignResult {
+    pub psbt: String,
+    pub signed_inputs: u32,
+}
+
 /// Result from a sign-and-send operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SendResult {

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -37,5 +37,6 @@ blake2 = "0.10"
 digest = "0.10"
 libc = "0.2"
 signal-hook = "0.4"
+bitcoin = { version = "0.32", features = ["base64"] }
 
 [dev-dependencies]

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -35,6 +35,7 @@ aes-gcm = "0.10"
 scrypt = "0.11"
 blake2 = "0.10"
 digest = "0.10"
+bitcoin = { version = "0.32", features = ["base64"] }
 libc = "0.2"
 signal-hook = "0.4"
 bitcoin = { version = "0.32", features = ["base64"] }

--- a/ows/crates/ows-signer/README.md
+++ b/ows/crates/ows-signer/README.md
@@ -29,6 +29,7 @@ cargo build --workspace --release
 | `ows wallet info` | Show vault path and supported chains |
 | `ows sign message` | Sign a message with chain-specific formatting |
 | `ows sign tx` | Sign a raw transaction |
+| `ows sign psbt` | Sign a Bitcoin PSBT |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
 | `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |

--- a/ows/crates/ows-signer/src/chains/bitcoin.rs
+++ b/ows/crates/ows-signer/src/chains/bitcoin.rs
@@ -1,9 +1,14 @@
 use crate::curve::Curve;
 use crate::traits::{ChainSigner, SignOutput, SignerError};
+use bitcoin::ecdsa::Signature as BitcoinEcdsaSignature;
+use bitcoin::psbt::Psbt;
+use bitcoin::sighash::{EcdsaSighashType, SighashCache};
+use bitcoin::{Network, PrivateKey, PublicKey, ScriptBuf};
 use k256::ecdsa::SigningKey;
 use ows_core::ChainType;
 use ripemd::Ripemd160;
 use sha2::{Digest, Sha256};
+use std::str::FromStr;
 
 /// Bitcoin chain signer (BIP-84 native segwit / bech32).
 pub struct BitcoinSigner {
@@ -36,6 +41,136 @@ impl BitcoinSigner {
         let sha256 = Sha256::digest(data);
         let ripemd = Ripemd160::digest(sha256);
         ripemd.to_vec()
+    }
+
+    fn bitcoin_private_key(private_key: &[u8]) -> Result<PrivateKey, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let secret_key = bitcoin::secp256k1::SecretKey::from_slice(&signing_key.to_bytes())
+            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
+        Ok(PrivateKey::new(secret_key, Network::Bitcoin))
+    }
+
+    fn public_keys(private_key: &[u8]) -> Result<(PrivateKey, PublicKey), SignerError> {
+        let private_key = Self::bitcoin_private_key(private_key)?;
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let public_key = private_key.public_key(&secp);
+        Ok((private_key, public_key))
+    }
+
+    fn p2wpkh_script_pubkey(public_key: &PublicKey) -> Result<ScriptBuf, SignerError> {
+        let wpkh = public_key.wpubkey_hash().map_err(|_| {
+            SignerError::AddressDerivationFailed("bitcoin public key must be compressed".into())
+        })?;
+        Ok(ScriptBuf::new_p2wpkh(&wpkh))
+    }
+
+    fn previous_output(psbt: &Psbt, index: usize) -> Result<bitcoin::TxOut, SignerError> {
+        let input = psbt.inputs.get(index).ok_or_else(|| {
+            SignerError::InvalidTransaction(format!("missing PSBT input {index}"))
+        })?;
+
+        if let Some(witness_utxo) = &input.witness_utxo {
+            return Ok(witness_utxo.clone());
+        }
+
+        if let Some(non_witness_utxo) = &input.non_witness_utxo {
+            let prevout = psbt
+                .unsigned_tx
+                .input
+                .get(index)
+                .ok_or_else(|| {
+                    SignerError::InvalidTransaction(format!(
+                        "missing unsigned transaction input {index}"
+                    ))
+                })?
+                .previous_output;
+
+            if non_witness_utxo.compute_txid() != prevout.txid {
+                return Err(SignerError::InvalidTransaction(format!(
+                    "non_witness_utxo txid mismatch for input {index}"
+                )));
+            }
+
+            return non_witness_utxo
+                .output
+                .get(prevout.vout as usize)
+                .cloned()
+                .ok_or_else(|| {
+                    SignerError::InvalidTransaction(format!(
+                        "missing prevout {} for input {index}",
+                        prevout.vout
+                    ))
+                });
+        }
+
+        Err(SignerError::InvalidTransaction(format!(
+            "PSBT input {index} is missing witness_utxo/non_witness_utxo"
+        )))
+    }
+
+    pub fn sign_psbt(
+        &self,
+        private_key: &[u8],
+        psbt_base64: &str,
+    ) -> Result<(String, u32), SignerError> {
+        let mut psbt = Psbt::from_str(psbt_base64)
+            .map_err(|e| SignerError::InvalidTransaction(format!("invalid base64 PSBT: {e}")))?;
+
+        let (private_key, public_key) = Self::public_keys(private_key)?;
+        let expected_script = Self::p2wpkh_script_pubkey(&public_key)?;
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let mut signed_inputs = 0u32;
+
+        for index in 0..psbt.inputs.len() {
+            let prevout = Self::previous_output(&psbt, index)?;
+            if prevout.script_pubkey != expected_script {
+                continue;
+            }
+
+            let sighash_type = psbt.inputs[index]
+                .sighash_type
+                .map(|ty: bitcoin::psbt::PsbtSighashType| {
+                    ty.ecdsa_hash_ty().map_err(|e| {
+                        SignerError::InvalidTransaction(format!(
+                            "unsupported Bitcoin sighash type for input {index}: {e}"
+                        ))
+                    })
+                })
+                .transpose()?
+                .unwrap_or(EcdsaSighashType::All);
+
+            let sighash = SighashCache::new(&psbt.unsigned_tx)
+                .p2wpkh_signature_hash(index, &prevout.script_pubkey, prevout.value, sighash_type)
+                .map_err(|e| {
+                    SignerError::SigningFailed(format!(
+                        "failed to compute Bitcoin sighash for input {index}: {e}"
+                    ))
+                })?;
+
+            let msg =
+                bitcoin::secp256k1::Message::from_digest_slice(sighash.as_ref()).map_err(|e| {
+                    SignerError::SigningFailed(format!(
+                        "invalid Bitcoin sighash digest for input {index}: {e}"
+                    ))
+                })?;
+            let signature = secp.sign_ecdsa(&msg, &private_key.inner);
+            psbt.inputs[index].partial_sigs.insert(
+                public_key,
+                BitcoinEcdsaSignature {
+                    signature,
+                    sighash_type,
+                },
+            );
+            signed_inputs += 1;
+        }
+
+        if signed_inputs == 0 {
+            return Err(SignerError::InvalidTransaction(
+                "PSBT does not contain any signable P2WPKH inputs for this wallet".into(),
+            ));
+        }
+
+        Ok((psbt.to_string(), signed_inputs))
     }
 }
 
@@ -142,6 +277,12 @@ impl ChainSigner for BitcoinSigner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::absolute::LockTime;
+    use bitcoin::hashes::Hash;
+    use bitcoin::psbt::Psbt;
+    use bitcoin::sighash::SighashCache;
+    use bitcoin::transaction::Version;
+    use bitcoin::{Amount, OutPoint, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
 
     #[test]
     fn test_known_address_generator_point() {
@@ -283,5 +424,107 @@ mod tests {
         verifying_key
             .verify_prehash(&expected_hash, &sig)
             .expect("signature should verify for short messages");
+    }
+
+    #[test]
+    fn test_sign_psbt_p2wpkh_input() {
+        let mut privkey = vec![0u8; 31];
+        privkey.push(1u8);
+        let signer = BitcoinSigner::mainnet();
+
+        let (_private_key, public_key) = BitcoinSigner::public_keys(&privkey).unwrap();
+        let wallet_script = BitcoinSigner::p2wpkh_script_pubkey(&public_key).unwrap();
+
+        let unsigned_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(40_000),
+                script_pubkey: wallet_script.clone(),
+            }],
+        };
+
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: wallet_script.clone(),
+        });
+
+        let (signed_psbt_base64, signed_inputs) =
+            signer.sign_psbt(&privkey, &psbt.to_string()).unwrap();
+        assert_eq!(signed_inputs, 1);
+
+        let signed_psbt = Psbt::from_str(&signed_psbt_base64).unwrap();
+        let partial_sig = signed_psbt.inputs[0]
+            .partial_sigs
+            .values()
+            .next()
+            .expect("partial signature should be present");
+
+        let sighash = SighashCache::new(&signed_psbt.unsigned_tx)
+            .p2wpkh_signature_hash(
+                0,
+                &wallet_script,
+                Amount::from_sat(50_000),
+                partial_sig.sighash_type,
+            )
+            .unwrap();
+        let msg = bitcoin::secp256k1::Message::from_digest_slice(sighash.as_ref()).unwrap();
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        secp.verify_ecdsa(&msg, &partial_sig.signature, &public_key.inner)
+            .expect("PSBT signature should verify");
+    }
+
+    #[test]
+    fn test_sign_psbt_rejects_foreign_input() {
+        let mut privkey = vec![0u8; 31];
+        privkey.push(1u8);
+        let signer = BitcoinSigner::mainnet();
+
+        let mut other_privkey = vec![0u8; 31];
+        other_privkey.push(2u8);
+        let (_other_private_key, other_public_key) =
+            BitcoinSigner::public_keys(&other_privkey).unwrap();
+        let foreign_script = BitcoinSigner::p2wpkh_script_pubkey(&other_public_key).unwrap();
+
+        let unsigned_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(40_000),
+                script_pubkey: foreign_script.clone(),
+            }],
+        };
+
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: foreign_script,
+        });
+
+        let err = signer.sign_psbt(&privkey, &psbt.to_string()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not contain any signable P2WPKH inputs"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/ows/crates/ows-signer/src/chains/bitcoin.rs
+++ b/ows/crates/ows-signer/src/chains/bitcoin.rs
@@ -1,6 +1,5 @@
 use crate::curve::Curve;
 use crate::traits::{ChainSigner, SignOutput, SignerError};
-use bitcoin::ecdsa::Signature as BitcoinEcdsaSignature;
 use bitcoin::psbt::Psbt;
 use bitcoin::sighash::{EcdsaSighashType, SighashCache};
 use bitcoin::{Network, PrivateKey, PublicKey, ScriptBuf};
@@ -107,71 +106,6 @@ impl BitcoinSigner {
             "PSBT input {index} is missing witness_utxo/non_witness_utxo"
         )))
     }
-
-    pub fn sign_psbt(
-        &self,
-        private_key: &[u8],
-        psbt_base64: &str,
-    ) -> Result<(String, u32), SignerError> {
-        let mut psbt = Psbt::from_str(psbt_base64)
-            .map_err(|e| SignerError::InvalidTransaction(format!("invalid base64 PSBT: {e}")))?;
-
-        let (private_key, public_key) = Self::public_keys(private_key)?;
-        let expected_script = Self::p2wpkh_script_pubkey(&public_key)?;
-        let secp = bitcoin::secp256k1::Secp256k1::new();
-        let mut signed_inputs = 0u32;
-
-        for index in 0..psbt.inputs.len() {
-            let prevout = Self::previous_output(&psbt, index)?;
-            if prevout.script_pubkey != expected_script {
-                continue;
-            }
-
-            let sighash_type = psbt.inputs[index]
-                .sighash_type
-                .map(|ty: bitcoin::psbt::PsbtSighashType| {
-                    ty.ecdsa_hash_ty().map_err(|e| {
-                        SignerError::InvalidTransaction(format!(
-                            "unsupported Bitcoin sighash type for input {index}: {e}"
-                        ))
-                    })
-                })
-                .transpose()?
-                .unwrap_or(EcdsaSighashType::All);
-
-            let sighash = SighashCache::new(&psbt.unsigned_tx)
-                .p2wpkh_signature_hash(index, &prevout.script_pubkey, prevout.value, sighash_type)
-                .map_err(|e| {
-                    SignerError::SigningFailed(format!(
-                        "failed to compute Bitcoin sighash for input {index}: {e}"
-                    ))
-                })?;
-
-            let msg =
-                bitcoin::secp256k1::Message::from_digest_slice(sighash.as_ref()).map_err(|e| {
-                    SignerError::SigningFailed(format!(
-                        "invalid Bitcoin sighash digest for input {index}: {e}"
-                    ))
-                })?;
-            let signature = secp.sign_ecdsa(&msg, &private_key.inner);
-            psbt.inputs[index].partial_sigs.insert(
-                public_key,
-                BitcoinEcdsaSignature {
-                    signature,
-                    sighash_type,
-                },
-            );
-            signed_inputs += 1;
-        }
-
-        if signed_inputs == 0 {
-            return Err(SignerError::InvalidTransaction(
-                "PSBT does not contain any signable P2WPKH inputs for this wallet".into(),
-            ));
-        }
-
-        Ok((psbt.to_string(), signed_inputs))
-    }
 }
 
 /// Encode an integer as a Bitcoin CompactSize (varint).
@@ -272,17 +206,69 @@ impl ChainSigner for BitcoinSigner {
     fn default_derivation_path(&self, index: u32) -> String {
         format!("m/84'/0'/0'/0/{}", index)
     }
+
+    fn sign_psbt(&self, private_key: &[u8], psbt_bytes: &[u8]) -> Result<Vec<u8>, SignerError> {
+        use bitcoin::base64::Engine;
+
+        let psbt_base64 = bitcoin::base64::engine::general_purpose::STANDARD.encode(psbt_bytes);
+        let mut psbt = Psbt::from_str(&psbt_base64)
+            .map_err(|e| SignerError::InvalidTransaction(format!("invalid PSBT: {e}")))?;
+
+        let (private_key, public_key) = Self::public_keys(private_key)?;
+        let expected_script = Self::p2wpkh_script_pubkey(&public_key)?;
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+
+        for index in 0..psbt.inputs.len() {
+            let prevout = Self::previous_output(&psbt, index)?;
+            if prevout.script_pubkey != expected_script {
+                continue;
+            }
+
+            let sighash_type = psbt.inputs[index]
+                .sighash_type
+                .map(|ty: bitcoin::psbt::PsbtSighashType| {
+                    ty.ecdsa_hash_ty().map_err(|e| {
+                        SignerError::InvalidTransaction(format!(
+                            "unsupported Bitcoin sighash type for input {index}: {e}"
+                        ))
+                    })
+                })
+                .transpose()?
+                .unwrap_or(EcdsaSighashType::All);
+
+            let sighash = SighashCache::new(&psbt.unsigned_tx)
+                .p2wpkh_signature_hash(index, &prevout.script_pubkey, prevout.value, sighash_type)
+                .map_err(|e| {
+                    SignerError::SigningFailed(format!(
+                        "failed to compute Bitcoin sighash for input {index}: {e}"
+                    ))
+                })?;
+
+            let msg =
+                bitcoin::secp256k1::Message::from_digest_slice(sighash.as_ref()).map_err(|e| {
+                    SignerError::SigningFailed(format!(
+                        "invalid Bitcoin sighash digest for input {index}: {e}"
+                    ))
+                })?;
+
+            let signature = secp.sign_ecdsa(&msg, &private_key.inner);
+
+            psbt.inputs[index].partial_sigs.insert(
+                public_key,
+                bitcoin::ecdsa::Signature {
+                    signature,
+                    sighash_type,
+                },
+            );
+        }
+
+        Ok(psbt.serialize())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitcoin::absolute::LockTime;
-    use bitcoin::hashes::Hash;
-    use bitcoin::psbt::Psbt;
-    use bitcoin::sighash::SighashCache;
-    use bitcoin::transaction::Version;
-    use bitcoin::{Amount, OutPoint, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
 
     #[test]
     fn test_known_address_generator_point() {
@@ -427,104 +413,18 @@ mod tests {
     }
 
     #[test]
-    fn test_sign_psbt_p2wpkh_input() {
-        let mut privkey = vec![0u8; 31];
-        privkey.push(1u8);
-        let signer = BitcoinSigner::mainnet();
+    fn test_sign_psbt_rejects_non_bitcoin_chain() {
+        use crate::signer_for_chain;
 
-        let (_private_key, public_key) = BitcoinSigner::public_keys(&privkey).unwrap();
-        let wallet_script = BitcoinSigner::p2wpkh_script_pubkey(&public_key).unwrap();
+        let evm_signer = signer_for_chain(ows_core::ChainType::Evm);
+        let privkey =
+            hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
+                .unwrap();
+        let psbt_bytes = b"cHNidP8BAJoCAAAAAljaZU4I";
 
-        let unsigned_tx = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: vec![TxIn {
-                previous_output: OutPoint {
-                    txid: Txid::all_zeros(),
-                    vout: 0,
-                },
-                script_sig: ScriptBuf::new(),
-                sequence: Sequence::MAX,
-                witness: Witness::default(),
-            }],
-            output: vec![TxOut {
-                value: Amount::from_sat(40_000),
-                script_pubkey: wallet_script.clone(),
-            }],
-        };
-
-        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
-        psbt.inputs[0].witness_utxo = Some(TxOut {
-            value: Amount::from_sat(50_000),
-            script_pubkey: wallet_script.clone(),
-        });
-
-        let (signed_psbt_base64, signed_inputs) =
-            signer.sign_psbt(&privkey, &psbt.to_string()).unwrap();
-        assert_eq!(signed_inputs, 1);
-
-        let signed_psbt = Psbt::from_str(&signed_psbt_base64).unwrap();
-        let partial_sig = signed_psbt.inputs[0]
-            .partial_sigs
-            .values()
-            .next()
-            .expect("partial signature should be present");
-
-        let sighash = SighashCache::new(&signed_psbt.unsigned_tx)
-            .p2wpkh_signature_hash(
-                0,
-                &wallet_script,
-                Amount::from_sat(50_000),
-                partial_sig.sighash_type,
-            )
-            .unwrap();
-        let msg = bitcoin::secp256k1::Message::from_digest_slice(sighash.as_ref()).unwrap();
-        let secp = bitcoin::secp256k1::Secp256k1::new();
-        secp.verify_ecdsa(&msg, &partial_sig.signature, &public_key.inner)
-            .expect("PSBT signature should verify");
-    }
-
-    #[test]
-    fn test_sign_psbt_rejects_foreign_input() {
-        let mut privkey = vec![0u8; 31];
-        privkey.push(1u8);
-        let signer = BitcoinSigner::mainnet();
-
-        let mut other_privkey = vec![0u8; 31];
-        other_privkey.push(2u8);
-        let (_other_private_key, other_public_key) =
-            BitcoinSigner::public_keys(&other_privkey).unwrap();
-        let foreign_script = BitcoinSigner::p2wpkh_script_pubkey(&other_public_key).unwrap();
-
-        let unsigned_tx = Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: vec![TxIn {
-                previous_output: OutPoint {
-                    txid: Txid::all_zeros(),
-                    vout: 0,
-                },
-                script_sig: ScriptBuf::new(),
-                sequence: Sequence::MAX,
-                witness: Witness::default(),
-            }],
-            output: vec![TxOut {
-                value: Amount::from_sat(40_000),
-                script_pubkey: foreign_script.clone(),
-            }],
-        };
-
-        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
-        psbt.inputs[0].witness_utxo = Some(TxOut {
-            value: Amount::from_sat(50_000),
-            script_pubkey: foreign_script,
-        });
-
-        let err = signer.sign_psbt(&privkey, &psbt.to_string()).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("does not contain any signable P2WPKH inputs"),
-            "unexpected error: {err}"
-        );
+        let result = evm_signer.sign_psbt(&privkey, psbt_bytes);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("not supported"));
     }
 }

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -79,6 +79,19 @@ pub trait ChainSigner: Send + Sync {
 
     /// Returns the default BIP-44 derivation path template for this chain.
     fn default_derivation_path(&self, index: u32) -> String;
+
+    /// Sign a PSBT (Partially Signed Bitcoin Transaction).
+    ///
+    /// Only supported for Bitcoin (returns an error for other chains).
+    /// The PSBT bytes should be raw binary, not base64-encoded.
+    ///
+    /// Returns the signed PSBT as raw bytes.
+    fn sign_psbt(&self, _private_key: &[u8], _psbt_bytes: &[u8]) -> Result<Vec<u8>, SignerError> {
+        Err(SignerError::InvalidTransaction(format!(
+            "PSBT signing is not supported for {}",
+            self.chain_type()
+        )))
+    }
 }
 
 /// Errors that can occur during signing operations.

--- a/readme/partials/cli-reference.md
+++ b/readme/partials/cli-reference.md
@@ -7,6 +7,7 @@
 | `ows wallet info` | Show vault path and supported chains |
 | `ows sign message` | Sign a message with chain-specific formatting |
 | `ows sign tx` | Sign a raw transaction |
+| `ows sign psbt` | Sign a Bitcoin PSBT |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
 | `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |

--- a/readme/templates/node.md
+++ b/readme/templates/node.md
@@ -41,6 +41,9 @@ ows sign message --wallet agent-treasury --chain evm --message "hello"
 
 # Sign a transaction
 ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
+
+# Sign a Bitcoin PSBT
+ows sign psbt --wallet agent-treasury --psbt "cHNidP8BA..."
 ```
 
 {{> supported-chains}}

--- a/readme/templates/python.md
+++ b/readme/templates/python.md
@@ -44,6 +44,7 @@ print(sig["signature"])
 | `sign_message(wallet, chain, message, passphrase?, encoding?, index?, vault_path?)` | Sign a message with chain-specific formatting |
 | `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, vault_path?)` | Sign EIP-712 typed data (EVM only) |
 | `sign_transaction(wallet, chain, tx_hex, passphrase?, index?, vault_path?)` | Sign a raw transaction |
+| `sign_psbt(wallet, psbt_base64, passphrase?, index?, vault_path?)` | Sign a Bitcoin PSBT |
 | `sign_and_send(wallet, chain, tx_hex, passphrase?, index?, rpc_url?, vault_path?)` | Sign and broadcast a transaction |
 | `generate_mnemonic(words?)` | Generate a BIP-39 mnemonic phrase |
 | `derive_address(mnemonic, chain, index?)` | Derive an address from a mnemonic |


### PR DESCRIPTION
## Summary

This PR implements the Bitcoin L1 PSBT signing slice of #99 without overlapping the existing Stacks work.

It adds:
- owner-mode Bitcoin PSBT signing for native SegWit P2WPKH inputs
- `ows sign psbt` in the CLI
- `signPsbt` in the Node SDK
- `sign_psbt` in the Python SDK
- regression tests and docs for the new flow

API-token PSBT signing is intentionally not included in this pass.

## Verification

- `cargo test -p ows-signer bitcoin::tests::test_sign_psbt_p2wpkh_input -- --nocapture`
- `cargo test -p ows-signer bitcoin::tests::test_sign_psbt_rejects_foreign_input -- --nocapture`
- `cargo test -p ows-lib privkey_wallet_sign_psbt -- --nocapture`
- `cargo test -p ows-cli -- --nocapture`
- `cargo check` in `bindings/node`
- `cargo check` in `bindings/python`
- `./readme/generate.sh --check`

Partially addresses #99
