### PR TITLE
fix: strip key material from InvalidPrivateKey error messages

### DIFF
--- a/ows/crates/ows-signer/src/chains/bitcoin.rs
+++ b/ows/crates/ows-signer/src/chains/bitcoin.rs
@@ -28,7 +28,7 @@ impl BitcoinSigner {
 
     fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
         SigningKey::from_slice(private_key)
-            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+            .map_err(|_| SignerError::InvalidPrivateKey("key parsing failed".into()))
     }
 
     /// Hash160: SHA256 then RIPEMD160 of the compressed public key.

--- a/ows/crates/ows-signer/src/chains/cosmos.rs
+++ b/ows/crates/ows-signer/src/chains/cosmos.rs
@@ -23,7 +23,7 @@ impl CosmosSigner {
 
     fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
         SigningKey::from_slice(private_key)
-            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+            .map_err(|_| SignerError::InvalidPrivateKey("key parsing failed".into()))
     }
 
     /// Hash160: SHA256 then RIPEMD160.

--- a/ows/crates/ows-signer/src/chains/evm.rs
+++ b/ows/crates/ows-signer/src/chains/evm.rs
@@ -35,7 +35,7 @@ impl EvmSigner {
 
     fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
         SigningKey::from_slice(private_key)
-            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+            .map_err(|_| SignerError::InvalidPrivateKey("key parsing failed".into()))
     }
 
     /// Sign EIP-712 typed structured data.

--- a/ows/crates/ows-signer/src/chains/filecoin.rs
+++ b/ows/crates/ows-signer/src/chains/filecoin.rs
@@ -14,7 +14,7 @@ const BASE32_ALPHABET: &[u8; 32] = b"abcdefghijklmnopqrstuvwxyz234567";
 impl FilecoinSigner {
     fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
         SigningKey::from_slice(private_key)
-            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+            .map_err(|_| SignerError::InvalidPrivateKey("key parsing failed".into()))
     }
 
     /// Encode bytes using Filecoin's lowercase base32 (no padding).

--- a/ows/crates/ows-signer/src/chains/spark.rs
+++ b/ows/crates/ows-signer/src/chains/spark.rs
@@ -13,7 +13,7 @@ pub struct SparkSigner;
 impl SparkSigner {
     fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
         SigningKey::from_slice(private_key)
-            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+            .map_err(|_| SignerError::InvalidPrivateKey("key parsing failed".into()))
     }
 }
 

--- a/ows/crates/ows-signer/src/chains/tron.rs
+++ b/ows/crates/ows-signer/src/chains/tron.rs
@@ -11,7 +11,7 @@ pub struct TronSigner;
 impl TronSigner {
     fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
         SigningKey::from_slice(private_key)
-            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+            .map_err(|_| SignerError::InvalidPrivateKey("key parsing failed".into()))
     }
 
     /// Derive the 20-byte address hash (same as EVM: keccak256 of uncompressed pubkey, last 20 bytes).


### PR DESCRIPTION
## Summary
- Replace `e.to_string()` with a static `"key parsing failed"` message in all `InvalidPrivateKey` error paths
- Prevents crypto library internals from leaking sensitive data through error logs
- Affects 6 chain signers: bitcoin, cosmos, evm, filecoin, spark, tron

## Test plan
- [x] `cargo test -p ows-signer` — 225 passed