### PR TITLE
refactor: Generalize funding target resolution

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -74,7 +74,7 @@ ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
 | `ows sign tx` | Sign a raw transaction |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
-| `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |
+| `ows fund deposit` | Create a funding deposit (default provider: MoonPay) to fund a wallet with USDC |
 | `ows fund balance` | Check token balances for a wallet |
 | `ows mnemonic generate` | Generate a BIP-39 mnemonic phrase |
 | `ows mnemonic derive` | Derive an address from a mnemonic |

--- a/ows/README.md
+++ b/ows/README.md
@@ -31,7 +31,7 @@ cargo build --workspace --release
 | `ows sign tx` | Sign a raw transaction |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
-| `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |
+| `ows fund deposit` | Create a funding deposit (default provider: MoonPay) to fund a wallet with USDC |
 | `ows fund balance` | Check token balances for a wallet |
 | `ows mnemonic generate` | Generate a BIP-39 mnemonic phrase |
 | `ows mnemonic derive` | Derive an address from a mnemonic |

--- a/ows/crates/ows-cli/README.md
+++ b/ows/crates/ows-cli/README.md
@@ -31,7 +31,7 @@ cargo build --workspace --release
 | `ows sign tx` | Sign a raw transaction |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
-| `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |
+| `ows fund deposit` | Create a funding deposit (default provider: MoonPay) to fund a wallet with USDC |
 | `ows fund balance` | Check token balances for a wallet |
 | `ows mnemonic generate` | Generate a BIP-39 mnemonic phrase |
 | `ows mnemonic derive` | Derive an address from a mnemonic |

--- a/ows/crates/ows-cli/src/commands/fund.rs
+++ b/ows/crates/ows-cli/src/commands/fund.rs
@@ -1,5 +1,5 @@
 use crate::CliError;
-use ows_pay::{FundProvider, FundRequest};
+use ows_pay::{FundProvider, FundRequest, WalletAccountRef};
 
 fn wallet_address_for_chain(wallet_name: &str, chain: &str) -> Result<String, CliError> {
     let wallet = ows_lib::get_wallet(wallet_name, None)?;
@@ -27,26 +27,33 @@ pub fn run(
 ) -> Result<(), CliError> {
     let provider: FundProvider = provider.parse().map_err(CliError::InvalidArgs)?;
     let asset = asset.unwrap_or("USDC");
-    let chain_name = match chain {
-        Some(chain) => chain,
-        None => "base",
-    };
-    let address = wallet_address_for_chain(wallet_name, chain_name)?;
+    let wallet = ows_lib::get_wallet(wallet_name, None)?;
+    let wallet_accounts: Vec<WalletAccountRef> = wallet
+        .accounts
+        .iter()
+        .map(|account| WalletAccountRef {
+            chain_id: account.chain_id.clone(),
+            address: account.address.clone(),
+        })
+        .collect();
+    let target = ows_pay::fund::resolve_deposit_target(provider, &wallet_accounts, chain, asset)
+        .map_err(|e| CliError::InvalidArgs(e.message))?;
 
     eprintln!(
-        "Creating funding flow with provider \"{provider}\" for wallet \"{wallet_name}\" ({address})"
+        "Creating funding flow with provider \"{provider}\" for wallet \"{wallet_name}\" ({})",
+        target.destination_address
     );
-    eprintln!("Asset: {asset}");
-    eprintln!("Destination chain: {chain_name}");
+    eprintln!("Asset: {}", target.asset);
+    eprintln!("Destination chain: {}", target.wallet_chain_name);
 
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| CliError::InvalidArgs(format!("tokio: {e}")))?;
 
     let result = rt.block_on(ows_pay::fund::deposit(&FundRequest {
         provider,
-        destination_address: address,
-        asset: asset.to_string(),
-        chain: Some(chain_name.to_string()),
+        destination_address: target.destination_address,
+        asset: target.asset,
+        chain: target.chain,
     }))?;
 
     eprintln!();

--- a/ows/crates/ows-cli/src/commands/fund.rs
+++ b/ows/crates/ows-cli/src/commands/fund.rs
@@ -123,5 +123,7 @@ pub fn balance(provider: &str, wallet_name: &str, chain: Option<&str>) -> Result
 }
 
 pub fn providers() {
-    println!("moonpay  fiat/hosted deposit flow into wallet tokens on supported EVM chains");
+    println!(
+        "moonpay  default provider: fiat/hosted deposit flow into wallet tokens on supported EVM chains"
+    );
 }

--- a/ows/crates/ows-cli/src/commands/fund.rs
+++ b/ows/crates/ows-cli/src/commands/fund.rs
@@ -1,98 +1,109 @@
 use crate::CliError;
-use ows_lib::types::AccountInfo;
+use ows_pay::{FundProvider, FundRequest};
 
-/// Returns the wallet account matching the target funding chain.
-fn find_account_for_chain<'a>(
-    accounts: &'a [AccountInfo],
-    chain: &str,
-) -> Result<&'a AccountInfo, CliError> {
-    let chain_prefix = match chain {
-        "solana" => "solana:",
-        _ => "eip155:",
-    };
+fn wallet_address_for_chain(wallet_name: &str, chain: &str) -> Result<String, CliError> {
+    let wallet = ows_lib::get_wallet(wallet_name, None)?;
+    let parsed = crate::parse_chain(chain)?;
 
-    accounts
+    wallet
+        .accounts
         .iter()
-        .find(|a| a.chain_id.starts_with(chain_prefix))
+        .find(|a| a.chain_id == parsed.chain_id)
+        .map(|a| a.address.clone())
         .ok_or_else(|| {
-            CliError::InvalidArgs(format!("wallet has no account for chain \"{chain}\""))
+            CliError::InvalidArgs(format!(
+                "wallet has no account for chain {} ({})",
+                parsed.name, parsed.chain_id
+            ))
         })
 }
 
-/// `ows fund buy --wallet <name> [--chain base] [--token USDC]`
-///
-/// Creates a MoonPay deposit that generates multi-chain deposit addresses.
-/// Anyone can send crypto from any chain — it auto-converts to the target token.
-pub fn run(wallet_name: &str, chain: Option<&str>, token: Option<&str>) -> Result<(), CliError> {
-    let wallet = ows_lib::get_wallet(wallet_name, None)?;
-    let chain_name = chain.unwrap_or("base");
+/// `ows fund deposit --provider moonpay --wallet <name> --asset USDC --chain base`
+pub fn run(
+    provider: &str,
+    wallet_name: &str,
+    chain: Option<&str>,
+    asset: Option<&str>,
+) -> Result<(), CliError> {
+    let provider: FundProvider = provider.parse().map_err(CliError::InvalidArgs)?;
+    let asset = asset.unwrap_or("USDC");
+    let chain_name = match chain {
+        Some(chain) => chain,
+        None => "base",
+    };
+    let address = wallet_address_for_chain(wallet_name, chain_name)?;
 
-    let account = find_account_for_chain(&wallet.accounts, chain_name)?;
-    let address = &account.address;
-    let token_name = token.unwrap_or("USDC");
-
-    eprintln!("Creating deposit for wallet \"{wallet_name}\" ({address})");
-    eprintln!("Target: {token_name} on {chain_name}");
+    eprintln!(
+        "Creating funding flow with provider \"{provider}\" for wallet \"{wallet_name}\" ({address})"
+    );
+    eprintln!("Asset: {asset}");
+    eprintln!("Destination chain: {chain_name}");
 
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| CliError::InvalidArgs(format!("tokio: {e}")))?;
 
-    let result = rt.block_on(ows_pay::fund::fund(
-        address,
-        Some(chain_name),
-        Some(token_name),
-    ))?;
+    let result = rt.block_on(ows_pay::fund::deposit(&FundRequest {
+        provider,
+        destination_address: address,
+        asset: asset.to_string(),
+        chain: Some(chain_name.to_string()),
+    }))?;
 
     eprintln!();
-    eprintln!("Deposit created (ID: {})", result.deposit_id);
-    eprintln!();
+    eprintln!(
+        "Funding flow created via {} (ID: {})",
+        result.provider, result.deposit_id
+    );
 
-    // Show deposit addresses.
-    if !result.wallets.is_empty() {
-        eprintln!("Send crypto to any of these addresses:");
-        for (chain, addr) in &result.wallets {
-            eprintln!("  {chain:>10}  {addr}");
-        }
+    if !result.details.is_empty() {
         eprintln!();
+        for (key, value) in &result.details {
+            eprintln!("{key:>16}: {value}");
+        }
     }
 
+    if !result.wallets.is_empty() {
+        eprintln!();
+        eprintln!("Relevant addresses:");
+        for (kind, addr) in &result.wallets {
+            eprintln!("  {kind:>10}  {addr}");
+        }
+    }
+
+    eprintln!();
     eprintln!("{}", result.instructions);
     eprintln!();
 
-    // Print the deposit URL (opens in browser for a web flow).
-    println!("{}", result.deposit_url);
+    if let Some(url) = &result.action_url {
+        println!("{url}");
 
-    // Try to open in browser.
-    #[cfg(target_os = "macos")]
-    {
-        let _ = std::process::Command::new("open")
-            .arg(&result.deposit_url)
-            .spawn();
-    }
-    #[cfg(target_os = "linux")]
-    {
-        let _ = std::process::Command::new("xdg-open")
-            .arg(&result.deposit_url)
-            .spawn();
+        #[cfg(target_os = "macos")]
+        {
+            let _ = std::process::Command::new("open").arg(url).spawn();
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let _ = std::process::Command::new("xdg-open").arg(url).spawn();
+        }
     }
 
     Ok(())
 }
 
-/// `ows fund balance --wallet <name> [--chain base]`
-///
-/// Check token balances via MoonPay.
-pub fn balance(wallet_name: &str, chain: Option<&str>) -> Result<(), CliError> {
-    let wallet = ows_lib::get_wallet(wallet_name, None)?;
+/// `ows fund balance --provider moonpay --wallet <name> --chain base`
+pub fn balance(provider: &str, wallet_name: &str, chain: Option<&str>) -> Result<(), CliError> {
+    let provider: FundProvider = provider.parse().map_err(CliError::InvalidArgs)?;
     let chain_name = chain.unwrap_or("base");
-
-    let account = find_account_for_chain(&wallet.accounts, chain_name)?;
-    let address = &account.address;
+    let address = wallet_address_for_chain(wallet_name, chain_name)?;
 
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| CliError::InvalidArgs(format!("tokio: {e}")))?;
 
-    let balances = rt.block_on(ows_pay::fund::get_balances(address, Some(chain_name)))?;
+    let balances = rt.block_on(ows_pay::fund::get_balances(
+        provider,
+        &address,
+        Some(chain_name),
+    ))?;
 
     if balances.is_empty() {
         eprintln!("No tokens found for {address} on {chain_name}");
@@ -109,4 +120,8 @@ pub fn balance(wallet_name: &str, chain: Option<&str>) -> Result<(), CliError> {
     }
 
     Ok(())
+}
+
+pub fn providers() {
+    println!("moonpay  fiat/hosted deposit flow into wallet tokens on supported EVM chains");
 }

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -33,7 +33,7 @@ enum Commands {
         #[command(subcommand)]
         subcommand: MnemonicCommands,
     },
-    /// Fund a wallet with USDC via MoonPay
+    /// Fund a wallet via one of the configured providers
     Fund {
         #[command(subcommand)]
         subcommand: FundCommands,
@@ -222,27 +222,35 @@ enum MnemonicCommands {
 
 #[derive(Subcommand)]
 enum FundCommands {
-    /// Create a MoonPay deposit — generates multi-chain deposit addresses that auto-convert to USDC
+    /// Create a provider-specific funding flow into a wallet asset/address
     Deposit {
         /// Wallet name or ID
         #[arg(long, env = "OWS_WALLET")]
         wallet: String,
-        /// Target chain (default: base)
-        #[arg(long, default_value = "base")]
-        chain: String,
-        /// Token to receive (default: USDC)
+        /// Funding provider (currently moonpay)
+        #[arg(long, default_value = "moonpay")]
+        provider: String,
+        /// Asset to receive (default: USDC)
         #[arg(long, default_value = "USDC")]
-        token: String,
+        asset: String,
+        /// Destination chain/network in the wallet (default: base)
+        #[arg(long)]
+        chain: Option<String>,
     },
-    /// Check token balances for a wallet
+    /// Check balances for a wallet via a provider that supports balance lookup
     Balance {
         /// Wallet name or ID
         #[arg(long, env = "OWS_WALLET")]
         wallet: String,
+        /// Funding provider (currently moonpay)
+        #[arg(long, default_value = "moonpay")]
+        provider: String,
         /// Chain to check (default: base)
         #[arg(long, default_value = "base")]
         chain: String,
     },
+    /// List available funding providers
+    Providers,
 }
 
 #[derive(Subcommand)]
@@ -464,11 +472,23 @@ fn run(cli: Cli) -> Result<(), CliError> {
         Commands::Fund { subcommand } => match subcommand {
             FundCommands::Deposit {
                 wallet,
+                provider,
+                asset,
                 chain,
-                token,
-            } => commands::fund::run(&wallet, Some(&chain), Some(&token)),
-            FundCommands::Balance { wallet, chain } => {
-                commands::fund::balance(&wallet, Some(&chain))
+            } => commands::fund::run(
+                &provider,
+                &wallet,
+                chain.as_deref(),
+                Some(&asset),
+            ),
+            FundCommands::Balance {
+                wallet,
+                provider,
+                chain,
+            } => commands::fund::balance(&provider, &wallet, Some(&chain)),
+            FundCommands::Providers => {
+                commands::fund::providers();
+                Ok(())
             }
         },
         Commands::Pay { subcommand } => match subcommand {

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -227,7 +227,7 @@ enum FundCommands {
         /// Wallet name or ID
         #[arg(long, env = "OWS_WALLET")]
         wallet: String,
-        /// Funding provider (currently moonpay)
+        /// Funding provider (default: moonpay)
         #[arg(long, default_value = "moonpay")]
         provider: String,
         /// Asset to receive (default: USDC)
@@ -242,7 +242,7 @@ enum FundCommands {
         /// Wallet name or ID
         #[arg(long, env = "OWS_WALLET")]
         wallet: String,
-        /// Funding provider (currently moonpay)
+        /// Funding provider (default: moonpay)
         #[arg(long, default_value = "moonpay")]
         provider: String,
         /// Chain to check (default: base)

--- a/ows/crates/ows-core/README.md
+++ b/ows/crates/ows-core/README.md
@@ -31,7 +31,7 @@ cargo build --workspace --release
 | `ows sign tx` | Sign a raw transaction |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
-| `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |
+| `ows fund deposit` | Create a funding deposit (default provider: MoonPay) to fund a wallet with USDC |
 | `ows fund balance` | Check token balances for a wallet |
 | `ows mnemonic generate` | Generate a BIP-39 mnemonic phrase |
 | `ows mnemonic derive` | Derive an address from a mnemonic |

