### PR TITLE
feat: add AllowedRecipients and MaxTransactionValue policy rules

### DIFF
--- a/ows/crates/ows-cli/src/commands/policy.rs
+++ b/ows/crates/ows-cli/src/commands/policy.rs
@@ -65,6 +65,12 @@ pub fn show(id: &str) -> Result<(), CliError> {
                 ows_core::PolicyRule::ExpiresAt { timestamp } => {
                     format!("  expires_at: {timestamp}")
                 }
+                ows_core::PolicyRule::AllowedRecipients { addresses } => {
+                    format!("  allowed_recipients: {}", addresses.join(", "))
+                }
+                ows_core::PolicyRule::MaxTransactionValue { max_wei } => {
+                    format!("  max_transaction_value: {max_wei} wei")
+                }
             };
             println!("{desc}");
         }

--- a/ows/crates/ows-core/src/policy.rs
+++ b/ows/crates/ows-core/src/policy.rs
@@ -246,4 +246,36 @@ mod tests {
         let deserialized: PolicyAction = serde_json::from_value(json).unwrap();
         assert_eq!(deserialized, PolicyAction::Deny);
     }
+
+    #[test]
+    fn test_policy_rule_serde_allowed_recipients() {
+        let rule = PolicyRule::AllowedRecipients {
+            addresses: vec![
+                "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".to_string(),
+                "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+            ],
+        };
+        let json = serde_json::to_value(&rule).unwrap();
+        assert_eq!(json["type"], "allowed_recipients");
+        assert_eq!(
+            json["addresses"][0],
+            "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C"
+        );
+
+        let deserialized: PolicyRule = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized, rule);
+    }
+
+    #[test]
+    fn test_policy_rule_serde_max_transaction_value() {
+        let rule = PolicyRule::MaxTransactionValue {
+            max_wei: "100000000000000000".to_string(),
+        };
+        let json = serde_json::to_value(&rule).unwrap();
+        assert_eq!(json["type"], "max_transaction_value");
+        assert_eq!(json["max_wei"], "100000000000000000");
+
+        let deserialized: PolicyRule = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized, rule);
+    }
 }

--- a/ows/crates/ows-core/src/policy.rs
+++ b/ows/crates/ows-core/src/policy.rs
@@ -16,6 +16,13 @@ pub enum PolicyRule {
 
     /// Deny if current time is past the timestamp.
     ExpiresAt { timestamp: String },
+    /// Deny if `to` address is not in the allowlist (EVM sign_transaction only).
+    /// Contract creation (to = None) is always denied when this rule is present.
+    AllowedRecipients { addresses: Vec<String> },
+
+    /// Deny if transaction value (in wei) exceeds the cap (EVM sign_transaction only).
+    /// Non-EVM chains and message signing pass through.
+    MaxTransactionValue { max_wei: String },
 }
 
 /// A stored policy definition.

--- a/ows/crates/ows-core/src/policy.rs
+++ b/ows/crates/ows-core/src/policy.rs
@@ -42,12 +42,23 @@ pub struct Policy {
     pub action: PolicyAction,
 }
 
+/// The signing operation type — used to gate rules to specific operations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SigningOperation {
+    SignTransaction,
+    SignMessage,
+    SignHash,
+    SignTypedData,
+}
+
 /// Context passed to policy evaluation (and to executable policies via stdin).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyContext {
     pub chain_id: String,
     pub wallet_id: String,
     pub api_key_id: String,
+    pub operation: SigningOperation,
     pub transaction: TransactionContext,
     pub spending: SpendingContext,
     pub timestamp: String,
