### PR TITLE
feat: add RiskScope wallet risk intelligence skill

### DIFF
--- a/skills/riskscope/SKILL.md
+++ b/skills/riskscope/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: riskscope
+description: On-chain wallet risk intelligence — scan any Ethereum address or ENS name to get a full risk profile including transaction history, token exposure, counterparty graph, and behavioral flags. Powered by OWS observatory agent and Allium data.
+version: 1.0.0
+metadata:
+  openclaw:
+    requires:
+      anyBins:
+        - ows
+        - node
+    emoji: "🔍"
+    homepage: https://riskscope.xyz
+    os:
+      - darwin
+      - linux
+    install:
+      - kind: node
+        package: "@open-wallet-standard/core"
+        bins: [ows]
+        label: Install OWS CLI
+---
+
+# RiskScope — On-Chain Wallet Risk Intelligence
+
+Scan any Ethereum wallet address or ENS name to generate a full risk report. Every scan is cryptographically signed by an OWS observatory agent wallet. Pay-per-scan via x402 protocol.
+
+**Live Demo:** [riskscope.xyz](https://riskscope.xyz)
+
+## When to use
+
+- Scan a wallet address for risk assessment
+- Check on-chain activity and behavioral patterns
+- Analyze token exposure and counterparty graph
+- Run due diligence on a wallet before a transaction
+
+## Quick Start
+```bash
+npm install -g @open-wallet-standard/core
+ows wallet create --name observatory-agent
+ows sign message --wallet observatory-agent --chain evm --message "RiskScope scan: 0x..."
+```
+
+## API
+```bash
+curl -X POST https://riskscope.xyz/api/scan \
+  -H "Content-Type: application/json" \
+  -d '{"address": "vitalik.eth"}'
+```
+
+## Stack
+
+- OWS CLI — observatory-agent wallet signs every scan
+- Etherscan V2 API — balance, transactions, token transfers
+- Allium Intelligence API — behavioral labels, DeFi/NFT detection
+- x402 Protocol — 0.001 USDC per scan
+- ENS Resolution — ensdata.net
+
+## Source
+
+- GitHub: [dogiladeveloper/riskscope](https://github.com/dogiladeveloper/riskscope)
+- Live: [riskscope.xyz](https://riskscope.xyz)


### PR DESCRIPTION
## RiskScope Skill

Adds a new OWS skill for on-chain wallet risk intelligence.

### What it does
- Scans any Ethereum address or ENS name
- Returns risk score (0-100) with behavioral flags
- Powered by OWS observatory-agent wallet signing
- Allium Intelligence API for behavioral labels
- x402 pay-per-scan monetization (0.001 USDC)

### Live Demo
https://riskscope.xyz

### Built for OWS Hackathon 2026 — The Observatory Track

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new skill descriptor/README only; no runtime code, auth, or data-handling changes are introduced.
> 
> **Overview**
> Adds a new `skills/riskscope/SKILL.md` skill definition for **RiskScope**, including OpenClaw metadata (required bins, OS support, and install steps) and brief docs for scanning an Ethereum address/ENS via a hosted `POST /api/scan` endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 317cb5d9d27398f78ae936e674fc51b88e18ee3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->