### PR TITLE
feat(evm): EIP-2612 permit signing helper (Node SDK + Rust CLI)

### DIFF
--- a/bindings/node/__test__/permit.spec.mjs
+++ b/bindings/node/__test__/permit.spec.mjs
@@ -1,0 +1,193 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { signPermit } from "../src/evm/permit.mjs";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function encodeString(value) {
+  const bytes = Buffer.from(value, "utf8");
+  const offset = "0000000000000000000000000000000000000000000000000000000000000020";
+  const length = bytes.length.toString(16).padStart(64, "0");
+  const data   = bytes.toString("hex").padEnd(Math.ceil(bytes.length / 32) * 64, "0");
+  return "0x" + offset + length + data;
+}
+
+function encodeUint256(value) {
+  return "0x" + BigInt(value).toString(16).padStart(64, "0");
+}
+
+function makeMockFetch({ name = "USD Coin", nonce = 0n, eip712Domain = null, revertDomain = false } = {}) {
+  return async (_url, init) => {
+    const body = JSON.parse(init.body);
+    if (body.method === "eth_chainId") {
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x2105" }));
+    }
+    if (body.method === "eth_call") {
+      const selector = body.params[0].data.slice(0, 10);
+
+      if (selector === "0x84b0196e") {
+        if (revertDomain) {
+          return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, error: { message: "execution reverted" } }));
+        }
+        if (eip712Domain) {
+          const nameBytes    = Buffer.from(eip712Domain.name, "utf8");
+          const versionBytes = Buffer.from(eip712Domain.version, "utf8");
+          const words = [
+            "0f00000000000000000000000000000000000000000000000000000000000000",
+            "00000000000000000000000000000000000000000000000000000000000000e0",
+            "0000000000000000000000000000000000000000000000000000000000000120",
+            eip712Domain.chainId.toString(16).padStart(64, "0"),
+            "000000000000000000000000833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000160",
+            nameBytes.length.toString(16).padStart(64, "0"),
+            nameBytes.toString("hex").padEnd(64, "0"),
+            versionBytes.length.toString(16).padStart(64, "0"),
+            versionBytes.toString("hex").padEnd(64, "0"),
+            "0000000000000000000000000000000000000000000000000000000000000000",
+          ];
+          return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x" + words.join("") }));
+        }
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, error: { message: "execution reverted" } }));
+      }
+
+      if (selector === "0x06fdde03") {
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: encodeString(name) }));
+      }
+
+      if (selector === "0x7ecebe00") {
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: encodeUint256(nonce) }));
+      }
+    }
+    throw new Error("Unexpected: " + body.method);
+  };
+}
+
+const MOCK_SIG = "0x" + "a".repeat(64) + "b".repeat(64) + "1b";
+const mockSignTypedData = async (_json) => MOCK_SIG;
+
+const BASE_USDC  = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const SPENDER    = "0xDeadBeefDeadBeefDeadBeefDeadBeefDeadBeef";
+const OWNER      = "0x1111111111111111111111111111111111111111";
+const BASE_CHAIN = "eip155:8453";
+const BASE_PARAMS = {
+  token:    BASE_USDC,
+  spender:  SPENDER,
+  value:    "1000000",
+  deadline: 1_800_000_000,
+  nonce:    0,
+  rpcUrl:   "http://mock-rpc",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("signPermit", () => {
+
+  it("returns correct v / r / s from mock signature", async () => {
+    globalThis.fetch = makeMockFetch({ eip712Domain: { name: "USD Coin", version: "2", chainId: 8453 } });
+    const result = await signPermit(OWNER, BASE_CHAIN, BASE_PARAMS, mockSignTypedData);
+    assert.equal(result.v, 27);
+    assert.equal(result.r, "0x" + "a".repeat(64));
+    assert.equal(result.s, "0x" + "b".repeat(64));
+    assert.equal(result.signature, MOCK_SIG);
+  });
+
+  it("builds correct EIP-712 typed data structure", async () => {
+    globalThis.fetch = makeMockFetch({ eip712Domain: { name: "USD Coin", version: "2", chainId: 8453 } });
+    const { typedData } = await signPermit(OWNER, BASE_CHAIN, BASE_PARAMS, mockSignTypedData);
+    assert.equal(typedData.primaryType, "Permit");
+    assert.equal(typedData.message.spender, SPENDER);
+    assert.equal(typedData.message.value, "1000000");
+    assert.equal(typedData.message.deadline, 1_800_000_000);
+    assert.equal(typedData.message.nonce, 0);
+    assert.deepEqual(typedData.types.Permit, [
+      { name: "owner",    type: "address" },
+      { name: "spender",  type: "address" },
+      { name: "value",    type: "uint256" },
+      { name: "nonce",    type: "uint256" },
+      { name: "deadline", type: "uint256" },
+    ]);
+  });
+
+  it("resolves domain via eip712Domain()", async () => {
+    globalThis.fetch = makeMockFetch({ eip712Domain: { name: "USD Coin", version: "2", chainId: 8453 } });
+    const { typedData } = await signPermit(OWNER, BASE_CHAIN, BASE_PARAMS, mockSignTypedData);
+    assert.equal(typedData.domain.name, "USD Coin");
+    assert.equal(typedData.domain.version, "2");
+    assert.equal(typedData.domain.chainId, 8453);
+  });
+
+  it("falls back to name() + override when eip712Domain() reverts", async () => {
+    globalThis.fetch = makeMockFetch({ revertDomain: true, name: "USD Coin" });
+    const { typedData } = await signPermit(OWNER, BASE_CHAIN, BASE_PARAMS, mockSignTypedData);
+    assert.equal(typedData.domain.name, "USD Coin");
+    assert.equal(typedData.domain.version, "2");
+  });
+
+  it("auto-fetches nonce when not supplied", async () => {
+    globalThis.fetch = makeMockFetch({ eip712Domain: { name: "USD Coin", version: "2", chainId: 8453 }, nonce: 5n });
+    const params = { ...BASE_PARAMS, nonce: undefined };
+    const { typedData } = await signPermit(OWNER, BASE_CHAIN, params, mockSignTypedData);
+    assert.equal(typedData.message.nonce, 5);
+  });
+
+  it("uses supplied nonce without RPC call", async () => {
+    let nonceCalled = false;
+    globalThis.fetch = async (url, init) => {
+      const body = JSON.parse(init.body);
+      if (body.method === "eth_call" && body.params[0].data.startsWith("0x7ecebe00")) {
+        nonceCalled = true;
+      }
+      return makeMockFetch({ eip712Domain: { name: "USD Coin", version: "2", chainId: 8453 } })(url, init);
+    };
+    await signPermit(OWNER, BASE_CHAIN, { ...BASE_PARAMS, nonce: 7 }, mockSignTypedData);
+    assert.equal(nonceCalled, false);
+  });
+
+  it("omits version field in EIP712Domain when token has no version", async () => {
+    globalThis.fetch = makeMockFetch({ eip712Domain: { name: "MyToken", version: "", chainId: 8453 } });
+    const params = { ...BASE_PARAMS, token: "0x1234567890123456789012345678901234567890" };
+    const { typedData } = await signPermit(OWNER, BASE_CHAIN, params, mockSignTypedData);
+    const hasVersion = typedData.types.EIP712Domain.some(f => f.name === "version");
+    assert.equal(hasVersion, false);
+  });
+
+  it("chainId matches CAIP-2 chain segment", async () => {
+    globalThis.fetch = makeMockFetch({ eip712Domain: { name: "USD Coin", version: "2", chainId: 8453 } });
+    const { typedData } = await signPermit(OWNER, BASE_CHAIN, BASE_PARAMS, mockSignTypedData);
+    assert.equal(typedData.domain.chainId, 8453);
+  });
+
+  it("throws when token name is empty and no override exists", async () => {
+    globalThis.fetch = makeMockFetch({ revertDomain: true, name: "" });
+    const params = { ...BASE_PARAMS, token: "0x0000000000000000000000000000000000000001" };
+    await assert.rejects(
+      () => signPermit(OWNER, BASE_CHAIN, params, mockSignTypedData),
+      /Could not resolve EIP-712 domain/
+    );
+  });
+
+  it("throws when RPC is unreachable", async () => {
+    globalThis.fetch = async () => { throw new TypeError("fetch failed"); };
+    await assert.rejects(() => signPermit(OWNER, BASE_CHAIN, BASE_PARAMS, mockSignTypedData));
+  });
+
+  it("DAI fallback domain version is 1", async () => {
+    globalThis.fetch = makeMockFetch({ revertDomain: true, name: "Dai Stablecoin" });
+    const params = { ...BASE_PARAMS, token: "0x6B175474E89094C44Da98b954EedeAC495271d0F" };
+    const { typedData } = await signPermit(OWNER, "eip155:1", params, mockSignTypedData);
+    assert.equal(typedData.domain.version, "1");
+  });
+
+  it("Ethereum USDC fallback domain version is 2", async () => {
+    globalThis.fetch = makeMockFetch({ revertDomain: true, name: "USD Coin" });
+    const params = { ...BASE_PARAMS, token: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" };
+    const { typedData } = await signPermit(OWNER, "eip155:1", params, mockSignTypedData);
+    assert.equal(typedData.domain.version, "2");
+  });
+
+});

--- a/bindings/node/src/evm/permit.mjs
+++ b/bindings/node/src/evm/permit.mjs
@@ -1,0 +1,191 @@
+/**
+ * EIP-2612 permit signing helper for OWS.
+ * Handles token metadata resolution, nonce fetching, and EIP-712 typed data
+ * construction automatically.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-2612
+ */
+
+const DOMAIN_OVERRIDES = {
+  "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913": { version: "2" },
+  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": { version: "2" },
+  "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359": { version: "2" },
+  "0xaf88d065e77c8cc2239327c5edb3a432268e5831": { version: "2" },
+  "0x0b2c639c533813f4aa9d7837caf62653d097ff85": { version: "2" },
+  "0x6b175474e89094c44da98b954eedeac495271d0f": { version: "1" },
+  "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2": { version: "1" },
+};
+
+const SELECTORS = {
+  name:         "0x06fdde03",
+  nonces:       "0x7ecebe00",
+  eip712Domain: "0x84b0196e",
+};
+
+const DEFAULT_RPCS = {
+  1:     "https://eth.llamarpc.com",
+  8453:  "https://mainnet.base.org",
+  137:   "https://polygon-rpc.com",
+  42161: "https://arb1.arbitrum.io/rpc",
+  10:    "https://mainnet.optimism.io",
+};
+
+async function ethCall(rpcUrl, to, data) {
+  const res = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1,
+      method: "eth_call",
+      params: [{ to, data }, "latest"],
+    }),
+  });
+  if (!res.ok) throw new Error(`RPC request failed: ${res.status}`);
+  const json = await res.json();
+  if (json.error) throw new Error(`eth_call error: ${json.error.message}`);
+  return json.result ?? "0x";
+}
+
+function encodeAddressArg(address) {
+  return address.toLowerCase().replace("0x", "").padStart(64, "0");
+}
+
+function decodeString(hex) {
+  const raw = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (raw.length < 128) return "";
+  const length = parseInt(raw.slice(64, 128), 16);
+  const dataHex = raw.slice(128, 128 + length * 2);
+  return Buffer.from(dataHex, "hex").toString("utf8");
+}
+
+function decodeUint256(hex) {
+  const raw = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return BigInt("0x" + (raw || "0"));
+}
+
+async function resolveDomain(rpcUrl, tokenAddress, chainId) {
+  const lower = tokenAddress.toLowerCase();
+
+  try {
+    const raw = await ethCall(rpcUrl, tokenAddress, SELECTORS.eip712Domain);
+    const stripped = raw.startsWith("0x") ? raw.slice(2) : raw;
+    if (stripped.length > 64) {
+      const words = stripped.match(/.{1,64}/g) ?? [];
+      const nameOffset    = parseInt(words[1] ?? "0", 16) / 32;
+      const versionOffset = parseInt(words[2] ?? "0", 16) / 32;
+      const domainChainId = parseInt(words[3] ?? "0", 16);
+
+      const nameLength   = parseInt(words[nameOffset] ?? "0", 16);
+      const nameData     = words.slice(nameOffset + 1).join("").slice(0, nameLength * 2);
+      const resolvedName = Buffer.from(nameData, "hex").toString("utf8");
+
+      const versionLength   = parseInt(words[versionOffset] ?? "0", 16);
+      const versionData     = words.slice(versionOffset + 1).join("").slice(0, versionLength * 2);
+      const resolvedVersion = Buffer.from(versionData, "hex").toString("utf8");
+
+      if (resolvedName) {
+        return {
+          name: resolvedName,
+          version: resolvedVersion || undefined,
+          chainId: domainChainId || chainId,
+          verifyingContract: tokenAddress,
+        };
+      }
+    }
+  } catch { /* eip712Domain() not supported */ }
+
+  const override  = DOMAIN_OVERRIDES[lower];
+  const nameHex   = await ethCall(rpcUrl, tokenAddress, SELECTORS.name);
+  const tokenName = decodeString(nameHex);
+
+  if (!tokenName) {
+    throw new Error(
+      `Could not resolve EIP-712 domain for token ${tokenAddress}. ` +
+      `Ensure the token implements name() or eip712Domain(), or pass rpcUrl.`
+    );
+  }
+
+  return {
+    name: tokenName,
+    version: override?.omitVersion ? undefined : (override?.version ?? "1"),
+    chainId,
+    verifyingContract: tokenAddress,
+  };
+}
+
+function buildTypedData(domain, owner, spender, value, nonce, deadline) {
+  const domainFields = [
+    { name: "name", type: "string" },
+    ...(domain.version !== undefined ? [{ name: "version", type: "string" }] : []),
+    { name: "chainId", type: "uint256" },
+    { name: "verifyingContract", type: "address" },
+  ];
+
+  return {
+    types: {
+      EIP712Domain: domainFields,
+      Permit: [
+        { name: "owner",    type: "address" },
+        { name: "spender",  type: "address" },
+        { name: "value",    type: "uint256" },
+        { name: "nonce",    type: "uint256" },
+        { name: "deadline", type: "uint256" },
+      ],
+    },
+    primaryType: "Permit",
+    domain: {
+      name: domain.name,
+      ...(domain.version !== undefined && { version: domain.version }),
+      chainId: domain.chainId,
+      verifyingContract: domain.verifyingContract,
+    },
+    message: { owner, spender, value, nonce, deadline },
+  };
+}
+
+/**
+ * Signs an EIP-2612 permit for an ERC-20 token.
+ *
+ * @param {string}   ownerAddress  - Token owner address (from OWS wallet)
+ * @param {string}   chainId       - CAIP-2 chain ID, e.g. "eip155:8453"
+ * @param {object}   params        - { token, spender, value, deadline, nonce?, rpcUrl? }
+ * @param {Function} signTypedData - OWS signTypedData(typedDataJson) => Promise<hexSig>
+ * @returns {Promise<{ signature, v, r, s, typedData }>}
+ *
+ * @example
+ * const sig = await signPermit(ownerAddress, "eip155:8453", {
+ *   token:    "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+ *   spender:  "0xYourProtocol",
+ *   value:    "1000000",
+ *   deadline: Math.floor(Date.now() / 1000) + 3600,
+ * }, owsSignTypedData);
+ */
+export async function signPermit(ownerAddress, chainId, params, signTypedData) {
+  const { token, spender, value, deadline } = params;
+  const numericChainId = parseInt(chainId.split(":")[1] ?? "1", 10);
+  const rpcUrl = params.rpcUrl ?? DEFAULT_RPCS[numericChainId];
+
+  if (!rpcUrl) {
+    throw new Error(
+      `No default RPC configured for chain ${numericChainId}. Pass rpcUrl in params.`
+    );
+  }
+
+  let nonce = params.nonce;
+  if (nonce === undefined) {
+    const nonceData = SELECTORS.nonces + encodeAddressArg(ownerAddress);
+    const nonceHex  = await ethCall(rpcUrl, token, nonceData);
+    nonce = Number(decodeUint256(nonceHex));
+  }
+
+  const domain       = await resolveDomain(rpcUrl, token, numericChainId);
+  const typedData    = buildTypedData(domain, ownerAddress, spender, value, nonce, deadline);
+  const rawSignature = await signTypedData(JSON.stringify(typedData));
+
+  const sig = rawSignature.startsWith("0x") ? rawSignature.slice(2) : rawSignature;
+  const r   = "0x" + sig.slice(0, 64);
+  const s   = "0x" + sig.slice(64, 128);
+  const v   = parseInt(sig.slice(128, 130), 16);
+
+  return { signature: "0x" + sig, v, r, s, typedData };
+}