--- a/ows/crates/ows-lib/README.md
+++ b/ows/crates/ows-lib/README.md
@@ -31,7 +31,7 @@ cargo build --workspace --release
 | `ows sign tx` | Sign a raw transaction |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
-| `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |
+| `ows fund deposit` | Create a funding deposit (default provider: MoonPay) to fund a wallet with USDC |
 | `ows fund balance` | Check token balances for a wallet |
 | `ows mnemonic generate` | Generate a BIP-39 mnemonic phrase |
 | `ows mnemonic derive` | Derive an address from a mnemonic |

--- a/ows/crates/ows-pay/src/fund.rs
+++ b/ows/crates/ows-pay/src/fund.rs
@@ -1,7 +1,7 @@
 use crate::error::{PayError, PayErrorCode};
 use crate::types::{
-    FundResult, MoonPayBalanceRequest, MoonPayBalanceResponse, MoonPayDepositRequest,
-    MoonPayDepositResponse, TokenBalance,
+    FundProvider, FundRequest, FundResult, MoonPayBalanceRequest, MoonPayBalanceResponse,
+    MoonPayDepositRequest, MoonPayDepositResponse, TokenBalance,
 };
 
 const MOONPAY_API: &str = "https://agents.moonpay.com";
@@ -106,13 +106,23 @@ fn resolve_moonpay_chain(chain: Option<&str>) -> Result<&'static MoonPayChain, P
 }
 
 /// Create a MoonPay deposit that auto-converts incoming crypto to USDC.
-pub async fn fund(
+pub async fn deposit(
+    request: &FundRequest,
+) -> Result<FundResult, PayError> {
+    match request.provider {
+        FundProvider::MoonPay => {
+            moonpay_deposit(&request.destination_address, request.chain.as_deref(), &request.asset)
+                .await
+        }
+    }
+}
+
+async fn moonpay_deposit(
     wallet_address: &str,
     chain: Option<&str>,
-    token: Option<&str>,
+    token: &str,
 ) -> Result<FundResult, PayError> {
     let mapping = resolve_moonpay_chain(chain)?;
-    let token = token.unwrap_or("USDC");
 
     let client = reqwest::Client::new();
     let req = MoonPayDepositRequest {
@@ -140,22 +150,35 @@ pub async fn fund(
     let deposit: MoonPayDepositResponse = resp.json().await?;
 
     Ok(FundResult {
+        provider: FundProvider::MoonPay,
         deposit_id: deposit.id,
-        deposit_url: deposit.deposit_url,
+        action_url: Some(deposit.deposit_url),
         wallets: deposit
             .wallets
             .iter()
             .map(|w| (w.chain.clone(), w.address.clone()))
             .collect(),
         instructions: deposit.instructions,
+        details: vec![
+            ("asset".into(), token.to_string()),
+            ("chain".into(), mapping.display_name.to_string()),
+        ],
     })
 }
 
 /// Check token balances for a wallet address via MoonPay.
 pub async fn get_balances(
+    provider: FundProvider,
     wallet_address: &str,
     chain: Option<&str>,
 ) -> Result<Vec<TokenBalance>, PayError> {
+    if provider != FundProvider::MoonPay {
+        return Err(PayError::new(
+            PayErrorCode::InvalidInput,
+            format!("balance is not supported for provider {}", provider),
+        ));
+    }
+
     let mapping = resolve_moonpay_chain(chain)?;
     let client = reqwest::Client::new();
 

--- a/ows/crates/ows-pay/src/fund.rs
+++ b/ows/crates/ows-pay/src/fund.rs
@@ -1,7 +1,8 @@
 use crate::error::{PayError, PayErrorCode};
 use crate::types::{
     FundProvider, FundRequest, FundResult, MoonPayBalanceRequest, MoonPayBalanceResponse,
-    MoonPayDepositRequest, MoonPayDepositResponse, TokenBalance,
+    MoonPayDepositRequest, MoonPayDepositResponse, ResolvedFundTarget, TokenBalance,
+    WalletAccountRef,
 };
 
 const MOONPAY_API: &str = "https://agents.moonpay.com";
@@ -11,6 +12,7 @@ const MOONPAY_API: &str = "https://agents.moonpay.com";
 /// MoonPay expects the BNB Chain funding slug to be `bnb`, while OWS uses `bsc` as the canonical chain name.
 #[derive(Debug)]
 struct MoonPayChain {
+    wallet_chain_id: &'static str,
     display_name: &'static str,
     moonpay_name: &'static str,
 }
@@ -19,6 +21,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
     (
         "base",
         MoonPayChain {
+            wallet_chain_id: "eip155:8453",
             display_name: "Base",
             moonpay_name: "base",
         },
@@ -26,6 +29,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
     (
         "ethereum",
         MoonPayChain {
+            wallet_chain_id: "eip155:1",
             display_name: "Ethereum",
             moonpay_name: "ethereum",
         },
@@ -33,6 +37,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
     (
         "polygon",
         MoonPayChain {
+            wallet_chain_id: "eip155:137",
             display_name: "Polygon",
             moonpay_name: "polygon",
         },
@@ -40,6 +45,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
     (
         "arbitrum",
         MoonPayChain {
+            wallet_chain_id: "eip155:42161",
             display_name: "Arbitrum",
             moonpay_name: "arbitrum",
         },
@@ -47,6 +53,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
     (
         "optimism",
         MoonPayChain {
+            wallet_chain_id: "eip155:10",
             display_name: "Optimism",
             moonpay_name: "optimism",
         },
@@ -54,6 +61,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
     (
         "bsc",
         MoonPayChain {
+            wallet_chain_id: "eip155:56",
             display_name: "BNB Chain",
             moonpay_name: "bnb",
         },
@@ -61,6 +69,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
     (
         "bnb",
         MoonPayChain {
+            wallet_chain_id: "eip155:56",
             display_name: "BNB Chain",
             moonpay_name: "bnb",
         },
@@ -68,6 +77,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
     (
         "base-sepolia",
         MoonPayChain {
+            wallet_chain_id: "eip155:84532",
             display_name: "Base Sepolia",
             moonpay_name: "base-sepolia",
         },
@@ -75,6 +85,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
     (
         "solana",
         MoonPayChain {
+            wallet_chain_id: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             display_name: "Solana",
             moonpay_name: "solana",
         },
@@ -82,6 +93,7 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
 ];
 
 const DEFAULT_MOONPAY_CHAIN: &MoonPayChain = &MoonPayChain {
+    wallet_chain_id: "eip155:8453",
     display_name: "Base",
     moonpay_name: "base",
 };
@@ -105,6 +117,44 @@ fn resolve_moonpay_chain(chain: Option<&str>) -> Result<&'static MoonPayChain, P
     }
 }
 
+pub fn resolve_deposit_target(
+    provider: FundProvider,
+    wallet_accounts: &[WalletAccountRef],
+    chain: Option<&str>,
+    asset: &str,
+) -> Result<ResolvedFundTarget, PayError> {
+    match provider {
+        FundProvider::MoonPay => resolve_moonpay_target(wallet_accounts, chain, asset),
+    }
+}
+
+fn resolve_moonpay_target(
+    wallet_accounts: &[WalletAccountRef],
+    chain: Option<&str>,
+    asset: &str,
+) -> Result<ResolvedFundTarget, PayError> {
+    let mapping = resolve_moonpay_chain(chain)?;
+    let account = wallet_accounts
+        .iter()
+        .find(|account| account.chain_id == mapping.wallet_chain_id)
+        .ok_or_else(|| {
+            PayError::new(
+                PayErrorCode::UnsupportedChain,
+                format!(
+                    "wallet has no account for {} ({})",
+                    mapping.display_name, mapping.wallet_chain_id
+                ),
+            )
+        })?;
+
+    Ok(ResolvedFundTarget {
+        destination_address: account.address.clone(),
+        asset: asset.to_string(),
+        chain: Some(mapping.moonpay_name.to_string()),
+        wallet_chain_id: mapping.wallet_chain_id.to_string(),
+        wallet_chain_name: mapping.display_name.to_string(),
+    })
+}
 /// Create a MoonPay deposit that auto-converts incoming crypto to USDC.
 pub async fn deposit(
     request: &FundRequest,
@@ -241,5 +291,42 @@ mod tests {
         let chain = resolve_moonpay_chain(None).unwrap();
         assert_eq!(chain.display_name, "Base");
         assert_eq!(chain.moonpay_name, "base");
+        assert_eq!(chain.wallet_chain_id, "eip155:8453");
+    }
+
+    fn account(chain_id: &str, address: &str) -> WalletAccountRef {
+        WalletAccountRef {
+            chain_id: chain_id.to_string(),
+            address: address.to_string(),
+        }
+    }
+
+    #[test]
+    fn resolves_moonpay_target_using_provider_mapping() {
+        let target = resolve_deposit_target(
+            FundProvider::MoonPay,
+            &[account("eip155:8453", "0xbase")],
+            Some("base"),
+            "USDC",
+        )
+        .unwrap();
+
+        assert_eq!(target.destination_address, "0xbase");
+        assert_eq!(target.chain.as_deref(), Some("base"));
+        assert_eq!(target.wallet_chain_id, "eip155:8453");
+    }
+
+    #[test]
+    fn moonpay_target_reports_missing_wallet_account() {
+        let err = resolve_deposit_target(
+            FundProvider::MoonPay,
+            &[account("eip155:1", "0xeth")],
+            Some("base"),
+            "USDC",
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, PayErrorCode::UnsupportedChain);
+        assert!(err.message.contains("wallet has no account for Base"));
     }
 }

--- a/ows/crates/ows-pay/src/lib.rs
+++ b/ows/crates/ows-pay/src/lib.rs
@@ -20,7 +20,10 @@ pub mod wallet;
 mod x402;
 
 pub use error::{PayError, PayErrorCode};
-pub use types::{DiscoverResult, FundProvider, FundRequest, PayResult, PaymentInfo, Protocol, Service};
+pub use types::{
+    DiscoverResult, FundProvider, FundRequest, PayResult, PaymentInfo, Protocol,
+    ResolvedFundTarget, Service, WalletAccountRef,
+};
 pub use wallet::{Account, WalletAccess};
 
 /// Make an HTTP request with automatic payment handling.

--- a/ows/crates/ows-pay/src/lib.rs
+++ b/ows/crates/ows-pay/src/lib.rs
@@ -20,7 +20,7 @@ pub mod wallet;
 mod x402;
 
 pub use error::{PayError, PayErrorCode};
-pub use types::{DiscoverResult, PayResult, PaymentInfo, Protocol, Service};
+pub use types::{DiscoverResult, FundProvider, FundRequest, PayResult, PaymentInfo, Protocol, Service};
 pub use wallet::{Account, WalletAccess};
 
 /// Make an HTTP request with automatic payment handling.

--- a/ows/crates/ows-pay/src/types.rs
+++ b/ows/crates/ows-pay/src/types.rs
@@ -245,6 +245,23 @@ pub struct FundRequest {
     pub chain: Option<String>,
 }
 
+/// Minimal wallet account view needed for provider funding resolution.
+#[derive(Debug, Clone)]
+pub struct WalletAccountRef {
+    pub chain_id: String,
+    pub address: String,
+}
+
+/// Resolved funding target after provider-aware wallet/account selection.
+#[derive(Debug, Clone)]
+pub struct ResolvedFundTarget {
+    pub destination_address: String,
+    pub asset: String,
+    pub chain: Option<String>,
+    pub wallet_chain_id: String,
+    pub wallet_chain_name: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct MoonPayDepositRequest {
     pub name: String,

--- a/ows/crates/ows-pay/src/types.rs
+++ b/ows/crates/ows-pay/src/types.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 // ===========================================================================
 // Unified public types
@@ -206,6 +207,44 @@ pub struct Pagination {
 // MoonPay wire types
 // ===========================================================================
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FundProvider {
+    MoonPay,
+}
+
+impl FundProvider {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FundProvider::MoonPay => "moonpay",
+        }
+    }
+}
+
+impl std::fmt::Display for FundProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for FundProvider {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "moonpay" => Ok(FundProvider::MoonPay),
+            other => Err(format!("unsupported funding provider: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FundRequest {
+    pub provider: FundProvider,
+    pub destination_address: String,
+    pub asset: String,
+    pub chain: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct MoonPayDepositRequest {
     pub name: String,
@@ -265,8 +304,10 @@ pub struct BalanceInfo {
 /// Result of `ows fund`.
 #[derive(Debug, Clone)]
 pub struct FundResult {
+    pub provider: FundProvider,
     pub deposit_id: String,
-    pub deposit_url: String,
+    pub action_url: Option<String>,
     pub wallets: Vec<(String, String)>,
     pub instructions: String,
+    pub details: Vec<(String, String)>,
 }

--- a/ows/crates/ows-signer/README.md
+++ b/ows/crates/ows-signer/README.md
@@ -31,7 +31,7 @@ cargo build --workspace --release
 | `ows sign tx` | Sign a raw transaction |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
-| `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |
+| `ows fund deposit` | Create a funding deposit (default provider: MoonPay) to fund a wallet with USDC |
 | `ows fund balance` | Check token balances for a wallet |
 | `ows mnemonic generate` | Generate a BIP-39 mnemonic phrase |
 | `ows mnemonic derive` | Derive an address from a mnemonic |

