### PR TITLE
feat: add XRP/Ripple chain support

### DIFF
--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -14,10 +14,11 @@ pub enum ChainType {
     Spark,
     Filecoin,
     Sui,
+    Xrp,
 }
 
 /// All supported chain families, used for universal wallet derivation.
-pub const ALL_CHAIN_TYPES: [ChainType; 8] = [
+pub const ALL_CHAIN_TYPES: [ChainType; 9] = [
     ChainType::Evm,
     ChainType::Solana,
     ChainType::Bitcoin,
@@ -26,6 +27,7 @@ pub const ALL_CHAIN_TYPES: [ChainType; 8] = [
     ChainType::Ton,
     ChainType::Filecoin,
     ChainType::Sui,
+    ChainType::Xrp,
 ];
 
 /// A specific chain (e.g. "ethereum", "arbitrum") with its family type and CAIP-2 ID.
@@ -123,6 +125,11 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_type: ChainType::Sui,
         chain_id: "sui:mainnet",
     },
+    Chain {
+        name: "xrp",
+        chain_type: ChainType::Xrp,
+        chain_id: "xrpl:mainnet",
+    },
 ];
 
 /// Parse a chain string into a `Chain`. Accepts:
@@ -187,6 +194,7 @@ impl ChainType {
             ChainType::Spark => "spark",
             ChainType::Filecoin => "fil",
             ChainType::Sui => "sui",
+            ChainType::Xrp => "xrpl",
         }
     }
 
@@ -202,6 +210,7 @@ impl ChainType {
             ChainType::Spark => 8797555,
             ChainType::Filecoin => 461,
             ChainType::Sui => 784,
+            ChainType::Xrp => 144,
         }
     }
 
@@ -217,6 +226,7 @@ impl ChainType {
             "spark" => Some(ChainType::Spark),
             "fil" => Some(ChainType::Filecoin),
             "sui" => Some(ChainType::Sui),
+            "xrpl" => Some(ChainType::Xrp),
             _ => None,
         }
     }
@@ -234,6 +244,7 @@ impl fmt::Display for ChainType {
             ChainType::Spark => "spark",
             ChainType::Filecoin => "filecoin",
             ChainType::Sui => "sui",
+            ChainType::Xrp => "xrp",
         };
         write!(f, "{}", s)
     }
@@ -253,6 +264,7 @@ impl FromStr for ChainType {
             "spark" => Ok(ChainType::Spark),
             "filecoin" => Ok(ChainType::Filecoin),
             "sui" => Ok(ChainType::Sui),
+            "xrp" | "ripple" | "xrpl" => Ok(ChainType::Xrp),
             _ => Err(format!("unknown chain type: {}", s)),
         }
     }
@@ -414,7 +426,7 @@ mod tests {
 
     #[test]
     fn test_all_chain_types() {
-        assert_eq!(ALL_CHAIN_TYPES.len(), 8);
+        assert_eq!(ALL_CHAIN_TYPES.len(), 9);
     }
 
     #[test]

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -697,6 +697,7 @@ fn broadcast(chain: ChainType, rpc_url: &str, signed_bytes: &[u8]) -> Result<Str
             "broadcast not yet supported for Filecoin".into(),
         )),
         ChainType::Sui => broadcast_sui(rpc_url, signed_bytes),
+        ChainType::Xrp => Err(OwsLibError::InvalidInput("broadcast not yet supported for XRP".into())),
     }
 }
 

--- a/ows/crates/ows-signer/src/chains/mod.rs
+++ b/ows/crates/ows-signer/src/chains/mod.rs
@@ -7,6 +7,7 @@ pub mod spark;
 pub mod sui;
 pub mod ton;
 pub mod tron;
+pub mod xrp;
 
 pub use self::bitcoin::BitcoinSigner;
 pub use self::cosmos::CosmosSigner;
@@ -17,6 +18,7 @@ pub use self::spark::SparkSigner;
 pub use self::sui::SuiSigner;
 pub use self::ton::TonSigner;
 pub use self::tron::TronSigner;
+pub use self::xrp::XrpSigner;
 
 use crate::traits::ChainSigner;
 use ows_core::ChainType;
@@ -33,5 +35,6 @@ pub fn signer_for_chain(chain: ChainType) -> Box<dyn ChainSigner> {
         ChainType::Spark => Box::new(SparkSigner),
         ChainType::Filecoin => Box::new(FilecoinSigner),
         ChainType::Sui => Box::new(SuiSigner),
+        ChainType::Xrp => Box::new(XrpSigner),
     }
 }

