### PR TITLE
feat: add getPublicKey across all chains

### DIFF
--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -399,3 +399,19 @@ pub fn sign_and_send(
     .map(|r| SendResult { tx_hash: r.tx_hash })
     .map_err(map_err)
 }
+
+#[napi]
+pub fn get_public_key(
+    wallet: String,
+    chain: String,
+    index: Option<u32>,
+    vault_path_opt: Option<String>,
+) -> Result<String> {
+    ows_lib::get_public_key(
+        &wallet,
+        &chain,
+        index,
+        vault_path(vault_path_opt).as_deref(),
+    )
+    .map_err(map_err)
+}

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -411,6 +411,22 @@ fn wallet_info_to_dict_inner<'py>(
 }
 
 /// Python module definition.
+#[pyfunction]
+fn get_public_key(
+    wallet: &str,
+    chain: &str,
+    index: Option<u32>,
+    vault_path_opt: Option<String>,
+) -> PyResult<String> {
+    ows_lib::get_public_key(
+        wallet,
+        chain,
+        index,
+        vault_path(vault_path_opt).as_deref(),
+    )
+    .map_err(map_err)
+}
+
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(generate_mnemonic, m)?)?;
@@ -433,6 +449,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(delete_policy, m)?)?;
     m.add_function(wrap_pyfunction!(create_api_key, m)?)?;
     m.add_function(wrap_pyfunction!(list_api_keys, m)?)?;
+    m.add_function(wrap_pyfunction!(get_public_key, m)?)?;
     m.add_function(wrap_pyfunction!(revoke_api_key, m)?)?;
     Ok(())
 }

--- a/ows/crates/ows-cli/src/commands/wallet.rs
+++ b/ows/crates/ows-cli/src/commands/wallet.rs
@@ -185,3 +185,19 @@ pub fn list() -> Result<(), CliError> {
 
     Ok(())
 }
+
+pub fn public_key(wallet_name: &str, chain: &str, index: u32, json_output: bool) -> Result<(), CliError> {
+    let pubkey = ows_lib::get_public_key(wallet_name, chain, Some(index), None)?;
+    if json_output {
+        let obj = serde_json::json!({
+            "wallet": wallet_name,
+            "chain": chain,
+            "index": index,
+            "public_key": pubkey,
+        });
+        println!("{}", serde_json::to_string_pretty(&obj)?);
+    } else {
+        println!("{pubkey}");
+    }
+    Ok(())
+}

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -132,6 +132,21 @@ enum WalletCommands {
     List,
     /// Show vault path and supported chains
     Info,
+    /// Show the raw public key for a wallet on a given chain
+    PublicKey {
+        /// Wallet name or ID
+        #[arg(long, env = "OWS_WALLET")]
+        wallet: String,
+        /// Chain name or CAIP-2 ID (e.g. "ton", "evm", "solana")
+        #[arg(long)]
+        chain: String,
+        /// Account index
+        #[arg(long, default_value = "0")]
+        index: u32,
+        /// Output structured JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -419,6 +434,9 @@ fn run(cli: Cli) -> Result<(), CliError> {
             }
             WalletCommands::List => commands::wallet::list(),
             WalletCommands::Info => commands::info::run(),
+            WalletCommands::PublicKey { wallet, chain, index, json } => {
+                commands::wallet::public_key(&wallet, &chain, index, json)
+            }
         },
         Commands::Sign { subcommand } => match subcommand {
             SignCommands::Message {

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -2911,3 +2911,112 @@ mod tests {
         }
     }
 }