--- a/readme/partials/cli-reference.md
+++ b/readme/partials/cli-reference.md
@@ -9,7 +9,7 @@
 | `ows sign tx` | Sign a raw transaction |
 | `ows pay request` | Make a paid request to an x402-enabled API endpoint |
 | `ows pay discover` | Discover x402-enabled services |
-| `ows fund deposit` | Create a MoonPay deposit to fund a wallet with USDC |
+| `ows fund deposit` | Create a funding deposit (default provider: MoonPay) to fund a wallet with USDC |
 | `ows fund balance` | Check token balances for a wallet |
 | `ows mnemonic generate` | Generate a BIP-39 mnemonic phrase |
 | `ows mnemonic derive` | Derive an address from a mnemonic |


### PR DESCRIPTION
## Summary

Trying to introduce a provider-aware interface layer needed to support additional funding backends under `ows fund`, while preserving the current MoonPay centered flow, and user experience. I believe this improves unit testability and also good for future wider adoption of OWS. 

The intent is narrow: keep `fund` _use-case driven_, but avoid hard-coding MoonPay as the only ever possible funding model, and make room for future additional providers without changing the meaning of the command.

## What Changed
- move funding target resolution behind provider-aware plumbing
- keep MoonPay as the default funding flow and preserve existing `ows fund` UX
- keep the current MoonPay semantics intact while opening the backend model up to other providers

## Why
The current implementation mixes the user-facing funding use case with MoonPay-specific assumptions. This PR **separates those concerns** without turning the CLI into a generic swap interface and losing coherency.

## Scope
This PR is intentionally limited to the generic abstraction layer.

So to be extra clear, it does not:
- change the role of `ows fund`
- replace or weaken MoonPay as the current default flow
- introduce a generic swap or bridge interface

Provider-specific expansions can follow separately on top of this.

## Validation
- `cargo test -p ows-pay fund:: --quiet`
- `cargo build -p ows-cli --quiet`