--- a/docs/examples/eip2612-permit.md
+++ b/docs/examples/eip2612-permit.md
@@ -1,0 +1,101 @@
+# EIP-2612 Permit Signing
+
+EIP-2612 `permit()` lets users approve an ERC-20 allowance with an off-chain
+signature instead of an on-chain `approve()` transaction. A relayer or protocol
+contract submits the permit on the user's behalf — no ETH needed for gas.
+
+OWS provides a `signPermit` helper that handles the boilerplate: nonce
+fetching, EIP-712 domain resolution (including per-token version quirks), and
+typed data construction.
+
+---
+
+## SDK usage
+```js
+import { signPermit } from "@open-wallet-standard/core/evm/permit";
+
+// ownerAddress : the wallet's EVM address (from createWallet / getWallet)
+// signTypedData: the OWS signTypedData binding for this wallet
+
+const sig = await signPermit(ownerAddress, "eip155:8453", {
+  token:    "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC on Base
+  spender:  "0xYourProtocolAddress",
+  value:    "1000000",   // 1 USDC (6 decimals)
+  deadline: Math.floor(Date.now() / 1000) + 3_600,       // 1 hour
+}, owsSignTypedData);
+
+console.log(sig.v, sig.r, sig.s);
+// Use on-chain: token.permit(owner, spender, value, deadline, v, r, s)
+```
+
+### PermitParams
+
+| Field      | Type     | Required | Description                                      |
+|------------|----------|----------|--------------------------------------------------|
+| `token`    | string   | yes      | ERC-20 contract address                          |
+| `spender`  | string   | yes      | Address to approve                               |
+| `value`    | string   | yes      | Amount in base units (e.g. `"1000000"` = 1 USDC) |
+| `deadline` | number   | yes      | Unix timestamp — permit invalid after this       |
+| `nonce`    | number   | no       | Auto-fetched from chain if omitted               |
+| `rpcUrl`   | string   | no       | JSON-RPC endpoint (chain default used if omitted) |
+
+### Return value
+```js
+{
+  signature: "0x...",  // full 65-byte hex (r + s + v)
+  v: 27,               // recovery id
+  r: "0x...",          // 32-byte hex
+  s: "0x...",          // 32-byte hex
+  typedData: { ... },  // the signed EIP-712 object (useful for debugging)
+}
+```
+
+---
+
+## How domain resolution works
+
+Getting the EIP-712 domain separator right is the error-prone part — tokens
+differ in which fields they include and what version string they use.
+`signPermit` resolves the domain in three stages:
+
+1. **`eip712Domain()`** (EIP-5267) — self-describing; used by USDC v2.2+,
+   OpenZeppelin ERC20Permit 5.x, and any future-compliant token.
+2. **Well-known override table** — covers USDC (`"2"`), DAI (`"1"`), and
+   others whose domain is fixed and well-established.
+3. **`name()` + default version `"1"`** — generic fallback for any other
+   EIP-2612-compliant token.
+
+Tokens that omit `version` from their domain are handled correctly — the
+`EIP712Domain` type array is built dynamically to match exactly what the
+token expects.
+
+### Supported tokens (override table)
+
+| Token | Chains | Version |
+|-------|--------|---------|
+| USDC  | Base, Ethereum, Polygon, Arbitrum, Optimism | `"2"` |
+| DAI   | Ethereum | `"1"` |
+| USDT  | Base | `"1"` |
+
+---
+
+## Supported chains (default RPC)
+
+| CAIP-2        | Chain          |
+|---------------|----------------|
+| `eip155:1`    | Ethereum       |
+| `eip155:8453` | Base           |
+| `eip155:137`  | Polygon        |
+| `eip155:42161`| Arbitrum One   |
+| `eip155:10`   | Optimism       |
+
+Pass `rpcUrl` for any other chain.
+
+---
+
+## Security notes
+
+- Set a tight `deadline` (30–60 minutes for interactive flows).
+- Nonces are single-use — the on-chain `permit()` call increments the nonce,
+  invalidating any other signatures with the same nonce.
+- OWS never exposes the private key; signing happens inside the OWS core.

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +812,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1110,7 +1135,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1458,6 +1483,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,6 +1611,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "ureq",
  "uuid",
  "zeroize",
 ]
