### PR TITLE
fix: correct broken Policy Engine Implementation Guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Reference implementation documentation:
 - [CLI Reference](docs/sdk-cli.md)
 - [Node.js SDK](docs/sdk-node.md)
 - [Python SDK](docs/sdk-python.md)
-- [Policy Engine Implementation Guide](docs/policy-engine-implementation.md)
+- [Policy Engine Implementation Guide](docs/03-policy-engine.md)
 
 ## License
 


### PR DESCRIPTION
Fixes #163

The README referenced a non-existing file `docs/policy-engine-implementation.md`. 
The correct path is `docs/03-policy-engine.md` which already exists in the repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that fixes a broken README link; no runtime or API behavior is affected.
> 
> **Overview**
> Fixes the README’s **Policy Engine Implementation Guide** reference by updating the link from the non-existent `docs/policy-engine-implementation.md` to the correct existing document `docs/03-policy-engine.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f064f3d2cc4d740b0d774c685c38753e3a31d1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->