+
+/// Return the raw public key bytes for a wallet on a given chain.
+///
+/// Public keys are not secret — exposing them does not weaken the security
+/// model. This eliminates the need to export the mnemonic just to derive
+/// the public key externally (e.g. for TON wallet contract initialization).
+///
+/// Returns:
+/// - secp256k1 chains (EVM, Bitcoin, Cosmos, Tron, XRPL, Filecoin, Spark):
+///   33-byte compressed SEC1 public key, hex-encoded.
+/// - Ed25519 chains (TON, Solana, Sui):
+///   32-byte public key, hex-encoded.
+///
+/// # Example
+/// ```no_run
+/// # use ows_lib::get_public_key;
+/// let pubkey = get_public_key("my-wallet", "ton", None, None).unwrap();
+/// // pubkey = "a1b2c3..." (32-byte hex for Ed25519)
+/// ```
+pub fn get_public_key(
+    wallet: &str,
+    chain: &str,
+    index: Option<u32>,
+    vault_path: Option<&std::path::Path>,
+) -> Result<String, OwsLibError> {
+    let chain_parsed = parse_chain(chain)?;
+    let key = decrypt_signing_key(wallet, chain_parsed.chain_type, "", index, vault_path)?;
+    let signer = signer_for_chain(chain_parsed.chain_type);
+    let pubkey_bytes = signer.derive_public_key(key.expose())?;
+    Ok(hex::encode(pubkey_bytes))
+}
+
+#[cfg(test)]
+mod pubkey_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn make_wallet(name: &str, vault: &std::path::Path) -> WalletInfo {
+        create_wallet(name, Some(12), None, Some(vault)).unwrap()
+    }
+
+    #[test]
+    fn get_public_key_evm_returns_33_bytes() {
+        let dir = tempdir().unwrap();
+        make_wallet("pk-evm", dir.path());
+        let hex = get_public_key("pk-evm", "evm", None, Some(dir.path())).unwrap();
+        assert_eq!(hex.len(), 66, "33 bytes = 66 hex chars");
+        assert!(hex.starts_with("02") || hex.starts_with("03"), "compressed secp256k1");
+    }
+
+    #[test]
+    fn get_public_key_ton_returns_32_bytes() {
+        let dir = tempdir().unwrap();
+        make_wallet("pk-ton", dir.path());
+        let hex = get_public_key("pk-ton", "ton", None, Some(dir.path())).unwrap();
+        assert_eq!(hex.len(), 64, "32 bytes = 64 hex chars");
+    }
+
+    #[test]
+    fn get_public_key_solana_returns_32_bytes() {
+        let dir = tempdir().unwrap();
+        make_wallet("pk-sol", dir.path());
+        let hex = get_public_key("pk-sol", "solana", None, Some(dir.path())).unwrap();
+        assert_eq!(hex.len(), 64);
+    }
+
+    #[test]
+    fn get_public_key_bitcoin_returns_33_bytes() {
+        let dir = tempdir().unwrap();
+        make_wallet("pk-btc", dir.path());
+        let hex = get_public_key("pk-btc", "bitcoin", None, Some(dir.path())).unwrap();
+        assert_eq!(hex.len(), 66);
+        assert!(hex.starts_with("02") || hex.starts_with("03"));
+    }
+
+    #[test]
+    fn get_public_key_is_deterministic() {
+        let dir = tempdir().unwrap();
+        make_wallet("pk-det", dir.path());
+        let pk1 = get_public_key("pk-det", "evm", None, Some(dir.path())).unwrap();
+        let pk2 = get_public_key("pk-det", "evm", None, Some(dir.path())).unwrap();
+        assert_eq!(pk1, pk2);
+    }
+
+    #[test]
+    fn get_public_key_different_index_yields_different_key() {
+        let dir = tempdir().unwrap();
+        make_wallet("pk-idx", dir.path());
+        let pk0 = get_public_key("pk-idx", "evm", Some(0), Some(dir.path())).unwrap();
+        let pk1 = get_public_key("pk-idx", "evm", Some(1), Some(dir.path())).unwrap();
+        assert_ne!(pk0, pk1);
+    }
+
+    #[test]
+    fn get_public_key_fails_for_nonexistent_wallet() {
+        let dir = tempdir().unwrap();
+        assert!(get_public_key("no-such-wallet", "evm", None, Some(dir.path())).is_err());
+    }
+
+    #[test]
+    fn get_public_key_all_chains() {
+        let dir = tempdir().unwrap();
+        make_wallet("pk-all", dir.path());
+        for chain in &["evm", "solana", "ton", "bitcoin", "cosmos", "tron", "sui", "filecoin"] {
+            let hex = get_public_key("pk-all", chain, None, Some(dir.path())).unwrap();
+            assert!(hex.len() == 64 || hex.len() == 66, "chain {chain}: unexpected key length {}", hex.len());
+        }
+    }
+}