@@ -2028,7 +2064,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2131,6 +2167,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2408,6 +2445,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2898,6 +2941,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3140,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/ows/crates/ows-cli/src/commands/mod.rs
+++ b/ows/crates/ows-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod pay;
 pub mod policy;
 pub mod send_transaction;
 pub mod sign_message;
+pub mod sign_permit;
 pub mod sign_transaction;
 pub mod uninstall;
 pub mod update;

--- a/ows/crates/ows-cli/src/commands/sign_permit.rs
+++ b/ows/crates/ows-cli/src/commands/sign_permit.rs
@@ -1,0 +1,44 @@
+use crate::CliError;
+use ows_lib::{sign_permit, types::PermitParams};
+
+pub fn run(
+    chain: &str,
+    wallet: &str,
+    token: &str,
+    spender: &str,
+    value: &str,
+    deadline: u64,
+    nonce: Option<u64>,
+    rpc_url: Option<&str>,
+    index: u32,
+    json_output: bool,
+) -> Result<(), CliError> {
+    let passphrase = super::peek_passphrase();
+    let result = sign_permit(
+        wallet,
+        chain,
+        PermitParams {
+            token: token.to_string(),
+            spender: spender.to_string(),
+            value: value.to_string(),
+            deadline,
+            nonce,
+            rpc_url: rpc_url.map(|s| s.to_string()),
+        },
+        passphrase.as_deref(),
+        Some(index),
+        None,
+    )?;
+    if json_output {
+        let obj = serde_json::json!({
+            "signature": result.signature,
+            "v": result.v,
+            "r": result.r,
+            "s": result.s,
+        });
+        println!("{}", serde_json::to_string_pretty(&obj)?);
+    } else {
+        println!("{}", result.signature);
+    }
+    Ok(())
+}

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -199,6 +199,39 @@ enum SignCommands {
         #[arg(long)]
         rpc_url: Option<String>,
     },
