### PR TITLE
feat: add Guardian Agent to built-with-OWS showcase

### DIFF
--- a/guardian-agent.md
+++ b/guardian-agent.md
@@ -1,0 +1,33 @@
+# Guardian Agent
+
+> Zero-trust AI transaction layer built on OWS — agents execute blockchain transactions without ever seeing the private key.
+
+**Repo:** [github.com/izmiradami/guardian-agent](https://github.com/izmiradami/guardian-agent)  
+**Live Demo:** [izmiradami.github.io/guardian-agent](https://izmiradami.github.io/guardian-agent)
+
+## What it does
+
+Guardian Agent sits between an AI agent and the wallet. The agent requests a transaction. Guardian decides if it's allowed. The key is never exposed.
+
+```
+AI Agent → Interface → Policy Engine → Signer → Vault
+                            ↓
+                    (key never leaves here)
+```
+
+## How it uses OWS
+
+- Uses OWS vault for local-first encrypted key storage (`~/.guardian/wallets/`)
+- Leverages OWS policy engine to enforce spend limits and token allowlists
+- Relies on OWS signing interface — key decrypted only during `sign()`, immediately zeroized
+- Agent receives only the transaction hash — never the raw key
+
+## Stack
+
+- OWS core for vault + signing
+- Policy engine layer on top
+- Interactive demo UI (HTML, no backend)
+
+## Key insight
+
+> "AI agents should be powerful but never trusted with private keys. OWS makes this possible out of the box."


### PR DESCRIPTION
Add documentation for Guardian Agent, detailing its functionality and integration with OWS.

## What

Added Guardian Agent showcase to the readme/ folder. 
Guardian Agent is a zero-trust AI transaction layer built on OWS.

## Why

Demonstrates a real-world use case of OWS — AI agents executing 
blockchain transactions without ever accessing the private key.

Closes #

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` is clean
- [ ] `npm test` passes (if Node bindings changed)
- [ ] Tested manually with `ows` CLI

## Notes

Documentation-only change. No code modified.
Live demo: https://izmiradami.github.io/guardian-agent
Repo: https://github.com/izmiradami/guardian-agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new markdown showcase page; no runtime code paths, data handling, or security-sensitive logic are modified.
> 
> **Overview**
> Adds a new `guardian-agent.md` showcase page describing *Guardian Agent*, a zero-trust AI transaction layer built on OWS.
> 
> The doc outlines the high-level architecture and explicitly calls out how it uses OWS features (vault storage path, policy enforcement, signing/zeroization behavior), plus links to the public repo and live demo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 612de368874f82bfa1f83eaee8849d2975f56f99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->