### PR TITLE
fix: only print "Paid" on successful x402 payment response

### DIFF
--- a/ows/crates/ows-cli/src/commands/pay.rs
+++ b/ows/crates/ows-cli/src/commands/pay.rs
@@ -106,7 +106,11 @@ pub fn run(
     let result = rt.block_on(ows_pay::pay(&wallet, url, method, body))?;
 
     if result.status >= 400 {
-        eprintln!("HTTP {} — payment rejected by server", result.status);
+        if result.payment.is_some() {
+            eprintln!("HTTP {} — payment rejected by server", result.status);
+        } else {
+            eprintln!("HTTP {}", result.status);
+        }
     } else if let Some(ref payment) = result.payment {
         if !payment.amount.is_empty() {
             eprintln!(

--- a/ows/crates/ows-cli/src/commands/pay.rs
+++ b/ows/crates/ows-cli/src/commands/pay.rs
@@ -105,7 +105,9 @@ pub fn run(
 
     let result = rt.block_on(ows_pay::pay(&wallet, url, method, body))?;
 
-    if let Some(ref payment) = result.payment {
+    if result.status >= 400 {
+        eprintln!("HTTP {} — payment rejected by server", result.status);
+    } else if let Some(ref payment) = result.payment {
         if !payment.amount.is_empty() {
             eprintln!(
                 "Paid {} on {} via {}",
@@ -114,10 +116,6 @@ pub fn run(
         } else {
             eprintln!("Paid via {}", result.protocol);
         }
-    }
-
-    if result.status >= 400 {
-        eprintln!("HTTP {}", result.status);
     }
 
     println!("{}", result.body);

--- a/ows/crates/ows-cli/src/commands/pay.rs
+++ b/ows/crates/ows-cli/src/commands/pay.rs
@@ -117,7 +117,11 @@ pub fn run(
             }
         }
     } else {
-        eprintln!("HTTP {}", result.status);
+        if result.payment.is_some() {
+            eprintln!("HTTP {} — payment rejected by server", result.status);
+        } else {
+            eprintln!("HTTP {}", result.status);
+        }
     }
 
     println!("{}", result.body);


### PR DESCRIPTION
Fixes #129

Previously `ows pay request` printed "Paid $X via x402" immediately after signing, before checking whether the server accepted the payment. If the server rejected with HTTP 402, the user saw both "Paid" and an error — contradictory and misleading.

## Fix
Move the status check before the "Paid" print. Now:
- `status < 400` → prints "Paid $X on {network} via {protocol}" as before
- `status >= 400` → prints "HTTP {status} — payment rejected by server"

## Changes
- `ows-cli/src/commands/pay.rs` — reorder status check and payment confirmation print

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI stderr messaging only; no changes to signing, payment flow, or response body handling.
> 
> **Overview**
> **`ows pay request`** no longer leaves users with a misleading success line when the HTTP response is an error after a signed x402 attempt.
> 
> On **failed responses** (`status >= 400`), stderr now prints **`HTTP {status} — payment rejected by server`** when a payment was included in the result, and keeps the plain **`HTTP {status}`** line when there was no payment context. Successful responses still show the existing **"Paid … via …"** messages only when `status < 400`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9b5d5797f457f3f2cf98aa20e26b50b24f8c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->