+    /// Sign an EIP-2612 permit for gasless ERC-20 approvals
+    Permit {
+        /// Chain name or CAIP-2 ID (e.g. "base", "eip155:8453", "ethereum")
+        #[arg(long)]
+        chain: String,
+        /// Wallet name or ID
+        #[arg(long, env = "OWS_WALLET")]
+        wallet: String,
+        /// ERC-20 token contract address
+        #[arg(long)]
+        token: String,
+        /// Address to approve
+        #[arg(long)]
+        spender: String,
+        /// Amount in token base units (e.g. 1000000 for 1 USDC)
+        #[arg(long)]
+        value: String,
+        /// Unix timestamp after which the permit is invalid
+        #[arg(long)]
+        deadline: u64,
+        /// Permit nonce (auto-fetched from chain if omitted)
+        #[arg(long)]
+        nonce: Option<u64>,
+        /// JSON-RPC endpoint (uses chain default if omitted)
+        #[arg(long)]
+        rpc_url: Option<String>,
+        /// Account index
+        #[arg(long, default_value = "0")]
+        index: u32,
+        /// Output structured JSON with v, r, s components
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -459,6 +492,29 @@ fn run(cli: Cli) -> Result<(), CliError> {
                 index,
                 json,
                 rpc_url.as_deref(),
+            ),
+            SignCommands::Permit {
+                chain,
+                wallet,
+                token,
+                spender,
+                value,
+                deadline,
+                nonce,
+                rpc_url,
+                index,
+                json,
+            } => commands::sign_permit::run(
+                &chain,
+                &wallet,
+                &token,
+                &spender,
+                &value,
+                deadline,
+                nonce,
+                rpc_url.as_deref(),
+                index,
+                json,
             ),
         },
         Commands::Fund { subcommand } => match subcommand {

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -25,6 +25,7 @@ getrandom = "0.2"
 zeroize = "1"
 sha2 = "0.10"
 rand = "0.8"
+ureq = { version = "2", features = ["json"] }
 prost = "0.13"
 tonic = { version = "0.12", features = ["transport"] }
 tokio = { version = "1", features = ["rt"] }

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -7,7 +7,7 @@ use ows_core::{
 };
 use ows_signer::{
     decrypt, encrypt, signer_for_chain, CryptoEnvelope, HdDeriver, Mnemonic, MnemonicStrength,
-    SecretBytes,
+    SecretBytes, ChainSigner,
 };
 
 use crate::error::OwsLibError;
@@ -2910,4 +2910,295 @@ mod tests {
             }
         }
     }
