### PR TITLE
chore: add x402 v2 integration tests

### DIFF
--- a/ows/crates/ows-pay/src/types.rs
+++ b/ows/crates/ows-pay/src/types.rs
@@ -90,16 +90,20 @@ pub struct PaymentRequirements {
     pub pay_to: String,
     #[serde(default = "default_timeout")]
     pub max_timeout_seconds: u64,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_json_null")]
     pub extra: serde_json::Value,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource: Option<String>,
 }
 
 fn default_timeout() -> u64 {
     30
+}
+
+fn is_json_null(value: &serde_json::Value) -> bool {
+    value.is_null()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ows/crates/ows-pay/src/x402.rs
+++ b/ows/crates/ows-pay/src/x402.rs
@@ -236,6 +236,18 @@ fn parse_requirements(
 /// Payment schemes we know how to handle.
 const SUPPORTED_SCHEMES: &[&str] = &["exact"];
 
+fn is_gateway_batched(req: &PaymentRequirements) -> bool {
+    req.extra
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(|name| name == "GatewayWalletBatched")
+        .unwrap_or(false)
+}
+
+fn parsed_amount(req: &PaymentRequirements) -> Option<u128> {
+    req.amount.parse().ok()
+}
+
 /// Pick the first payment option whose scheme we support and whose
 /// network the wallet supports. Returns the requirement and its
 /// resolved CAIP-2 network string.
@@ -244,9 +256,16 @@ fn pick_payment_option<'a>(
     requirements: &'a [PaymentRequirements],
 ) -> Result<(&'a PaymentRequirements, String), PayError> {
     let supported = wallet.supported_chains();
+    let mut candidates = Vec::new();
 
     for req in requirements {
         if !SUPPORTED_SCHEMES.contains(&req.scheme.as_str()) {
+            continue;
+        }
+
+        // GatewayWalletBatched requires a pre-funded gateway wallet, which
+        // this client does not currently manage.
+        if is_gateway_batched(req) {
             continue;
         }
 
@@ -265,7 +284,28 @@ fn pick_payment_option<'a>(
             Err(_) => req.network.clone(), // Already CAIP-2 (unknown to registry but namespace matched).
         };
 
-        return Ok((req, network));
+        candidates.push((req, network));
+    }
+
+    if let Some((_, first_network)) = candidates.first() {
+        let mut best = &candidates[0];
+        for candidate in candidates.iter().skip(1) {
+            if candidate.1 != *first_network {
+                break;
+            }
+
+            let current = parsed_amount(candidate.0);
+            let best_amount = parsed_amount(best.0);
+            if current
+                .zip(best_amount)
+                .map(|(a, b)| a < b)
+                .unwrap_or(false)
+            {
+                best = candidate;
+            }
+        }
+
+        return Ok((best.0, best.1.clone()));
     }
 
     let networks: Vec<_> = requirements.iter().map(|r| r.network.as_str()).collect();
@@ -777,6 +817,35 @@ mod tests {
     }
 
     #[test]
+    fn pick_prefers_cheapest_option_within_first_supported_network() {
+        let expensive = base_requirement();
+        let mut cheap = base_requirement();
+        cheap.amount = "1000".into();
+        let reqs = [expensive, cheap];
+        let (req, network) = pick_payment_option(&EvmWallet, &reqs).unwrap();
+        assert_eq!(network, "eip155:8453");
+        assert_eq!(req.amount, "1000");
+    }
+
+    #[test]
+    fn pick_skips_gateway_batched_offer() {
+        let mut gateway = base_requirement();
+        gateway.amount = "100".into();
+        gateway.extra = serde_json::json!({
+            "name": "GatewayWalletBatched",
+            "version": "1"
+        });
+
+        let mut regular = base_requirement();
+        regular.amount = "1000".into();
+
+        let reqs = [gateway, regular];
+        let (req, _) = pick_payment_option(&EvmWallet, &reqs).unwrap();
+        assert_eq!(req.amount, "1000");
+        assert_eq!(req.extra["name"], "USD Coin");
+    }
+
+    #[test]
     fn pick_unknown_namespace_errors() {
         let mut req = base_requirement();
         req.network = "foochain:1".into();
@@ -871,6 +940,22 @@ mod tests {
         };
         assert_eq!(v2.x402_version, 2);
         assert!(v2.resource.is_none());
+    }
+
+    #[test]
+    fn build_evm_exact_v2_omits_null_requirement_fields() {
+        let mut req = base_requirement();
+        req.extra = serde_json::Value::Null;
+        req.description = None;
+        req.resource = None;
+
+        let (payload, _) = build_evm_exact(&EvmWallet, &req, "eip155:8453", 2, None).unwrap();
+        let encoded = serde_json::to_value(payload).unwrap();
+        let accepted = &encoded["accepted"];
+
+        assert!(accepted.get("extra").is_none());
+        assert!(accepted.get("description").is_none());
+        assert!(accepted.get("resource").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix version inference in `parse_requirements`: when the `payment-required` (v2) header is used without an explicit `x402Version` field, default to version 2 instead of 1
- Add unit tests validating v2 header version defaulting and v2 payload construction
- Add integration tests (`pay_retries_v1_flow_with_v1_payload`, `pay_retries_v2_flow_with_v2_payload_without_explicit_version`) that spin up a local TCP server to verify the full 402 -> retry flow sends the correct payload version and headers for both v1 and v2 paths
- Tighten requirement selection so the client skips unsupported gateway-batched offers and prefers the cheapest compatible option within the first supported network
- Omit null optional fields from serialized v2 `accepted` requirements to better match live provider payload expectations

## Live Provider Matrix
Successful end-to-end validations below were run with the local repo build via `cargo run -q -p ows-cli -- ...`, not the globally installed `ows` binary.

| Provider | Endpoint | Protocol | Result |
| --- | --- | --- | --- |
| Elfa | `/x402/v2/aggregations/trending-tokens?timeWindow=24h` | v2 | Success, paid `0.009 USDC`, returned live JSON |
| Elfa | `/x402/v2/data/keyword-mentions?keywords=bitcoin&timeWindow=24h` | v2 | Success, paid `0.009 USDC`, returned live JSON |
| x402engine | `/api/crypto/price?ids=bitcoin` | v2 | Success, paid `0.001 USDC`, returned live JSON |
| x402engine | `/api/crypto/trending` | v2 | Success, paid `0.001 USDC`, returned live JSON |
| Heurist | `/x402/agents/EtherscanAgent/get_address_history` | v1 | Success, paid `0.01 USDC`, returned live JSON |
| QuickNode | `/base` | v2 | 402 after retry, provider returned `Unexpected error verifying payment` |
| x402-next | `/protected` | v1 | 500 after payment, provider returned `Failed to verify payment: Bad Request` |
| CodeNut | `/credit-drop/xs` | v1 | 500 after payment, provider returned `Payment verification failed` |
| Pinata | `/v1/retrieve/private/...` | v2 | 401 after payment |
| Heurist | `/x402/agents/ElfaTwitterIntelligenceAgent/search_mentions` | v1 | 500 after payment |

## Test plan
- [x] `cargo test -p ows-pay`
- [x] `parse_requirements_v2_header_defaults_version_to_2`
- [x] `v2_header_without_version_builds_v2_payment_payload`
- [x] `pay_retries_v1_flow_with_v1_payload`
- [x] `pay_retries_v2_flow_with_v2_payload_without_explicit_version`
- [x] `pick_prefers_cheapest_option_within_first_supported_network`
- [x] `pick_skips_gateway_batched_offer`
- [x] `build_evm_exact_v2_omits_null_requirement_fields`
- [x] Live v2 success against Elfa
- [x] Live v2 success against x402engine
- [x] Live v1 success against Heurist

🤖 Generated with [Claude Code](https://claude.com/claude-code)