### PR TITLE
feat: add initia chain support

### DIFF
--- a/bindings/node/__test__/index.spec.mjs
+++ b/bindings/node/__test__/index.spec.mjs
@@ -51,7 +51,7 @@ describe('@open-wallet-standard/core', () => {
 
   it('derives addresses for all chains', () => {
     const phrase = generateMnemonic(12);
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin']) {
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'initia', 'tron', 'ton', 'filecoin']) {
       const addr = deriveAddress(phrase, chain);
       assert.ok(addr.length > 0, `address should be non-empty for ${chain}`);
     }
@@ -59,10 +59,10 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Universal wallet lifecycle ----
 
-  it('creates a universal wallet with 8 accounts', () => {
+  it('creates a universal wallet with 9 accounts', () => {
     const wallet = createWallet('lifecycle-test', undefined, 12, vaultDir);
     assert.equal(wallet.name, 'lifecycle-test');
-    assert.equal(wallet.accounts.length, 8);
+    assert.equal(wallet.accounts.length, 9);
 
     const chainIds = wallet.accounts.map((a) => a.chainId);
     assert.ok(chainIds.some((c) => c.startsWith('eip155:')));
@@ -70,6 +70,7 @@ describe('@open-wallet-standard/core', () => {
     assert.ok(chainIds.some((c) => c.startsWith('sui:')));
     assert.ok(chainIds.some((c) => c.startsWith('bip122:')));
     assert.ok(chainIds.some((c) => c.startsWith('cosmos:')));
+    assert.ok(chainIds.some((c) => c.startsWith('initia:')));
     assert.ok(chainIds.some((c) => c.startsWith('tron:')));
     assert.ok(chainIds.some((c) => c.startsWith('ton:')));
     assert.ok(chainIds.some((c) => c.startsWith('fil:')));
@@ -106,7 +107,7 @@ describe('@open-wallet-standard/core', () => {
 
     const wallet = importWalletMnemonic('mn-import', phrase, undefined, undefined, vaultDir);
     assert.equal(wallet.name, 'mn-import');
-    assert.equal(wallet.accounts.length, 8);
+    assert.equal(wallet.accounts.length, 9);
 
     const evmAcct = wallet.accounts.find((a) => a.chainId.startsWith('eip155:'));
     assert.equal(evmAcct.address, expectedEvm);
@@ -119,12 +120,12 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Private key import (secp256k1) ----
 
-  it('imports a secp256k1 private key with all 8 accounts', () => {
+  it('imports a secp256k1 private key with all 9 accounts', () => {
     const privkey = '4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318';
     const wallet = importWalletPrivateKey('pk-secp', privkey, undefined, vaultDir, 'evm');
 
     assert.equal(wallet.name, 'pk-secp');
-    assert.equal(wallet.accounts.length, 8, 'should have all 8 chain accounts');
+    assert.equal(wallet.accounts.length, 9, 'should have all 9 chain accounts');
 
     // Sign on EVM (provided key's curve)
     const evmSig = signMessage('pk-secp', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
@@ -144,11 +145,11 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Private key import (ed25519) ----
 
-  it('imports an ed25519 private key with all 8 accounts', () => {
+  it('imports an ed25519 private key with all 9 accounts', () => {
     const privkey = '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60';
     const wallet = importWalletPrivateKey('pk-ed', privkey, undefined, vaultDir, 'solana');
 
-    assert.equal(wallet.accounts.length, 8);
+    assert.equal(wallet.accounts.length, 9);
 
     // Sign on Solana (provided key)
     const solSig = signMessage('pk-ed', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
@@ -176,7 +177,7 @@ describe('@open-wallet-standard/core', () => {
     );
 
     assert.equal(wallet.name, 'pk-both');
-    assert.equal(wallet.accounts.length, 8, 'should have all 8 chain accounts');
+    assert.equal(wallet.accounts.length, 9, 'should have all 9 chain accounts');
 
     // Sign on EVM (secp256k1 key)
     const evmSig = signMessage('pk-both', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
@@ -199,7 +200,7 @@ describe('@open-wallet-standard/core', () => {
   it('signs messages on all chains', () => {
     createWallet('all-chain-signer', undefined, 12, vaultDir);
 
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin']) {
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'initia', 'tron', 'ton', 'filecoin']) {
       const result = signMessage('all-chain-signer', chain, 'test', undefined, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);
     }
@@ -215,7 +216,7 @@ describe('@open-wallet-standard/core', () => {
     // Build a minimal tx with 1 sig slot (0x01) + 64 zero bytes + a message.
     const solTxHex = '01' + '00'.repeat(64) + 'deadbeefdeadbeef';
 
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin']) {
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'initia', 'tron', 'ton', 'filecoin']) {
       const hex = chain === 'solana' ? solTxHex : txHex;
       const result = signTransaction('tx-signer', chain, hex, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);

--- a/bindings/python/tests/test_bindings.py
+++ b/bindings/python/tests/test_bindings.py
@@ -40,7 +40,7 @@ def test_create_and_list_wallets(vault_dir):
     wallet = ows.create_wallet("test-wallet", vault_path_opt=vault_dir)
     assert wallet["name"] == "test-wallet"
     assert isinstance(wallet["accounts"], list)
-    assert len(wallet["accounts"]) == 8
+    assert len(wallet["accounts"]) == 9
 
     # Verify each chain family is present
     chain_ids = [a["chain_id"] for a in wallet["accounts"]]
@@ -49,6 +49,7 @@ def test_create_and_list_wallets(vault_dir):
     assert any(c.startswith("sui:") for c in chain_ids)
     assert any(c.startswith("bip122:") for c in chain_ids)
     assert any(c.startswith("cosmos:") for c in chain_ids)
+    assert any(c.startswith("initia:") for c in chain_ids)
     assert any(c.startswith("tron:") for c in chain_ids)
     assert any(c.startswith("ton:") for c in chain_ids)
     assert any(c.startswith("fil:") for c in chain_ids)
@@ -98,7 +99,7 @@ def test_import_wallet_mnemonic(vault_dir):
         "imported", phrase, vault_path_opt=vault_dir
     )
     assert wallet["name"] == "imported"
-    assert len(wallet["accounts"]) == 8
+    assert len(wallet["accounts"]) == 9
 
     # EVM account should match derived address
     evm_account = next(a for a in wallet["accounts"] if a["chain_id"].startswith("eip155:"))

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -138,7 +138,7 @@ enum WalletCommands {
 enum SignCommands {
     /// Sign a message with chain-specific formatting (EIP-191, Bitcoin message signing, etc.)
     Message {
-        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
+        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, initia, or CAIP-2 ID)
         #[arg(long)]
         chain: String,
         /// Wallet name or ID (uses stored encrypted mnemonic)
@@ -162,7 +162,7 @@ enum SignCommands {
     },
     /// Sign a transaction (accepts hex-encoded unsigned transaction bytes)
     Tx {
-        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
+        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, initia, or CAIP-2 ID)
         #[arg(long)]
         chain: String,
         /// Wallet name or ID (uses stored encrypted mnemonic)
@@ -180,7 +180,7 @@ enum SignCommands {
     },
     /// Sign and broadcast a transaction
     SendTx {
-        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID)
+        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, initia, or CAIP-2 ID)
         #[arg(long)]
         chain: String,
         /// Wallet name or ID (uses stored encrypted mnemonic)
@@ -211,7 +211,7 @@ enum MnemonicCommands {
     },
     /// Derive an address from a mnemonic (reads from OWS_MNEMONIC env or stdin)
     Derive {
-        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, or CAIP-2 ID). If omitted, derives all chains.
+        /// Chain (ethereum, plasma, arbitrum, solana, bitcoin, cosmos, tron, initia, or CAIP-2 ID). If omitted, derives all chains.
         #[arg(long)]
         chain: Option<String>,
         /// Account index

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -14,10 +14,11 @@ pub enum ChainType {
     Spark,
     Filecoin,
     Sui,
+    Initia,
 }
 
 /// All supported chain families, used for universal wallet derivation.
-pub const ALL_CHAIN_TYPES: [ChainType; 8] = [
+pub const ALL_CHAIN_TYPES: [ChainType; 9] = [
     ChainType::Evm,
     ChainType::Solana,
     ChainType::Bitcoin,
@@ -26,6 +27,7 @@ pub const ALL_CHAIN_TYPES: [ChainType; 8] = [
     ChainType::Ton,
     ChainType::Filecoin,
     ChainType::Sui,
+    ChainType::Initia,
 ];
 
 /// A specific chain (e.g. "ethereum", "arbitrum") with its family type and CAIP-2 ID.
@@ -118,6 +120,11 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_type: ChainType::Sui,
         chain_id: "sui:mainnet",
     },
+    Chain {
+        name: "initia",
+        chain_type: ChainType::Initia,
+        chain_id: "initia:interwoven-1",
+    },
 ];
 
 /// Parse a chain string into a `Chain`. Accepts:
@@ -182,6 +189,7 @@ impl ChainType {
             ChainType::Spark => "spark",
             ChainType::Filecoin => "fil",
             ChainType::Sui => "sui",
+            ChainType::Initia => "initia",
         }
     }
 
@@ -197,6 +205,7 @@ impl ChainType {
             ChainType::Spark => 8797555,
             ChainType::Filecoin => 461,
             ChainType::Sui => 784,
+            ChainType::Initia => 60,
         }
     }
 
@@ -212,6 +221,7 @@ impl ChainType {
             "spark" => Some(ChainType::Spark),
             "fil" => Some(ChainType::Filecoin),
             "sui" => Some(ChainType::Sui),
+            "initia" => Some(ChainType::Initia),
             _ => None,
         }
     }
@@ -229,6 +239,7 @@ impl fmt::Display for ChainType {
             ChainType::Spark => "spark",
             ChainType::Filecoin => "filecoin",
             ChainType::Sui => "sui",
+            ChainType::Initia => "initia",
         };
         write!(f, "{}", s)
     }
@@ -248,6 +259,7 @@ impl FromStr for ChainType {
             "spark" => Ok(ChainType::Spark),
             "filecoin" => Ok(ChainType::Filecoin),
             "sui" => Ok(ChainType::Sui),
+            "initia" => Ok(ChainType::Initia),
             _ => Err(format!("unknown chain type: {}", s)),
         }
     }
@@ -278,6 +290,7 @@ mod tests {
             (ChainType::Spark, "\"spark\""),
             (ChainType::Filecoin, "\"filecoin\""),
             (ChainType::Sui, "\"sui\""),
+            (ChainType::Initia, "\"initia\""),
         ] {
             let json = serde_json::to_string(&chain).unwrap();
             assert_eq!(json, expected);
@@ -297,6 +310,7 @@ mod tests {
         assert_eq!(ChainType::Spark.namespace(), "spark");
         assert_eq!(ChainType::Filecoin.namespace(), "fil");
         assert_eq!(ChainType::Sui.namespace(), "sui");
+        assert_eq!(ChainType::Initia.namespace(), "initia");
     }
 
     #[test]
@@ -310,6 +324,7 @@ mod tests {
         assert_eq!(ChainType::Spark.default_coin_type(), 8797555);
         assert_eq!(ChainType::Filecoin.default_coin_type(), 461);
         assert_eq!(ChainType::Sui.default_coin_type(), 784);
+        assert_eq!(ChainType::Initia.default_coin_type(), 60);
     }
 
     #[test]
@@ -326,6 +341,7 @@ mod tests {
         assert_eq!(ChainType::from_namespace("spark"), Some(ChainType::Spark));
         assert_eq!(ChainType::from_namespace("fil"), Some(ChainType::Filecoin));
         assert_eq!(ChainType::from_namespace("sui"), Some(ChainType::Sui));
+        assert_eq!(ChainType::from_namespace("initia"), Some(ChainType::Initia));
         assert_eq!(ChainType::from_namespace("unknown"), None);
     }
 
@@ -401,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_all_chain_types() {
-        assert_eq!(ALL_CHAIN_TYPES.len(), 8);
+        assert_eq!(ALL_CHAIN_TYPES.len(), 9);
     }
 
     #[test]

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -54,6 +54,10 @@ impl Config {
             "cosmos:cosmoshub-4".into(),
             "https://cosmos-rest.publicnode.com".into(),
         );
+        rpc.insert(
+            "initia:interwoven-1".into(),
+            "https://rpc.initia.xyz".into(),
+        );
         rpc.insert("tron:mainnet".into(), "https://api.trongrid.io".into());
         rpc.insert("ton:mainnet".into(), "https://toncenter.com/api/v2".into());
         rpc.insert(
@@ -195,6 +199,10 @@ mod tests {
             Some("https://cosmos-rest.publicnode.com")
         );
         assert_eq!(
+            config.rpc_url("initia:interwoven-1"),
+            Some("https://rpc.initia.xyz")
+        );
+        assert_eq!(
             config.rpc_url("tron:mainnet"),
             Some("https://api.trongrid.io")
         );
@@ -244,7 +252,7 @@ mod tests {
     fn test_load_or_default_nonexistent() {
         let config = Config::load_or_default_from(std::path::Path::new("/nonexistent/config.json"));
         // Should have all default RPCs
-        assert_eq!(config.rpc.len(), 15);
+        assert_eq!(config.rpc.len(), 16);
         assert_eq!(config.rpc_url("eip155:1"), Some("https://eth.llamarpc.com"));
     }
 

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -689,6 +689,7 @@ fn broadcast(chain: ChainType, rpc_url: &str, signed_bytes: &[u8]) -> Result<Str
             "broadcast not yet supported for Filecoin".into(),
         )),
         ChainType::Sui => broadcast_sui(rpc_url, signed_bytes),
+        ChainType::Initia => broadcast_cosmos(rpc_url, signed_bytes),
     }
 }
 
@@ -925,7 +926,9 @@ mod tests {
     #[test]
     fn derive_address_all_chains() {
         let phrase = generate_mnemonic(12).unwrap();
-        let chains = ["evm", "solana", "bitcoin", "cosmos", "tron", "ton", "sui"];
+        let chains = [
+            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "sui", "initia",
+        ];
         for chain in &chains {
             let addr = derive_address(&phrase, chain, None).unwrap();
             assert!(!addr.is_empty(), "address should be non-empty for {chain}");
@@ -1006,7 +1009,7 @@ mod tests {
         create_wallet("multi-sign", None, None, Some(vault)).unwrap();
 
         let chains = [
-            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui",
+            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "initia",
         ];
         for chain in &chains {
             let result = sign_message(
@@ -1046,7 +1049,7 @@ mod tests {
         let solana_tx_hex = hex::encode(&solana_tx);
 
         let chains = [
-            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui",
+            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "initia",
         ];
         for chain in &chains {
             let tx = if *chain == "solana" {

--- a/ows/crates/ows-signer/src/chains/initia.rs
+++ b/ows/crates/ows-signer/src/chains/initia.rs
@@ -1,0 +1,188 @@
+use crate::curve::Curve;
+use crate::traits::{ChainSigner, SignOutput, SignerError};
+use k256::ecdsa::SigningKey;
+use ows_core::ChainType;
+use sha2::{Digest as Sha2Digest, Sha256};
+use sha3::Keccak256;
+
+pub struct InitiaSigner {
+    hrp: String,
+}
+
+impl InitiaSigner {
+    pub fn new(hrp: &str) -> Self {
+        InitiaSigner {
+            hrp: hrp.to_string(),
+        }
+    }
+
+    pub fn mainnet() -> Self {
+        Self::new("init")
+    }
+
+    fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
+        SigningKey::from_slice(private_key)
+            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+    }
+}
+
+impl ChainSigner for InitiaSigner {
+    fn chain_type(&self) -> ChainType {
+        ChainType::Initia
+    }
+
+    fn curve(&self) -> Curve {
+        Curve::Secp256k1
+    }
+
+    fn coin_type(&self) -> u32 {
+        60
+    }
+
+    fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+
+        let pubkey_bytes = verifying_key.to_encoded_point(false);
+        let pubkey_uncompressed = pubkey_bytes.as_bytes();
+
+        let hash = Keccak256::digest(&pubkey_uncompressed[1..]);
+        let address_bytes = &hash[12..];
+
+        let hrp = bech32::Hrp::parse(&self.hrp)
+            .map_err(|e| SignerError::AddressDerivationFailed(e.to_string()))?;
+        let address = bech32::encode::<bech32::Bech32>(hrp, address_bytes)
+            .map_err(|e| SignerError::AddressDerivationFailed(e.to_string()))?;
+
+        Ok(address)
+    }
+
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        if message.len() != 32 {
+            return Err(SignerError::InvalidMessage(format!(
+                "expected 32-byte hash, got {} bytes",
+                message.len()
+            )));
+        }
+
+        let signing_key = Self::signing_key(private_key)?;
+        let (signature, recovery_id) = signing_key
+            .sign_prehash_recoverable(message)
+            .map_err(|e| SignerError::SigningFailed(e.to_string()))?;
+
+        let mut sig_bytes = signature.to_bytes().to_vec();
+        sig_bytes.push(recovery_id.to_byte());
+
+        Ok(SignOutput {
+            signature: sig_bytes,
+            recovery_id: Some(recovery_id.to_byte()),
+            public_key: None,
+        })
+    }
+
+    fn sign_transaction(
+        &self,
+        private_key: &[u8],
+        tx_bytes: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        let hash = Sha256::digest(tx_bytes);
+        self.sign(private_key, &hash)
+    }
+
+    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        let hash = Sha256::digest(message);
+        self.sign(private_key, &hash)
+    }
+
+    fn default_derivation_path(&self, index: u32) -> String {
+        format!("m/44'/60'/0'/0/{}", index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_privkey() -> Vec<u8> {
+        hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318").unwrap()
+    }
+
+    #[test]
+    fn test_address_derivation() {
+        let signer = InitiaSigner::mainnet();
+        let address = signer.derive_address(&test_privkey()).unwrap();
+        assert!(address.starts_with("init1"));
+
+        // Same private key as EVM test — the raw 20-byte address should match
+        // EVM: 0x2c7536E3605D9C16a7a3D7b1898e529396a65c23
+        // Initia: bech32("init", 0x2c7536e3605d9c16a7a3d7b1898e529396a65c23)
+        let (_, addr_bytes) = bech32::decode(&address).unwrap();
+        let expected_bytes = hex::decode("2c7536e3605d9c16a7a3d7b1898e529396a65c23").unwrap();
+        assert_eq!(addr_bytes, expected_bytes);
+    }
+
+    #[test]
+    fn test_sign_roundtrip() {
+        let signer = InitiaSigner::mainnet();
+        let hash = Sha256::digest(b"test message");
+        let result = signer.sign(&test_privkey(), &hash).unwrap();
+
+        assert_eq!(result.signature.len(), 65);
+        assert!(result.recovery_id.is_some());
+
+        let signing_key = SigningKey::from_slice(&test_privkey()).unwrap();
+        let verifying_key = signing_key.verifying_key();
+        let r_bytes: [u8; 32] = result.signature[..32].try_into().unwrap();
+        let s_bytes: [u8; 32] = result.signature[32..64].try_into().unwrap();
+        let sig = k256::ecdsa::Signature::from_scalars(r_bytes, s_bytes).unwrap();
+
+        use k256::ecdsa::signature::hazmat::PrehashVerifier;
+        verifying_key
+            .verify_prehash(&hash, &sig)
+            .expect("signature should verify");
+    }
+
+    #[test]
+    fn test_derivation_path() {
+        let signer = InitiaSigner::mainnet();
+        assert_eq!(signer.default_derivation_path(0), "m/44'/60'/0'/0/0");
+        assert_eq!(signer.default_derivation_path(3), "m/44'/60'/0'/0/3");
+    }
+
+    #[test]
+    fn test_chain_properties() {
+        let signer = InitiaSigner::mainnet();
+        assert_eq!(signer.chain_type(), ChainType::Initia);
+        assert_eq!(signer.curve(), Curve::Secp256k1);
+        assert_eq!(signer.coin_type(), 60);
+    }
+
+    #[test]
+    fn test_deterministic() {
+        let signer = InitiaSigner::mainnet();
+        let addr1 = signer.derive_address(&test_privkey()).unwrap();
+        let addr2 = signer.derive_address(&test_privkey()).unwrap();
+        assert_eq!(addr1, addr2);
+    }
+
+    #[test]
+    fn test_invalid_key_rejection() {
+        let signer = InitiaSigner::mainnet();
+        let bad_key = vec![0u8; 16];
+        assert!(signer.derive_address(&bad_key).is_err());
+    }
+
+    #[test]
+    fn test_custom_hrp() {
+        let signer = InitiaSigner::new("custom");
+        let address = signer.derive_address(&test_privkey()).unwrap();
+        assert!(address.starts_with("custom1"));
+
+        let mainnet_signer = InitiaSigner::mainnet();
+        let mainnet_addr = mainnet_signer.derive_address(&test_privkey()).unwrap();
+
+        let (_, custom_bytes) = bech32::decode(&address).unwrap();
+        let (_, mainnet_bytes) = bech32::decode(&mainnet_addr).unwrap();
+        assert_eq!(custom_bytes, mainnet_bytes);
+    }
+}

--- a/ows/crates/ows-signer/src/chains/mod.rs
+++ b/ows/crates/ows-signer/src/chains/mod.rs
@@ -2,6 +2,7 @@ pub mod bitcoin;
 pub mod cosmos;
 pub mod evm;
 pub mod filecoin;
+pub mod initia;
 pub mod solana;
 pub mod spark;
 pub mod sui;
@@ -12,6 +13,7 @@ pub use self::bitcoin::BitcoinSigner;
 pub use self::cosmos::CosmosSigner;
 pub use self::evm::EvmSigner;
 pub use self::filecoin::FilecoinSigner;
+pub use self::initia::InitiaSigner;
 pub use self::solana::SolanaSigner;
 pub use self::spark::SparkSigner;
 pub use self::sui::SuiSigner;
@@ -33,5 +35,6 @@ pub fn signer_for_chain(chain: ChainType) -> Box<dyn ChainSigner> {
         ChainType::Spark => Box::new(SparkSigner),
         ChainType::Filecoin => Box::new(FilecoinSigner),
         ChainType::Sui => Box::new(SuiSigner),
+        ChainType::Initia => Box::new(InitiaSigner::mainnet()),
     }
 }

--- a/ows/crates/ows-signer/src/lib.rs
+++ b/ows/crates/ows-signer/src/lib.rs
@@ -124,6 +124,17 @@ mod integration_tests {
     }
 
     #[test]
+    fn test_full_pipeline_initia() {
+        let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
+        let address = derive_address_for_chain(&mnemonic, ChainType::Initia);
+        assert!(
+            address.starts_with("init1"),
+            "Initia address should start with init1, got: {}",
+            address
+        );
+    }
+
+    #[test]
     fn test_spark_uses_bitcoin_derivation_path() {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
         let btc_signer = signer_for_chain(ChainType::Bitcoin);
@@ -165,6 +176,7 @@ mod integration_tests {
         let ton_addr = derive_address_for_chain(&mnemonic, ChainType::Ton);
         let spark_addr = derive_address_for_chain(&mnemonic, ChainType::Spark);
         let fil_addr = derive_address_for_chain(&mnemonic, ChainType::Filecoin);
+        let initia_addr = derive_address_for_chain(&mnemonic, ChainType::Initia);
 
         // All addresses should be different
         let addrs = [
@@ -176,6 +188,7 @@ mod integration_tests {
             &ton_addr,
             &spark_addr,
             &fil_addr,
+            &initia_addr,
         ];
         for i in 0..addrs.len() {
             for j in (i + 1)..addrs.len() {
@@ -203,6 +216,7 @@ mod integration_tests {
             ChainType::Tron,
             ChainType::Spark,
             ChainType::Filecoin,
+            ChainType::Initia,
         ] {
             let signer = signer_for_chain(chain);
             let path = signer.default_derivation_path(0);
@@ -245,6 +259,7 @@ mod integration_tests {
             ChainType::Ton,
             ChainType::Spark,
             ChainType::Filecoin,
+            ChainType::Initia,
         ] {
             let signer = signer_for_chain(chain);
             assert_eq!(signer.chain_type(), chain);


### PR DESCRIPTION
## What

This PR adds [Initia](https://initia.xyz) mainnet as a supported chain across the core registry, signer registry, library operations, and CLI help text.

It introduces a dedicated `InitiaSigner`, registers `initia:interwoven-1` in the chain registry, wires Initia through the signer factory and library broadcast dispatch, and updates the CLI `--chain` help text so the exposed user interface matches the supported chain set.

## Why

Without this change, Initia is not available as a first-class chain in OWS even though its signing and address format fit the existing secp256k1-based chain model.

Users need to be able to derive Initia addresses, create wallets that include Initia accounts, sign Initia messages and transactions, and see Initia reflected in the CLI help output. The missing support meant the chain could not be selected consistently through the normal OWS flows.

Closes #

## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `npm test` passes (if Node bindings changed)
- [x] Tested manually with `ows` CLI

## Notes

Python bindings were also updated for the added Initia account coverage and passed locally with `maturin develop --features fast-kdf && pytest`.

Local Python validation was run on Python 3.14 with `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`; CI still runs the binding job on Python 3.12.