+}
+
+/// Sign an EIP-2612 permit for an ERC-20 token.
+///
+/// Fetches the token nonce and domain fields on-chain, constructs the
+/// EIP-712 typed data, and signs it using the wallet's EVM key.
+///
+/// # Example
+/// ```no_run
+/// let sig = sign_permit("my-wallet", "eip155:8453", PermitParams {
+///     token:   "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".into(),
+///     spender: "0xYourProtocol".into(),
+///     value:   "1000000".into(),
+///     deadline: 1_800_000_000,
+///     nonce:   None,
+///     rpc_url: None,
+/// }, None, None, None).unwrap();
+/// ```
+pub fn sign_permit(
+    wallet: &str,
+    chain: &str,
+    params: crate::types::PermitParams,
+    passphrase: Option<&str>,
+    index: Option<u32>,
+    vault_path: Option<&std::path::Path>,
+) -> Result<crate::types::PermitSignResult, OwsLibError> {
+    // Build the EIP-712 typed data via the JS helper (Node binding path)
+    // or inline for the Rust CLI path. Here we construct it inline so the
+    // Rust CLI has zero external dependencies.
+
+    let rpc_url = params.rpc_url.clone().unwrap_or_else(|| {
+        let chain_id = chain.split(':').nth(1).unwrap_or("1");
+        match chain_id {
+            "1"     => "https://eth.llamarpc.com".into(),
+            "8453"  => "https://mainnet.base.org".into(),
+            "137"   => "https://polygon-rpc.com".into(),
+            "42161" => "https://arb1.arbitrum.io/rpc".into(),
+            "10"    => "https://mainnet.optimism.io".into(),
+            other   => format!("https://rpc.ankr.com/eth_{}_{}", other, other),
+        }
+    });
+
+    let numeric_chain_id: u64 = chain
+        .split(':')
+        .nth(1)
+        .unwrap_or("1")
+        .parse()
+        .map_err(|_| OwsLibError::InvalidInput(format!("invalid CAIP-2 chain: {chain}")))?;
+
+    // Resolve owner address from wallet.
+    let chain_parsed = parse_chain(chain)?;
+    let key = decrypt_signing_key(
+        wallet,
+        chain_parsed.chain_type,
+        passphrase.unwrap_or(""),
+        index,
+        vault_path,
+    )?;
+    let evm_signer = ows_signer::chains::EvmSigner;
+    let owner = evm_signer
+        .derive_address(key.expose())
+        .map_err(|e| OwsLibError::Signer(e))?;
+
+    // Fetch nonce on-chain if not supplied.
+    let nonce = if let Some(n) = params.nonce {
+        n
+    } else {
+        fetch_permit_nonce(&rpc_url, &params.token, &owner)
+            .map_err(|e| OwsLibError::InvalidInput(e))?
+    };
+
+    // Resolve EIP-712 domain.
+    let domain = resolve_permit_domain(&rpc_url, &params.token, numeric_chain_id)
+        .map_err(|e| OwsLibError::InvalidInput(e))?;
+
+    // Build typed data JSON.
+    let typed_data_json = build_permit_typed_data(
+        &domain,
+        &owner,
+        &params.spender,
+        &params.value,
+        nonce,
+        params.deadline,
+        numeric_chain_id,
+        &params.token,
+    );
+
+    // Sign via existing sign_typed_data path.
+    let result = sign_typed_data(wallet, chain, &typed_data_json, passphrase, index, vault_path)?;
+
+    // Split signature into v / r / s.
+    let sig_bytes = hex::decode(&result.signature)
+        .map_err(|e| OwsLibError::InvalidInput(format!("invalid signature hex: {e}")))?;
+    if sig_bytes.len() != 65 {
+        return Err(OwsLibError::InvalidInput(
+            format!("expected 65-byte signature, got {}", sig_bytes.len())
+        ));
+    }
+    let r = format!("0x{}", hex::encode(&sig_bytes[0..32]));
+    let s = format!("0x{}", hex::encode(&sig_bytes[32..64]));
+    let v = sig_bytes[64];
+
+    Ok(crate::types::PermitSignResult {
+        signature: format!("0x{}", result.signature),
+        v,
+        r,
+        s,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// EIP-2612 domain resolution helpers (synchronous, uses ureq for HTTP)
+// ---------------------------------------------------------------------------
+
+/// Well-known token domain version overrides keyed by lowercase address.
+fn permit_domain_version(token: &str) -> Option<&'static str> {
+    match token.to_lowercase().as_str() {
+        // USDC on all chains
+        "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" => Some("2"),
+        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" => Some("2"),
+        "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359" => Some("2"),
+        "0xaf88d065e77c8cc2239327c5edb3a432268e5831" => Some("2"),
+        "0x0b2c639c533813f4aa9d7837caf62653d097ff85" => Some("2"),
+        // DAI
+        "0x6b175474e89094c44da98b954eedeac495271d0f" => Some("1"),
+        // USDT on Base
+        "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2" => Some("1"),
+        _ => None,
+    }
+}
+
+struct PermitDomain {
+    name: String,
+    version: Option<String>,
+}
+
+fn eth_call(rpc_url: &str, to: &str, data: &str) -> Result<String, String> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_call",
+        "params": [{ "to": to, "data": data }, "latest"]
+    });
+    let response = ureq::post(rpc_url)
+        .set("Content-Type", "application/json")
+        .send_string(&body.to_string())
+        .map_err(|e| format!("RPC request failed: {e}"))?;
+    let json: serde_json::Value = response
+        .into_json()
+        .map_err(|e| format!("RPC response parse error: {e}"))?;
+    if let Some(err) = json.get("error") {
+        return Err(format!("eth_call error: {err}"));
+    }
+    Ok(json["result"].as_str().unwrap_or("0x").to_string())
+}
+
+fn decode_abi_string(hex: &str) -> String {
+    let raw = hex.trim_start_matches("0x");
+    if raw.len() < 128 { return String::new(); }
+    let length = usize::from_str_radix(&raw[64..128], 16).unwrap_or(0);
+    let data_hex = &raw[128..128 + length * 2];
+    hex::decode(data_hex)
+        .ok()
+        .and_then(|b| String::from_utf8(b).ok())
+        .unwrap_or_default()
+}
+
+fn decode_abi_uint256(hex: &str) -> u64 {
+    let raw = hex.trim_start_matches("0x");
+    u64::from_str_radix(raw.trim_start_matches('0'), 16).unwrap_or(0)
+}
+
+fn encode_address_arg(address: &str) -> String {
+    format!("{:0>64}", address.trim_start_matches("0x").to_lowercase())
+}
+
+fn fetch_permit_nonce(rpc_url: &str, token: &str, owner: &str) -> Result<u64, String> {
+    let data = format!("0x7ecebe00{}", encode_address_arg(owner));
+    let result = eth_call(rpc_url, token, &data)?;
+    Ok(decode_abi_uint256(&result))
+}
+
+fn resolve_permit_domain(rpc_url: &str, token: &str, _chain_id: u64) -> Result<PermitDomain, String> {
+    // 1. Try eip712Domain() — EIP-5267
+    if let Ok(raw) = eth_call(rpc_url, token, "0x84b0196e") {
+        let stripped = raw.trim_start_matches("0x");
+        if stripped.len() > 64 {
+            let words: Vec<&str> = (0..stripped.len())
+                .step_by(64)
+                .map(|i| &stripped[i..std::cmp::min(i + 64, stripped.len())])
+                .collect();
+            if words.len() > 3 {
+                let name_offset  = usize::from_str_radix(words[1], 16).unwrap_or(0) / 32;
+                let version_offset = usize::from_str_radix(words[2], 16).unwrap_or(0) / 32;
+                if name_offset < words.len() {
+                    let name_len = usize::from_str_radix(words[name_offset], 16).unwrap_or(0);
+                    let name_data: String = words[name_offset + 1..].join("").chars().take(name_len * 2).collect();
+                    let name = hex::decode(&name_data).ok()
+                        .and_then(|b| String::from_utf8(b).ok())
+                        .unwrap_or_default();
+                    if !name.is_empty() {
+                        let version = if version_offset < words.len() {
+                            let ver_len = usize::from_str_radix(words[version_offset], 16).unwrap_or(0);
+                            let ver_data: String = words[version_offset + 1..].join("").chars().take(ver_len * 2).collect();
+                            hex::decode(&ver_data).ok()
+                                .and_then(|b| String::from_utf8(b).ok())
+                                .filter(|s| !s.is_empty())
+                        } else { None };
+                        return Ok(PermitDomain { name, version });
+                    }
+                }
+            }
+        }
+    }
+
+    // 2. Well-known override table + name()
+    let name_hex = eth_call(rpc_url, token, "0x06fdde03")?;
+    let name = decode_abi_string(&name_hex);
+    if name.is_empty() {
+        return Err(format!(
+            "Could not resolve EIP-712 domain for token {token}. \
+             Ensure the token implements name() or eip712Domain()."
+        ));
+    }
+    let version = permit_domain_version(token).map(|s| s.to_string()).or(Some("1".into()));
+    Ok(PermitDomain { name, version })
+}
+
+fn build_permit_typed_data(
+    domain: &PermitDomain,
+    owner: &str,
+    spender: &str,
+    value: &str,
+    nonce: u64,
+    deadline: u64,
+    chain_id: u64,
+    verifying_contract: &str,
+) -> String {
+    let domain_fields = if domain.version.is_some() {
+        serde_json::json!([
+            { "name": "name", "type": "string" },
+            { "name": "version", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+        ])
+    } else {
+        serde_json::json!([
+            { "name": "name", "type": "string" },
+            { "name": "chainId", "type": "uint256" },
+            { "name": "verifyingContract", "type": "address" }
+        ])
+    };
+
+    let domain_obj = if let Some(ref ver) = domain.version {
+        serde_json::json!({
+            "name": domain.name,
+            "version": ver,
+            "chainId": chain_id,
+            "verifyingContract": verifying_contract
+        })
+    } else {
+        serde_json::json!({
+            "name": domain.name,
+            "chainId": chain_id,
+            "verifyingContract": verifying_contract
+        })
+    };
+
+    let typed_data = serde_json::json!({
+        "types": {
+            "EIP712Domain": domain_fields,
+            "Permit": [
+                { "name": "owner",    "type": "address" },
+                { "name": "spender",  "type": "address" },
+                { "name": "value",    "type": "uint256" },
+                { "name": "nonce",    "type": "uint256" },
+                { "name": "deadline", "type": "uint256" }
+            ]
+        },
+        "primaryType": "Permit",
+        "domain": domain_obj,
+        "message": {
+            "owner":    owner,
+            "spender":  spender,
+            "value":    value,
+            "nonce":    nonce,
+            "deadline": deadline
+        }
+    });
+
+    serde_json::to_string(&typed_data).unwrap_or_default()
 }

--- a/ows/crates/ows-lib/src/types.rs
+++ b/ows/crates/ows-lib/src/types.rs
@@ -29,3 +29,29 @@ pub struct SignResult {
 pub struct SendResult {
     pub tx_hash: String,
 }
+
+/// Parameters for EIP-2612 permit signing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermitParams {
+    /// ERC-20 token contract address.
+    pub token: String,
+    /// Address to approve.
+    pub spender: String,
+    /// Amount in token base units (e.g. "1000000" for 1 USDC).
+    pub value: String,
+    /// Unix timestamp after which the permit is invalid.
+    pub deadline: u64,
+    /// Permit nonce — auto-fetched from chain if None.
+    pub nonce: Option<u64>,
+    /// JSON-RPC endpoint for on-chain lookups.
+    pub rpc_url: Option<String>,
+}
+
+/// Result from an EIP-2612 permit signing operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermitSignResult {
+    pub signature: String,
+    pub v: u8,
+    pub r: String,
+    pub s: String,
+}


