### PR TITLE
fix(cli): append v byte to EVM signMessage output

### DIFF
--- a/ows/crates/ows-cli/src/commands/sign_message.rs
+++ b/ows/crates/ows-cli/src/commands/sign_message.rs
@@ -63,7 +63,14 @@ pub fn run(
     };
 
     print_result(
-        &hex::encode(&output.signature),
+        &{
+            let mut sig = output.signature.clone();
+            if let Some(rid) = output.recovery_id {
+                let v = if rid < 27 { rid + 27 } else { rid };
+                sig.push(v);
+            }
+            hex::encode(&sig)
+        },
         output.recovery_id,
         json_output,
     )


### PR DESCRIPTION
## Bug

`ows sign message --chain evm` returns 64-byte signatures (r + s) instead of the expected 65 bytes (r + s + v), causing `ecrecover` failures in ERC-8128 and EIP-191 verification flows.

Fixes #171

## Root cause

In `sign_message.rs`, the owner mode path encoded only `output.signature` (64 bytes) without appending the recovery ID as the `v` byte. The `recoveryId` field was correct but not included in the hex output.

## Fix

Append `v` (normalized to 27/28) to the signature bytes before hex-encoding:

```rust
let mut sig = output.signature.clone();
if let Some(rid) = output.recovery_id {
    let v = if rid < 27 { rid + 27 } else { rid };
    sig.push(v);
}
hex::encode(&sig)
```

## Notes
- Node SDK binding was not affected — CLI only
- API key path (via ows_lib::sign_message) was also not affected
- 1 file changed, 7 lines