--- a/ows/crates/ows-signer/src/chains/xrp.rs
+++ b/ows/crates/ows-signer/src/chains/xrp.rs
@@ -1,0 +1,73 @@
+use crate::curve::Curve;
+use crate::traits::{ChainSigner, SignOutput, SignerError};
+use k256::ecdsa::SigningKey;
+use ows_core::ChainType;
+use ripemd::Ripemd160;
+use sha2::{Digest, Sha256};
+
+pub struct XrpSigner;
+
+impl XrpSigner {
+    fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
+        SigningKey::from_slice(private_key).map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+    }
+    fn account_id(private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let sk = Self::signing_key(private_key)?;
+        let pk = sk.verifying_key().to_encoded_point(true);
+        let sha = Sha256::digest(pk.as_bytes());
+        Ok(Ripemd160::digest(&sha).to_vec())
+    }
+}
+
+impl ChainSigner for XrpSigner {
+    fn chain_type(&self) -> ChainType { ChainType::Xrp }
+    fn curve(&self) -> Curve { Curve::Secp256k1 }
+    fn coin_type(&self) -> u32 { 144 }
+
+    fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError> {
+        let id = Self::account_id(private_key)?;
+        let mut payload = vec![0x00u8];
+        payload.extend_from_slice(&id);
+        Ok(bs58::encode(&payload).with_alphabet(bs58::Alphabet::RIPPLE).with_check().into_string())
+    }
+
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        if message.len() != 32 { return Err(SignerError::InvalidMessage(format!("expected 32-byte hash, got {}", message.len()))); }
+        let sk = Self::signing_key(private_key)?;
+        let (sig, rid) = sk.sign_prehash_recoverable(message).map_err(|e| SignerError::SigningFailed(e.to_string()))?;
+        let mut out = Vec::with_capacity(65);
+        out.extend_from_slice(&sig.r().to_bytes());
+        out.extend_from_slice(&sig.s().to_bytes());
+        out.push(rid.to_byte());
+        Ok(SignOutput { signature: out, recovery_id: Some(rid.to_byte()), public_key: None })
+    }
+
+    fn sign_transaction(&self, private_key: &[u8], tx_bytes: &[u8]) -> Result<SignOutput, SignerError> {
+        self.sign(private_key, &Sha256::digest(tx_bytes))
+    }
+
+    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        self.sign(private_key, &Sha256::digest(message))
+    }
+
+    fn default_derivation_path(&self, index: u32) -> String {
+        format!("m/44'/144'/0'/0/{index}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn test_privkey() -> Vec<u8> { hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318").unwrap() }
+
+    #[test] fn test_address_starts_with_r() { assert!(XrpSigner.derive_address(&test_privkey()).unwrap().starts_with('r')); }
+    #[test] fn test_address_length() { let a = XrpSigner.derive_address(&test_privkey()).unwrap(); assert!(a.len() >= 25 && a.len() <= 35); }
+    #[test] fn test_base58check_roundtrip() {
+        let a = XrpSigner.derive_address(&test_privkey()).unwrap();
+        let d = bs58::decode(&a).with_alphabet(bs58::Alphabet::RIPPLE).with_check(None).into_vec().unwrap();
+        assert_eq!(d[0], 0x00); assert_eq!(d.len(), 21);
+    }
+    #[test] fn test_derivation_path() { assert_eq!(XrpSigner.default_derivation_path(0), "m/44'/144'/0'/0/0"); }
+    #[test] fn test_chain_properties() { assert_eq!(XrpSigner.chain_type(), ChainType::Xrp); assert_eq!(XrpSigner.coin_type(), 144); }
+    #[test] fn test_deterministic() { assert_eq!(XrpSigner.derive_address(&test_privkey()).unwrap(), XrpSigner.derive_address(&test_privkey()).unwrap()); }
+}


### PR DESCRIPTION
## Summary

Adds XRP (Ripple) as the 10th supported chain in OWS.

## Details

| Property | Value |
|----------|-------|
| Curve | secp256k1 |
| Coin type | 144 (SLIP-44) |
| CAIP-2 | `xrpl:mainnet` |
| Derivation | `m/44'/144'/0'/0/0` |
| Address | RIPEMD160(SHA256(compressed_pubkey)), ripple base58check |

## Changes (4 files, ~90 lines)

| File | What |
|------|------|
| `ows-core/src/chain.rs` | Added `Xrp` to `ChainType`, `ALL_CHAIN_TYPES`, `KNOWN_CHAINS`, all match arms |
| `ows-signer/src/chains/xrp.rs` | **New** — `XrpSigner` implementing `ChainSigner` |
| `ows-signer/src/chains/mod.rs` | Registered `XrpSigner` |
| `ows-lib/src/ops.rs` | Added `Xrp` to broadcast match (not yet supported) |

## Tests (6 passing)

- Address starts with `r`
- Address length 25-35 chars
- Base58check roundtrip (ripple alphabet, version byte 0x00)
- Derivation path `m/44'/144'/0'/0/{index}`
- Chain properties (type, coin type)
- Deterministic address derivation

## What this enables

After merge:
- `ows wallet create` derives XRP addresses alongside EVM, Solana, Bitcoin, etc.
- `ows sign message --chain xrp` works automatically
- Node/Python SDKs: `signMessage("wallet", "xrp", ...)` works automatically