@@ -187,6 +198,7 @@ mod tests {
             chain_id: "eip155:8453".into(),
             wallet_id: "3198bc9c-6672-5ab3-d995-4942343ae5b6".into(),
             api_key_id: "7a2f1b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c".into(),
+            operation: SigningOperation::SignTransaction,
             transaction: TransactionContext {
                 to: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into()),
                 value: Some("100000000000000000".into()),

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -77,6 +77,129 @@ pub fn create_api_key(
 /// 3. Load and evaluate policies
 /// 4. HKDF(token) → decrypt wallet secret
 /// 5. Resolve signing key → sign
+// Parse to/value from EVM tx bytes for policy evaluation.
+fn parse_evm_tx_fields(tx_bytes: &[u8]) -> (Option<String>, Option<String>) {
+    if tx_bytes.is_empty() {
+        return (None, None);
+    }
+
+    // Determine tx type and skip type byte for typed txs
+    let (data, _typed) = if tx_bytes[0] == 0x02 || tx_bytes[0] == 0x01 {
+        (&tx_bytes[1..], true)
+    } else {
+        (tx_bytes, false)
+    };
+
+    // Parse RLP list
+    if data.is_empty() || data[0] < 0xc0 {
+        return (None, None);
+    }
+
+    let payload = if data[0] <= 0xf7 {
+        let len = (data[0] - 0xc0) as usize;
+        if data.len() < 1 + len {
+            return (None, None);
+        }
+        &data[1..1 + len]
+    } else {
+        let len_of_len = (data[0] - 0xf7) as usize;
+        if data.len() < 1 + len_of_len {
+            return (None, None);
+        }
+        let mut len = 0usize;
+        for b in &data[1..1 + len_of_len] {
+            len = (len << 8) | (*b as usize);
+        }
+        if data.len() < 1 + len_of_len + len {
+            return (None, None);
+        }
+        &data[1 + len_of_len..1 + len_of_len + len]
+    };
+
+    // Decode RLP items from payload
+    let mut items: Vec<Vec<u8>> = Vec::new();
+    let mut pos = 0;
+    while pos < payload.len() {
+        let b = payload[pos];
+        if b < 0x80 {
+            items.push(vec![b]);
+            pos += 1;
+        } else if b <= 0xb7 {
+            let len = (b - 0x80) as usize;
+            if pos + 1 + len > payload.len() {
+                break;
+            }
+            items.push(payload[pos + 1..pos + 1 + len].to_vec());
+            pos += 1 + len;
+        } else if b <= 0xbf {
+            let len_of_len = (b - 0xb7) as usize;
+            if pos + 1 + len_of_len > payload.len() {
+                break;
+            }
+            let mut len = 0usize;
+            for byte in &payload[pos + 1..pos + 1 + len_of_len] {
+                len = (len << 8) | (*byte as usize);
+            }
+            if pos + 1 + len_of_len + len > payload.len() {
+                break;
+            }
+            items.push(payload[pos + 1 + len_of_len..pos + 1 + len_of_len + len].to_vec());
+            pos += 1 + len_of_len + len;
+        } else {
+            // List item — skip for now
+            if b <= 0xf7 {
+                let len = (b - 0xc0) as usize;
+                items.push(vec![]);
+                pos += 1 + len;
+            } else {
+                let len_of_len = (b - 0xf7) as usize;
+                if pos + 1 + len_of_len > payload.len() {
+                    break;
+                }
+                let mut len = 0usize;
+                for byte in &payload[pos + 1..pos + 1 + len_of_len] {
+                    len = (len << 8) | (*byte as usize);
+                }
+                items.push(vec![]);
+                pos += 1 + len_of_len + len;
+            }
+        }
+    }
+
+    // EIP-1559 (0x02): chain_id, nonce, max_priority_fee, max_fee, gas, to, value, data, access_list
+    // Legacy:          nonce, gas_price, gas, to, value, data, v, r, s
+    // EIP-2930 (0x01): chain_id, nonce, gas_price, gas, to, value, data, access_list
+    let (to_idx, value_idx) = if tx_bytes[0] == 0x02 {
+        (5, 6) // EIP-1559
+    } else if tx_bytes[0] == 0x01 {
+        (4, 5) // EIP-2930
+    } else {
+        (3, 4) // Legacy
+    };
+
+    let to = items.get(to_idx).and_then(|b| {
+        if b.len() == 20 {
+            Some(format!("0x{}", hex::encode(b)))
+        } else {
+            None // contract creation
+        }
+    });
+
+    let value = items.get(value_idx).map(|b| {
+        if b.is_empty() {
+            "0".to_string()
+        } else {
+            let mut n: u128 = 0;
+            for byte in b.iter().take(16) {
+                n = n.wrapping_shl(8) | (*byte as u128);
+            }
+            n.to_string()
+        }
+    });
+
+    (to, value)
+}
+
 pub fn sign_with_api_key(
     token: &str,
     wallet_name_or_id: &str,
@@ -108,13 +231,19 @@ pub fn sign_with_api_key(
 
     let tx_hex = hex::encode(tx_bytes);
 
+    let (parsed_to, parsed_value) = if chain.chain_id.starts_with("eip155:") {
+        parse_evm_tx_fields(tx_bytes)
+    } else {
+        (None, None)
+    };
+
     let context = ows_core::PolicyContext {
         chain_id: chain.chain_id.to_string(),
         wallet_id: wallet.id.clone(),
         api_key_id: key_file.id.clone(),
         transaction: ows_core::policy::TransactionContext {
-            to: None,
-            value: None,
+            to: parsed_to,
+            value: parsed_value,
             raw_hex: tx_hex,
             data: None,
         },

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -170,12 +170,12 @@ fn parse_evm_tx_fields(tx_bytes: &[u8]) -> (Option<String>, Option<String>) {
     // EIP-1559 (0x02): chain_id, nonce, max_priority_fee, max_fee, gas, to, value, data, access_list
     // Legacy:          nonce, gas_price, gas, to, value, data, v, r, s
     // EIP-2930 (0x01): chain_id, nonce, gas_price, gas, to, value, data, access_list
-    let (to_idx, value_idx) = if tx_bytes[0] == 0x02 {
-        (5, 6) // EIP-1559
-    } else if tx_bytes[0] == 0x01 {
+    let (to_idx, value_idx) = if tx_bytes[0] == 0x01 {
         (4, 5) // EIP-2930
+    } else if tx_bytes[0] <= 0x7f {
+        (5, 6) // EIP-1559 layout: 0x02, 0x03 (EIP-4844), 0x04 (EIP-7702), future types
     } else {
-        (3, 4) // Legacy
+        (3, 4) // Legacy (first byte >= 0xc0)
     };
 
     let to = items.get(to_idx).and_then(|b| {

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -189,12 +189,22 @@ fn parse_evm_tx_fields(tx_bytes: &[u8]) -> (Option<String>, Option<String>) {
     let value = items.get(value_idx).map(|b| {
         if b.is_empty() {
             "0".to_string()
+        } else if b.len() > 32 {
+            // Value exceeds uint256 — return sentinel to trigger policy denial
+            "U256_OVERFLOW".to_string()
         } else {
-            let mut n: u128 = 0;
-            for byte in b.iter().take(16) {
-                n = n.wrapping_shl(8) | (*byte as u128);
+            // Decode big-endian bytes as u128 (safe for values up to ~3.4e38)
+            // For values > u128::MAX, return a string that exceeds any reasonable max_wei
+            if b.len() > 16 {
+                // Value is > u128::MAX — treat as effectively infinite
+                u128::MAX.to_string()
+            } else {
+                let mut n: u128 = 0;
+                for byte in b {
+                    n = n.wrapping_shl(8) | (*byte as u128);
+                }
+                n.to_string()
             }
-            n.to_string()
         }
     });
 
@@ -363,14 +373,19 @@ pub fn enforce_policy_and_decrypt_key(
 
     let tx_hex = hex::encode(tx_bytes);
 
+    let (parsed_to, parsed_value) = if chain.chain_id.starts_with("eip155:") {
+        parse_evm_tx_fields(tx_bytes)
+    } else {
+        (None, None)
+    };
     let context = ows_core::PolicyContext {
         chain_id: chain.chain_id.to_string(),
         wallet_id: wallet.id.clone(),
         api_key_id: key_file.id.clone(),
-        operation: ows_core::policy::SigningOperation::SignMessage,
+        operation: ows_core::policy::SigningOperation::SignTransaction,
         transaction: ows_core::policy::TransactionContext {
-            to: None,
-            value: None,
+            to: parsed_to,
+            value: parsed_value,
             raw_hex: tx_hex,
             data: None,
         },

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -196,8 +196,8 @@ fn parse_evm_tx_fields(tx_bytes: &[u8]) -> (Option<String>, Option<String>) {
             // Decode big-endian bytes as u128 (safe for values up to ~3.4e38)
             // For values > u128::MAX, return a string that exceeds any reasonable max_wei
             if b.len() > 16 {
-                // Value is > u128::MAX — treat as effectively infinite
-                u128::MAX.to_string()
+                // Value exceeds u128::MAX — use non-parseable sentinel to force denial
+                "U128_OVERFLOW".to_string()
             } else {
                 let mut n: u128 = 0;
                 for byte in b {

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -84,7 +84,8 @@ fn parse_evm_tx_fields(tx_bytes: &[u8]) -> (Option<String>, Option<String>) {
     }
 
     // Determine tx type and skip type byte for typed txs
-    let (data, _typed) = if tx_bytes[0] == 0x02 || tx_bytes[0] == 0x01 {
+    // EIP-2718: any first byte in [0x00, 0x7f] is a typed transaction
+    let (data, _typed) = if tx_bytes[0] <= 0x7f {
         (&tx_bytes[1..], true)
     } else {
         (tx_bytes, false)
@@ -241,6 +242,7 @@ pub fn sign_with_api_key(
         chain_id: chain.chain_id.to_string(),
         wallet_id: wallet.id.clone(),
         api_key_id: key_file.id.clone(),
+        operation: ows_core::policy::SigningOperation::SignTransaction,
         transaction: ows_core::policy::TransactionContext {
             to: parsed_to,
             value: parsed_value,
@@ -304,6 +306,7 @@ pub fn sign_message_with_api_key(
         chain_id: chain.chain_id.to_string(),
         wallet_id: wallet.id.clone(),
         api_key_id: key_file.id.clone(),
+        operation: ows_core::policy::SigningOperation::SignMessage,
         transaction: ows_core::policy::TransactionContext {
             to: None,
             value: None,
@@ -364,6 +367,7 @@ pub fn enforce_policy_and_decrypt_key(
         chain_id: chain.chain_id.to_string(),
         wallet_id: wallet.id.clone(),
         api_key_id: key_file.id.clone(),
+        operation: ows_core::policy::SigningOperation::SignMessage,
         transaction: ows_core::policy::TransactionContext {
             to: None,
             value: None,

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -41,6 +41,12 @@ fn evaluate_rule(rule: &PolicyRule, policy_id: &str, ctx: &PolicyContext) -> Pol
     match rule {
         PolicyRule::AllowedChains { chain_ids } => eval_allowed_chains(policy_id, chain_ids, ctx),
         PolicyRule::ExpiresAt { timestamp } => eval_expires_at(policy_id, timestamp, ctx),
+        PolicyRule::AllowedRecipients { addresses } => {
+            eval_allowed_recipients(policy_id, addresses, ctx)
+        }
+        PolicyRule::MaxTransactionValue { max_wei } => {
+            eval_max_transaction_value(policy_id, max_wei, ctx)
+        }
     }
 }
 
@@ -466,5 +472,171 @@ mod tests {
         let result = evaluate_policies(&[policy], &ctx);
         assert!(!result.allow);
         assert!(!marker.exists(), "executable should not have run");
+    }
+    // --- AllowedRecipients ---
+    #[test]
+    fn allowed_recipients_passes_matching_address() {
+        let ctx = base_context();
+        let policy = policy_with_rules(
+            "recipients",
+            vec![PolicyRule::AllowedRecipients {
+                addresses: vec!["0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".to_string()],
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(result.allow);
+    }
+
+    #[test]
+    fn allowed_recipients_is_case_insensitive() {
+        let ctx = base_context();
+        let policy = policy_with_rules(
+            "recipients",
+            vec![PolicyRule::AllowedRecipients {
+                addresses: vec!["0x742d35cc6634c0532925a3b844bc9e7595f2bd0c".to_string()],
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(result.allow);
+    }
+
+    #[test]
+    fn allowed_recipients_denies_unlisted_address() {
+        let ctx = base_context();
+        let policy = policy_with_rules(
+            "recipients",
+            vec![PolicyRule::AllowedRecipients {
+                addresses: vec!["0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string()],
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(!result.allow);
+        assert!(result.reason.unwrap().contains("not in allowed_recipients"));
+    }
+
+    #[test]
+    fn allowed_recipients_denies_contract_creation() {
+        let mut ctx = base_context();
+        ctx.transaction.to = None;
+        let policy = policy_with_rules(
+            "recipients",
+            vec![PolicyRule::AllowedRecipients {
+                addresses: vec!["0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".to_string()],
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(!result.allow);
+        assert!(result.reason.unwrap().contains("contract creation denied"));
+    }
+
+    // --- MaxTransactionValue ---
+    #[test]
+    fn max_transaction_value_passes_under_limit() {
+        let ctx = base_context();
+        let policy = policy_with_rules(
+            "max-value",
+            vec![PolicyRule::MaxTransactionValue {
+                max_wei: "200000000000000000".to_string(),
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(result.allow);
+    }
+
+    #[test]
+    fn max_transaction_value_passes_exact_limit() {
+        let ctx = base_context();
+        let policy = policy_with_rules(
+            "max-value",
+            vec![PolicyRule::MaxTransactionValue {
+                max_wei: "100000000000000000".to_string(),
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(result.allow);
+    }
+
+    #[test]
+    fn max_transaction_value_denies_over_limit() {
+        let ctx = base_context();
+        let policy = policy_with_rules(
+            "max-value",
+            vec![PolicyRule::MaxTransactionValue {
+                max_wei: "50000000000000000".to_string(),
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(!result.allow);
+        assert!(result.reason.unwrap().contains("exceeds max_wei"));
+    }
+
+    #[test]
+    fn max_transaction_value_passes_when_value_is_none() {
+        let mut ctx = base_context();
+        ctx.transaction.value = None;
+        let policy = policy_with_rules(
+            "max-value",
+            vec![PolicyRule::MaxTransactionValue {
+                max_wei: "1".to_string(),
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(result.allow);
+    }
+}
+fn eval_allowed_recipients(
+    policy_id: &str,
+    addresses: &[String],
+    ctx: &PolicyContext,
+) -> PolicyResult {
+    match &ctx.transaction.to {
+        None => PolicyResult::denied(
+            policy_id,
+            "contract creation denied: no recipient address (allowed_recipients policy)",
+        ),
+        Some(to) => {
+            let to_lower = to.to_lowercase();
+            if addresses.iter().any(|a| a.to_lowercase() == to_lower) {
+                PolicyResult::allowed()
+            } else {
+                PolicyResult::denied(
+                    policy_id,
+                    format!("recipient {to} not in allowed_recipients allowlist"),
+                )
+            }
+        }
+    }
+}
+
+fn eval_max_transaction_value(policy_id: &str, max_wei: &str, ctx: &PolicyContext) -> PolicyResult {
+    let value_str = match &ctx.transaction.value {
+        None => return PolicyResult::allowed(),
+        Some(v) => v,
+    };
+    let value: u128 = match value_str.parse() {
+        Ok(v) => v,
+        Err(_) => {
+            return PolicyResult::denied(
+                policy_id,
+                format!("could not parse transaction value '{value_str}' as integer"),
+            )
+        }
+    };
+    let max: u128 = match max_wei.parse() {
+        Ok(v) => v,
+        Err(_) => {
+            return PolicyResult::denied(
+                policy_id,
+                format!("could not parse max_wei '{max_wei}' as integer"),
+            )
+        }
+    };
+    if value <= max {
+        PolicyResult::allowed()
+    } else {
+        PolicyResult::denied(
+            policy_id,
+            format!("transaction value {value} wei exceeds max_wei {max}"),
+        )
     }
 }

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -589,6 +589,10 @@ fn eval_allowed_recipients(
     addresses: &[String],
     ctx: &PolicyContext,
 ) -> PolicyResult {
+    // Only gate EVM transactions — non-EVM and message signing pass through
+    if !ctx.chain_id.starts_with("eip155:") {
+        return PolicyResult::allowed();
+    }
     match &ctx.transaction.to {
         None => PolicyResult::denied(
             policy_id,
@@ -609,6 +613,10 @@ fn eval_allowed_recipients(
 }
 
 fn eval_max_transaction_value(policy_id: &str, max_wei: &str, ctx: &PolicyContext) -> PolicyResult {
+    // Only gate EVM transactions — non-EVM chains pass through
+    if !ctx.chain_id.starts_with("eip155:") {
+        return PolicyResult::allowed();
+    }
     let value_str = match &ctx.transaction.value {
         None => return PolicyResult::allowed(),
         Some(v) => v,

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -70,6 +70,71 @@ fn eval_expires_at(policy_id: &str, timestamp: &str, ctx: &PolicyContext) -> Pol
     }
 }
 
+fn eval_allowed_recipients(
+    policy_id: &str,
+    addresses: &[String],
+    ctx: &PolicyContext,
+) -> PolicyResult {
+    // Only gate EVM transactions — non-EVM and message signing pass through
+    if !ctx.chain_id.starts_with("eip155:") {
+        return PolicyResult::allowed();
+    }
+    match &ctx.transaction.to {
+        None => PolicyResult::denied(
+            policy_id,
+            "contract creation denied: no recipient address (allowed_recipients policy)",
+        ),
+        Some(to) => {
+            let to_lower = to.to_lowercase();
+            if addresses.iter().any(|a| a.to_lowercase() == to_lower) {
+                PolicyResult::allowed()
+            } else {
+                PolicyResult::denied(
+                    policy_id,
+                    format!("recipient {to} not in allowed_recipients allowlist"),
+                )
+            }
+        }
+    }
+}
+
+fn eval_max_transaction_value(policy_id: &str, max_wei: &str, ctx: &PolicyContext) -> PolicyResult {
+    // Only gate EVM transactions — non-EVM chains pass through
+    if !ctx.chain_id.starts_with("eip155:") {
+        return PolicyResult::allowed();
+    }
+    let value_str = match &ctx.transaction.value {
+        None => return PolicyResult::allowed(),
+        Some(v) => v,
+    };
+    let value: u128 = match value_str.parse() {
+        Ok(v) => v,
+        Err(_) => {
+            return PolicyResult::denied(
+                policy_id,
+                format!("could not parse transaction value '{value_str}' as integer"),
+            )
+        }
+    };
+    let max: u128 = match max_wei.parse() {
+        Ok(v) => v,
+        Err(_) => {
+            return PolicyResult::denied(
+                policy_id,
+                format!("could not parse max_wei '{max_wei}' as integer"),
+            )
+        }
+    };
+    if value <= max {
+        PolicyResult::allowed()
+    } else {
+        PolicyResult::denied(
+            policy_id,
+            format!("transaction value {value} wei exceeds max_wei {max}"),
+        )
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Executable policy evaluation
 // ---------------------------------------------------------------------------
@@ -584,67 +649,4 @@ mod tests {
         assert!(result.allow);
     }
 }
-fn eval_allowed_recipients(
-    policy_id: &str,
-    addresses: &[String],
-    ctx: &PolicyContext,
-) -> PolicyResult {
-    // Only gate EVM transactions — non-EVM and message signing pass through
-    if !ctx.chain_id.starts_with("eip155:") {
-        return PolicyResult::allowed();
-    }
-    match &ctx.transaction.to {
-        None => PolicyResult::denied(
-            policy_id,
-            "contract creation denied: no recipient address (allowed_recipients policy)",
-        ),
-        Some(to) => {
-            let to_lower = to.to_lowercase();
-            if addresses.iter().any(|a| a.to_lowercase() == to_lower) {
-                PolicyResult::allowed()
-            } else {
-                PolicyResult::denied(
-                    policy_id,
-                    format!("recipient {to} not in allowed_recipients allowlist"),
-                )
-            }
-        }
-    }
-}
 
-fn eval_max_transaction_value(policy_id: &str, max_wei: &str, ctx: &PolicyContext) -> PolicyResult {
-    // Only gate EVM transactions — non-EVM chains pass through
-    if !ctx.chain_id.starts_with("eip155:") {
-        return PolicyResult::allowed();
-    }
-    let value_str = match &ctx.transaction.value {
-        None => return PolicyResult::allowed(),
-        Some(v) => v,
-    };
-    let value: u128 = match value_str.parse() {
-        Ok(v) => v,
-        Err(_) => {
-            return PolicyResult::denied(
-                policy_id,
-                format!("could not parse transaction value '{value_str}' as integer"),
-            )
-        }
-    };
-    let max: u128 = match max_wei.parse() {
-        Ok(v) => v,
-        Err(_) => {
-            return PolicyResult::denied(
-                policy_id,
-                format!("could not parse max_wei '{max_wei}' as integer"),
-            )
-        }
-    };
-    if value <= max {
-        PolicyResult::allowed()
-    } else {
-        PolicyResult::denied(
-            policy_id,
-            format!("transaction value {value} wei exceeds max_wei {max}"),
-        )
-    }
-}

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -75,8 +75,11 @@ fn eval_allowed_recipients(
     addresses: &[String],
     ctx: &PolicyContext,
 ) -> PolicyResult {
-    // Only gate EVM transactions — non-EVM and message signing pass through
+    // Only applies to EVM sign_transaction — message signing has no recipient
     if !ctx.chain_id.starts_with("eip155:") {
+        return PolicyResult::allowed();
+    }
+    if ctx.operation != ows_core::policy::SigningOperation::SignTransaction {
         return PolicyResult::allowed();
     }
     match &ctx.transaction.to {
@@ -99,8 +102,11 @@ fn eval_allowed_recipients(
 }
 
 fn eval_max_transaction_value(policy_id: &str, max_wei: &str, ctx: &PolicyContext) -> PolicyResult {
-    // Only gate EVM transactions — non-EVM chains pass through
+    // Only applies to EVM sign_transaction — message signing has no value
     if !ctx.chain_id.starts_with("eip155:") {
+        return PolicyResult::allowed();
+    }
+    if ctx.operation != ows_core::policy::SigningOperation::SignTransaction {
         return PolicyResult::allowed();
     }
     let value_str = match &ctx.transaction.value {
@@ -264,6 +270,7 @@ mod tests {
             chain_id: "eip155:8453".to_string(),
             wallet_id: "wallet-1".to_string(),
             api_key_id: "key-1".to_string(),
+            operation: ows_core::policy::SigningOperation::SignTransaction,
             transaction: TransactionContext {
                 to: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".to_string()),
                 value: Some("100000000000000000".to_string()), // 0.1 ETH
@@ -648,5 +655,40 @@ mod tests {
         let result = evaluate_policies(&[policy], &ctx);
         assert!(result.allow);
     }
-}
+    #[test]
+    fn allowed_recipients_passes_message_signing() {
+        // Message signing should pass through AllowedRecipients regardless
+        let mut ctx = base_context();
+        ctx.operation = ows_core::policy::SigningOperation::SignMessage;
+        ctx.transaction.to = None; // messages have no recipient
+        let policy = policy_with_rules(
+            "recipients",
+            vec![PolicyRule::AllowedRecipients {
+                addresses: vec!["0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".to_string()],
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(
+            result.allow,
+            "message signing should not be blocked by AllowedRecipients"
+        );
+    }
 
+    #[test]
+    fn max_transaction_value_passes_message_signing() {
+        let mut ctx = base_context();
+        ctx.operation = ows_core::policy::SigningOperation::SignMessage;
+        ctx.transaction.value = Some("999999999999999999".to_string()); // huge value
+        let policy = policy_with_rules(
+            "max-value",
+            vec![PolicyRule::MaxTransactionValue {
+                max_wei: "1".to_string(), // very low cap
+            }],
+        );
+        let result = evaluate_policies(&[policy], &ctx);
+        assert!(
+            result.allow,
+            "message signing should not be blocked by MaxTransactionValue"
+        );
+    }
+}


### PR DESCRIPTION
Closes #153

## Summary

Adds two new declarative policy rules to the OWS policy engine:

### `AllowedRecipients`
Deny transactions to addresses not in an explicit allowlist. Contract creation (`to = None`) is always denied when this rule is present — same strict stance as `AllowedTypedDataContracts` for missing `verifyingContract`.
```json
{
  "type": "allowed_recipients",
  "addresses": ["0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C"]
}
```

### `MaxTransactionValue`
Deny transactions whose value exceeds a per-tx wei cap. Message signing and non-EVM chains pass through when `value = None`.
```json
{
  "type": "max_transaction_value",
  "max_wei": "100000000000000000"
}
```

## Changes
- `ows-core/src/policy.rs` — two new `PolicyRule` variants
- `ows-lib/src/policy_engine.rs` — evaluation logic + 8 new unit tests
- `ows-cli/src/commands/policy.rs` — CLI display for new rule types

## Test plan
- 8 new unit tests: address matching, case-insensitivity, contract creation denial, value under/at/over limit, None passthrough
- All 228 existing tests pass
- `cargo fmt` and `cargo clippy -D warnings` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new declarative enforcement in the signing path (including EVM transaction field parsing), which can deny previously-allowed transactions if parsing or rule configuration is incorrect. Changes touch core policy types and agent signing context, so compatibility and edge cases around tx formats/values are the main risk.
> 
> **Overview**
> Adds two new declarative policy rules: `allowed_recipients` (EVM `sign_transaction` recipient allowlist, denying contract creation) and `max_transaction_value` (per-tx wei cap).
> 
> Extends `PolicyContext` with `SigningOperation` and updates agent signing to populate `operation` plus parse EVM `to`/`value` from raw tx bytes for policy evaluation; non-EVM chains and message signing bypass these rules. Updates CLI `policy show` output and adds unit tests covering serde and rule behavior (case-insensitive matching, contract creation denial, value limits, and pass-through cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0596edb8a7e2f23206636e60dcbd6f782c8770ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->