### PR DESCRIPTION
## Summary

Adds a purpose-built `signPermit` helper that eliminates the boilerplate currently required to sign EIP-2612 permits via OWS. Closes #132

## What's included

### Node SDK — `signPermit()`
```js
import { signPermit } from '@open-wallet-standard/core/evm/permit';

const sig = await signPermit(ownerAddress, 'eip155:8453', {
  token:    '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC on Base
  spender:  '0xYourProtocol',
  value:    '1000000',
  deadline: Math.floor(Date.now() / 1000) + 3600,
}, owsSignTypedData);
// → { v, r, s, signature, typedData }
```

### CLI — `ows sign permit`
```bash
ows sign permit   --wallet my-wallet   --chain  eip155:8453   --token  0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913   --spender 0xYourProtocol   --value  1000000   --deadline 1800000000   --json
```

## Domain resolution

The hard part of EIP-2612 is getting the domain separator right. `signPermit` resolves it in three stages:

1. **`eip712Domain()`** (EIP-5267) — self-describing; works for USDC v2.2+, OZ ERC20Permit 5.x
2. **Well-known override table** — USDC (`"2"`), DAI (`"1"`), Base USDT
3. **`name()` + default version `"1"`** — generic fallback

Tokens that omit `version` from their domain are handled correctly — the `EIP712Domain` type array is built dynamically.

