### PR TITLE
chore: script set version;

### DIFF
--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -43,15 +43,7 @@ set_node_version() {
     '.optionalDependencies |= with_entries(.value = $v)' \
     package.json > tmp.json && mv tmp.json package.json
 
-  # Sync optionalDependencies and platform package versions in the lockfile
-  jq --arg v "$VERSION" '
-    .packages[""].optionalDependencies |= with_entries(.value = $v)
-    | .packages |= with_entries(
-        if (.key | test("node_modules/@open-wallet-standard/core-"))
-        then .value.version = $v
-        else . end
-      )
-  ' package-lock.json > tmp.json && mv tmp.json package-lock.json
+  npm install
 
   cargo update --workspace
 }


### PR DESCRIPTION
## What

Brief description of the change.

## Why

Why is this change needed? Link to related issue(s) if applicable.

Closes #

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` is clean
- [ ] `npm test` passes (if Node bindings changed)
- [ ] Tested manually with `ows` CLI

## Notes

Anything reviewers should know.
