### PR TITLE
chore: bump version to 1.1.2

### DIFF
--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -1116,7 +1116,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-core"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "serde",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "ows-node"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "napi",
  "napi-build",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-node"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "Node.js native bindings for the Open Wallet Standard"
 

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-darwin-arm64",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "os": [
     "darwin"
   ],

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-darwin-x64",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "os": [
     "darwin"
   ],

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-linux-arm64-gnu",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "os": [
     "linux"
   ],

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-linux-x64-gnu",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "os": [
     "linux"
   ],

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-wallet-standard/core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-wallet-standard/core",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "bin": {
         "ows": "bin/ows"

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Node.js native bindings for the Open Wallet Standard",
   "main": "index.js",
   "types": "index.d.ts",
@@ -31,10 +31,10 @@
     "@napi-rs/cli": "^2.18.0"
   },
   "optionalDependencies": {
-    "@open-wallet-standard/core-linux-x64-gnu": "1.1.1",
-    "@open-wallet-standard/core-linux-arm64-gnu": "1.1.1",
-    "@open-wallet-standard/core-darwin-x64": "1.1.1",
-    "@open-wallet-standard/core-darwin-arm64": "1.1.1"
+    "@open-wallet-standard/core-linux-x64-gnu": "1.1.2",
+    "@open-wallet-standard/core-linux-arm64-gnu": "1.1.2",
+    "@open-wallet-standard/core-darwin-x64": "1.1.2",
+    "@open-wallet-standard/core-darwin-arm64": "1.1.2"
   },
   "license": "MIT",
   "files": [

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1037,7 +1037,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-core"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "serde",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "ows-python"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "ows-core",
  "ows-lib",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-python"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "Python native bindings for the Open Wallet Standard"
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "open-wallet-standard"
-version = "1.1.1"
+version = "1.1.2"
 description = "Python native bindings for the Open Wallet Standard"
 requires-python = ">=3.8"
 license = { text = "MIT" }

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -1319,7 +1319,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-cli"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "ows-core"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "serde",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "ows-pay"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/ows/crates/ows-cli/Cargo.toml
+++ b/ows/crates/ows-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-cli"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "MIT"
 description = "CLI for the Open Wallet Standard"
@@ -12,9 +12,9 @@ name = "ows"
 path = "src/main.rs"
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=1.1.1" }
-ows-signer = { path = "../ows-signer", version = "=1.1.1" }
-ows-lib = { path = "../ows-lib", version = "=1.1.1" }
+ows-core = { path = "../ows-core", version = "=1.1.2" }
+ows-signer = { path = "../ows-signer", version = "=1.1.2" }
+ows-lib = { path = "../ows-lib", version = "=1.1.2" }
 clap = { version = "4", features = ["derive", "env"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -25,8 +25,8 @@ tempfile = "3"
 rpassword = "7"
 serde = { version = "1", features = ["derive"] }
 zeroize = "1"
-ows-pay = { path = "../ows-pay", version = "=1.1.1" }
+ows-pay = { path = "../ows-pay", version = "=1.1.2" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
-ows-signer = { path = "../ows-signer", version = "=1.1.1", features = ["fast-kdf"] }
+ows-signer = { path = "../ows-signer", version = "=1.1.2", features = ["fast-kdf"] }

--- a/ows/crates/ows-core/Cargo.toml
+++ b/ows/crates/ows-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-core"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "MIT"
 description = "Core types and traits for the Open Wallet Standard"

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-lib"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "MIT"
 description = "High-level library API for the Open Wallet Standard"
@@ -12,8 +12,8 @@ default = []
 fast-kdf = ["ows-signer/fast-kdf"]
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=1.1.1" }
-ows-signer = { path = "../ows-signer", version = "=1.1.1" }
+ows-core = { path = "../ows-core", version = "=1.1.2" }
+ows-signer = { path = "../ows-signer", version = "=1.1.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -35,4 +35,4 @@ sha3 = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"] }
 ed25519-dalek = "2"
 bs58 = "0.5"
-ows-signer = { path = "../ows-signer", version = "=1.1.1", features = ["fast-kdf"] }
+ows-signer = { path = "../ows-signer", version = "=1.1.2", features = ["fast-kdf"] }

--- a/ows/crates/ows-pay/Cargo.toml
+++ b/ows/crates/ows-pay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-pay"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "MIT"
 description = "Payment client for the Open Wallet Standard (x402)"
@@ -8,7 +8,7 @@ repository = "https://github.com/open-wallet-standard/core"
 
 [dependencies]
 # Core types (ChainType, parse_chain, etc.)
-ows-core = { path = "../ows-core", version = "=1.1.1" }
+ows-core = { path = "../ows-core", version = "=1.1.2" }
 
 # HTTP
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-signer"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "MIT"
 description = "Cryptographic signing and key management for the Open Wallet Standard"
@@ -12,7 +12,7 @@ default = []
 fast-kdf = []
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=1.1.1" }
+ows-core = { path = "../ows-core", version = "=1.1.2" }
 k256 = { version = "0.13", features = ["ecdsa", "arithmetic"] }
 ed25519-dalek = { version = "2", features = ["hazmat"] }
 coins-bip32 = "0.11"

--- a/skills/ows/SKILL.md
+++ b/skills/ows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ows
 description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin via CLI, Node.js, or Python.
-version: 1.1.1
+version: 1.1.2
 metadata:
   openclaw:
     requires:

--- a/website-docs/index.html
+++ b/website-docs/index.html
@@ -43,7 +43,7 @@
     </aside>
 
     <main class="docs-content">
-      <h1>Open Wallet Standard v1.1.1</h1>
+      <h1>Open Wallet Standard v1.1.2</h1>
       <p class="subtitle">An open standard for local wallet storage, delegated agent access, and policy-gated signing.</p>
 
       <h2>Abstract</h2>


### PR DESCRIPTION
## Summary

Automated version bump to `1.1.2` triggered by tag [`v1.1.2`](https://github.com/open-wallet-standard/core/releases/tag/v1.1.2).

### Changes
- Rust crate versions (`Cargo.toml`)
- Python binding version (`pyproject.toml`, `Cargo.toml`)
- Node binding version (`package.json`, `Cargo.toml`, platform packages)
- Skill manifest version (`SKILL.md`)
- Docs site version badge and heading (`website-docs/`)
- Regenerated READMEs