--- a/ows/crates/ows-signer/src/chains/bitcoin.rs
+++ b/ows/crates/ows-signer/src/chains/bitcoin.rs
@@ -88,6 +88,13 @@ impl ChainSigner for BitcoinSigner {
 
         Ok(address)
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+        let compressed = verifying_key.to_encoded_point(true);
+        Ok(compressed.as_bytes().to_vec())
+    }
+
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         if message.len() != 32 {

--- a/ows/crates/ows-signer/src/chains/cosmos.rs
+++ b/ows/crates/ows-signer/src/chains/cosmos.rs
@@ -66,6 +66,13 @@ impl ChainSigner for CosmosSigner {
 
         Ok(address)
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+        let compressed = verifying_key.to_encoded_point(true);
+        Ok(compressed.as_bytes().to_vec())
+    }
+
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         if message.len() != 32 {

--- a/ows/crates/ows-signer/src/chains/evm.rs
+++ b/ows/crates/ows-signer/src/chains/evm.rs
@@ -88,6 +88,13 @@ impl ChainSigner for EvmSigner {
 
         Ok(Self::eip55_checksum(&address_hex))
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+        let compressed = verifying_key.to_encoded_point(true);
+        Ok(compressed.as_bytes().to_vec())
+    }
+
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         if message.len() != 32 {

--- a/ows/crates/ows-signer/src/chains/filecoin.rs
+++ b/ows/crates/ows-signer/src/chains/filecoin.rs
@@ -97,6 +97,13 @@ impl ChainSigner for FilecoinSigner {
 
         Ok(format!("f1{}", Self::base32_encode(&addr_bytes)))
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+        let compressed = verifying_key.to_encoded_point(true);
+        Ok(compressed.as_bytes().to_vec())
+    }
+
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         if message.len() != 32 {

--- a/ows/crates/ows-signer/src/chains/solana.rs
+++ b/ows/crates/ows-signer/src/chains/solana.rs
@@ -55,6 +55,12 @@ impl ChainSigner for SolanaSigner {
         let verifying_key: VerifyingKey = signing_key.verifying_key();
         Ok(bs58::encode(verifying_key.as_bytes()).into_string())
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+        Ok(verifying_key.as_bytes().to_vec())
+    }
+
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         let signing_key = Self::signing_key(private_key)?;

--- a/ows/crates/ows-signer/src/chains/spark.rs
+++ b/ows/crates/ows-signer/src/chains/spark.rs
@@ -39,6 +39,13 @@ impl ChainSigner for SparkSigner {
             hex::encode(pubkey_compressed.as_bytes())
         ))
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+        let compressed = verifying_key.to_encoded_point(true);
+        Ok(compressed.as_bytes().to_vec())
+    }
+
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         if message.len() != 32 {

--- a/ows/crates/ows-signer/src/chains/sui.rs
+++ b/ows/crates/ows-signer/src/chains/sui.rs
@@ -74,6 +74,12 @@ impl ChainSigner for SuiSigner {
 
         Ok(format!("0x{}", hex::encode(hash)))
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+        Ok(verifying_key.as_bytes().to_vec())
+    }
+
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         let signing_key = Self::signing_key(private_key)?;

--- a/ows/crates/ows-signer/src/chains/ton.rs
+++ b/ows/crates/ows-signer/src/chains/ton.rs
@@ -174,6 +174,12 @@ impl ChainSigner for TonSigner {
 
         Ok(Self::encode_address(0, &state_hash, false))
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+        Ok(verifying_key.as_bytes().to_vec())
+    }
+
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         let signing_key = Self::signing_key(private_key)?;

--- a/ows/crates/ows-signer/src/chains/tron.rs
+++ b/ows/crates/ows-signer/src/chains/tron.rs
@@ -52,6 +52,13 @@ impl ChainSigner for TronSigner {
 
         Ok(address)
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key = signing_key.verifying_key();
+        let compressed = verifying_key.to_encoded_point(true);
+        Ok(compressed.as_bytes().to_vec())
+    }
+
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         if message.len() != 32 {

--- a/ows/crates/ows-signer/src/chains/xrpl.rs
+++ b/ows/crates/ows-signer/src/chains/xrpl.rs
@@ -70,6 +70,13 @@ impl ChainSigner for XrplSigner {
             public_key: None,
         })
     }
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+        let signing_key = SigningKey::from_slice(private_key)
+            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
+        let compressed = signing_key.verifying_key().to_encoded_point(true);
+        Ok(compressed.as_bytes().to_vec())
+    }
+
 
     /// Sign a binary-encoded unsigned XRPL transaction.
     ///

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -29,6 +29,15 @@ pub trait ChainSigner: Send + Sync {
     /// Derive an on-chain address from a private key.
     fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError>;
 
+    /// Derive the raw public key bytes from a private key.
+    ///
+    /// Returns the canonical public key encoding for this chain's curve:
+    /// - secp256k1 chains: 33-byte compressed public key (SEC1)
+    /// - Ed25519 chains: 32-byte public key
+    ///
+    /// Public keys are not secret — exposing them does not weaken the security model.
+    fn derive_public_key(&self, private_key: &[u8]) -> Result<Vec<u8>, SignerError>;
+
     /// Sign a pre-hashed message (32 bytes for secp256k1, raw message for ed25519).
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError>;
 


### PR DESCRIPTION
## Summary

Adds `getPublicKey(walletName, chainId)` to the Node SDK, Python SDK, and CLI. Eliminates the mnemonic round-trip workaround for public key access.

Closes #157

## Problem

TON wallet contract initialization (`WalletContractV5R1`) requires the raw Ed25519 public key. The only workaround was calling `exportWallet()` to get the mnemonic, re-deriving the keypair externally, then zeroing secret material — partially undermining key isolation even with careful zeroing.

## Solution

```js
// Node SDK
const pubkey = getPublicKey('my-wallet', 'ton', undefined, vaultDir);
// → 'a1b2c3...' (32-byte hex, Ed25519)

const evmPubkey = getPublicKey('my-wallet', 'evm', undefined, vaultDir);
// → '02a1b2...' (33-byte compressed SEC1)
```

```bash
# CLI
ows wallet public-key --wallet my-wallet --chain ton
ows wallet public-key --wallet my-wallet --chain evm --json
```

```python
# Python SDK
pubkey = get_public_key('my-wallet', 'ton', None, vault_dir)
```

## Return format

| Curve | Chains | Format |
|-------|--------|--------|
| Ed25519 | TON, Solana, Sui | 32-byte hex (64 chars) |
| secp256k1 | EVM, Bitcoin, Cosmos, Tron, XRPL, Filecoin, Spark | 33-byte compressed SEC1 (66 chars, `02`/`03` prefix) |

## Changes

- `ows-signer`: `derive_public_key()` added to `ChainSigner` trait, implemented for all 10 chains
- `ows-lib`: `get_public_key(wallet, chain, index, vault_path)` with 8 unit tests
- `bindings/node`: `getPublicKey()` exported via NAPI
- `bindings/python`: `get_public_key()` exported via PyO3
- `ows-cli`: `ows wallet public-key --wallet --chain [--index] [--json]`

## Tests

```
test get_public_key_evm_returns_33_bytes ... ok
test get_public_key_ton_returns_32_bytes ... ok
test get_public_key_solana_returns_32_bytes ... ok
test get_public_key_bitcoin_returns_33_bytes ... ok
test get_public_key_is_deterministic ... ok
test get_public_key_different_index_yields_different_key ... ok
test get_public_key_fails_for_nonexistent_wallet ... ok
test get_public_key_all_chains ... ok

8 passed — 144 existing ows-lib tests also pass
```

## Security

Public keys are not secret — exposing them does not weaken the security model. Private key material never leaves the OWS signing core.