## Tests

```
✔ returns correct v / r / s from mock signature
✔ builds correct EIP-712 typed data structure
✔ resolves domain via eip712Domain()
✔ falls back to name() + override when eip712Domain() reverts
✔ auto-fetches nonce when not supplied
✔ uses supplied nonce without RPC call
✔ omits version field in EIP712Domain when token has no version
✔ chainId matches CAIP-2 chain segment
✔ throws when token name is empty and no override exists
✔ throws when RPC is unreachable
✔ DAI fallback domain version is 1
✔ Ethereum USDC fallback domain version is 2

12 passed, 0 failed — fully offline, no network required
```

## Files changed

| File | Description |
|------|-------------|
| `bindings/node/src/evm/permit.mjs` | SDK function |
| `bindings/node/__test__/permit.spec.mjs` | 12 offline tests |
| `docs/examples/eip2612-permit.md` | Usage guide |
| `ows/crates/ows-lib/src/ops.rs` | `sign_permit()` Rust implementation |
| `ows/crates/ows-lib/src/types.rs` | `PermitParams`, `PermitSignResult` types |
| `ows/crates/ows-lib/Cargo.toml` | Added `ureq` for sync HTTP |
| `ows/crates/ows-cli/src/commands/sign_permit.rs` | CLI command handler |
| `ows/crates/ows-cli/src/commands/mod.rs` | Module registration |
| `ows/crates/ows-cli/src/main.rs` | `Permit` subcommand + handler |

## Checklist
- [x] Node SDK `signPermit()`
- [x] CLI `ows sign permit`
- [x] 12 offline tests, all passing
- [x] Rust workspace builds without errors
- [x] Documentation
- [x] Follows existing code patterns (sign_message, sign_transaction)