### PR TITLE
feat: add Stellar chain support with Soroban auth signing and x402 payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Local, policy-gated signing and wallet management for every chain.
 ## Why OWS
 
 - **Local key custody.** Private keys stay encrypted at rest and are decrypted only inside the OWS signing path after the relevant checks pass. Current implementations harden in-process memory handling and wipe key material after use.
-- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
+- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Stellar, Spark, Filecoin — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
 - **Policy before signing.** A pre-signing policy engine gates agent (API key) operations before decryption — chain allowlists, expiry, and optional custom executables.
 - **Built for agents.** Native SDK and CLI today. A wallet created by one tool works in every other.
 
@@ -55,7 +55,7 @@ ows sign tx --wallet agent-treasury --chain 8453 --tx "02f8..."
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("agent-treasury");
-// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Stellar, Filecoin, Sui, and XRPL
 
 const sig = signMessage("agent-treasury", "evm", "hello");
 console.log(sig.signature);
@@ -65,7 +65,7 @@ console.log(sig.signature);
 from ows import create_wallet, sign_message
 
 wallet = create_wallet("agent-treasury")
-# => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+# => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Stellar, Filecoin, Sui, and XRPL
 
 sig = sign_message("agent-treasury", "evm", "hello")
 print(sig["signature"])
@@ -106,6 +106,7 @@ Agent / CLI / App
 | Tron | secp256k1 | base58check | `m/44'/195'/0'/0/0` |
 | TON | Ed25519 | raw/bounceable | `m/44'/607'/0'` |
 | Sui | Ed25519 | 0x + BLAKE2b-256 hex | `m/44'/784'/0'/0'/0'` |
+| Stellar | Ed25519 | Base32 Strkey (G...) | `m/44'/148'/0'` |
 | Spark (Bitcoin L2) | secp256k1 | spark: prefixed | `m/84'/0'/0'/0/0` |
 | Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
 | XRPL | secp256k1 | base58check | `m/44'/144'/0'/0/0`|

--- a/docs/02-signing-interface.md
+++ b/docs/02-signing-interface.md
@@ -79,6 +79,7 @@ Message signing follows chain-specific conventions:
 - **Solana**: Ed25519 signature over the raw message bytes
 - **Sui**: Intent-prefixed (scope=3) BLAKE2b-256 digest, Ed25519 signature
 - **Cosmos**: ADR-036 off-chain signing
+- **Stellar**: SEP-53 message signing
 - **Filecoin**: Blake2b-256 hash then secp256k1 signing
 
 ### `signTypedData(request: SignTypedDataRequest): Promise<SignMessageResult>`

--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -21,7 +21,7 @@ type AssetId = `${ChainId}:${string}`;
 // e.g. "eip155:8453:native" (ETH on Base)
 ```
 
-The `native` token refers to the chain's native currency (ETH, SOL, SUI, XRP, BTC, ATOM, TRX, TON, etc.).
+The `native` token refers to the chain's native currency (ETH, SOL, SUI, XRP, XLM, BTC, ATOM, TRX, TON, etc.).
 
 ## Chain Families
 
@@ -37,6 +37,7 @@ OWS groups chains into families that share a cryptographic curve and address der
 | TON | ed25519 | 607 | `m/44'/607'/{index}'` | Base64url wallet v5r1 (`UQ...`) | `ton` |
 | Sui | ed25519 | 784 | `m/44'/784'/{index}'/0'/0'` | `0x` + BLAKE2b-256 hex (32 bytes) | `sui` |
 | XRPL | secp256k1 | 144 | `m/44'/144'/0'/0/{index}` | Base58Check (`r...`) | `xrpl` |
+| Stellar | ed25519 | 148 | `m/44'/148'/0'` | Base32 Strkey (`G...`, 56 chars) | `stellar` |
 | Spark | secp256k1 | 8797555 | `m/84'/0'/0'/0/{index}` | `spark:` + compressed pubkey hex | `spark` |
 | Filecoin | secp256k1 | 461 | `m/44'/461'/0'/0/{index}` | `f1` + base32(blake2b-160) | `fil` |
 
@@ -71,6 +72,9 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | TON | `ton:mainnet` |
 | Sui | `sui:mainnet` |
 | XRPL | `xrpl:mainnet` |
+| Stellar | `stellar:pubnet` |
+| Stellar Testnet | `stellar:testnet` |
+| Stellar Futurenet | `stellar:futurenet` |
 | Spark | `spark:mainnet` |
 | Filecoin | `fil:mainnet` |
 
@@ -102,6 +106,9 @@ xrpl          → xrpl:mainnet
 xrpl-mainnet  → xrpl:mainnet
 xrpl-testnet  → xrpl:testnet
 xrpl-devnet   → xrpl:devnet
+stellar          → stellar:pubnet
+stellar-testnet  → stellar:testnet
+stellar-futurenet → stellar:futurenet
 spark     → spark:mainnet
 filecoin  → fil:mainnet
 ```
@@ -126,6 +133,7 @@ Master Seed (512 bits via PBKDF2)
     ├── m/44'/607'/0'       → TON Account 0
     ├── m/44'/784'/0'/0'/0' → Sui Account 0
     ├── m/44'/144'/0'/0/0   → XRPL Account 0
+    ├── m/44'/148'/0'       → Stellar Account 0
     ├── m/84'/0'/0'/0/0     → Spark Account 0
     └── m/44'/461'/0'/0/0   → Filecoin Account 0
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,7 +19,7 @@ pip install open-wallet-standard           # Python
 
 ## Create a wallet
 
-A single command derives addresses for every supported chain — EVM, Solana, Sui, Bitcoin, Cosmos, Tron, and TON.
+A single command derives addresses for every supported chain — EVM, Solana, Sui, Bitcoin, Cosmos, Tron, TON, and Stellar.
 
 ```bash
 ows wallet create --name "agent-treasury"

--- a/docs/sdk-cli.md
+++ b/docs/sdk-cli.md
@@ -45,6 +45,7 @@ Created wallet 3198bc9c-...
   cosmos:cosmoshub-4                     cosmos1... m/44'/118'/0'/0/0
   tron:mainnet                           TKLm...    m/44'/195'/0'/0/0
   xrpl:mainnet                           rHsM...    m/44'/144'/0'/0/0
+  stellar:pubnet                         GABC...    m/44'/148'/0'
 ```
 
 ### `ows wallet import`
@@ -58,7 +59,7 @@ echo "goose puzzle decorate ..." | ows wallet import --name "imported" --mnemoni
 # Import from private key (reads from OWS_PRIVATE_KEY env or stdin)
 echo "4c0883a691..." | ows wallet import --name "from-evm" --private-key
 
-# Import an Ed25519 key (e.g. from Solana)
+# Import an Ed25519 key (e.g. from Solana or Stellar)
 echo "9d61b19d..." | ows wallet import --name "from-sol" --private-key --chain solana
 
 # Import explicit keys for both curves via environment variables
@@ -77,7 +78,7 @@ OWS_ED25519_KEY="9d61b19d..." \
 | `OWS_SECP256K1_KEY` | Explicit secp256k1 private key via environment variable |
 | `OWS_ED25519_KEY` | Explicit Ed25519 private key via environment variable |
 
-Private key imports generate all 9 chain accounts: the provided key is used for its curve's chains, and a random key is generated for the other curve. Use `OWS_SECP256K1_KEY` and `OWS_ED25519_KEY` together to supply both keys explicitly.
+Private key imports generate all 10 chain accounts: the provided key is used for its curve's chains, and a random key is generated for the other curve. Use `OWS_SECP256K1_KEY` and `OWS_ED25519_KEY` together to supply both keys explicitly.
 
 ### `ows wallet export`
 

--- a/docs/sdk-node.md
+++ b/docs/sdk-node.md
@@ -92,7 +92,7 @@ const solAddr = deriveAddress(mnemonic, "solana");
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mnemonic` | `string` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `string` | &mdash; | `"evm"`, `"solana"`, `"xrpl"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` |
+| `chain` | `string` | &mdash; | `"evm"`, `"solana"`, `"xrpl"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"stellar"`, `"filecoin"` |
 | `index` | `number` | `0` | Account index in derivation path |
 
 **Returns:** `string`
@@ -115,6 +115,7 @@ console.log(wallet.accounts);
 //   { chainId: "ton:mainnet", address: "UQ...", derivationPath: "m/44'/607'/0'" },
 //   { chainId: "sui:mainnet", address: "0x...", derivationPath: "m/44'/784'/0'/0'/0'" },
 //   { chainId: "xrpl:mainnet", address: "r...", derivationPath: "m/44'/144'/0'/0/0" },
+//   { chainId: "stellar:pubnet", address: "GABC...", derivationPath: "m/44'/148'/0'" },
 //   { chainId: "fil:mainnet", address: "f1...", derivationPath: "m/44'/461'/0'/0/0" },
 // ]
 ```
@@ -189,7 +190,7 @@ const keys = JSON.parse(keysJson);
 
 #### `importWalletMnemonic(name, mnemonic, passphrase?, index?, vaultPath?)`
 
-Import a wallet from a BIP-39 mnemonic. Derives all 9 chain accounts via HD paths.
+Import a wallet from a BIP-39 mnemonic. Derives all 10 chain accounts via HD paths.
 
 ```javascript
 const wallet = importWalletMnemonic("imported", "goose puzzle decorate ...");
@@ -199,7 +200,7 @@ const wallet = importWalletMnemonic("imported", "goose puzzle decorate ...");
 
 #### `importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?)`
 
-Import a wallet from a hex-encoded private key. All 9 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
+Import a wallet from a hex-encoded private key. All 10 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
 
 The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
 
@@ -208,7 +209,7 @@ Alternatively, provide explicit keys for each curve via `secp256k1Key` and `ed25
 ```javascript
 // Import an EVM private key — generates a random Ed25519 key for Solana/Sui/TON
 const wallet = importWalletPrivateKey("from-evm", "4c0883a691...");
-console.log(wallet.accounts.length); // => 9
+console.log(wallet.accounts.length); // => 10
 
 // Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
 const wallet2 = importWalletPrivateKey(
@@ -231,7 +232,7 @@ console.log(wallet3.accounts.length); // => 8
 | `privateKeyHex` | `string` | &mdash; | Hex-encoded private key (with or without `0x` prefix). Ignored when both curve keys are provided. |
 | `passphrase` | `string` | `undefined` | Encryption passphrase |
 | `vaultPath` | `string` | `~/.ows` | Custom vault directory root |
-| `chain` | `string` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"` (Ed25519) |
+| `chain` | `string` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"`, `"stellar"` (Ed25519) |
 | `secp256k1Key` | `string` | `undefined` | Explicit secp256k1 private key (hex). Overrides random generation for secp256k1 chains. |
 | `ed25519Key` | `string` | `undefined` | Explicit Ed25519 private key (hex). Overrides random generation for Ed25519 chains. |
 

--- a/docs/sdk-python.md
+++ b/docs/sdk-python.md
@@ -92,7 +92,7 @@ sol_addr = derive_address(mnemonic, "solana")
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mnemonic` | `str` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `str` | &mdash; | `"evm"`, `"solana"`, `"xrpl"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"ton"`, `"spark"`, `"filecoin"` |
+| `chain` | `str` | &mdash; | `"evm"`, `"solana"`, `"xrpl"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"ton"`, `"stellar"`, `"spark"`, `"filecoin"` |
 | `index` | `int` | `0` | Account index in derivation path |
 
 ### Wallet Management
@@ -162,7 +162,7 @@ keys = json.loads(export_wallet("pk-wallet"))
 
 #### `import_wallet_mnemonic(name, mnemonic, passphrase=None, index=None, vault_path=None)`
 
-Import a wallet from a BIP-39 mnemonic. Derives all 9 chain accounts via HD paths.
+Import a wallet from a BIP-39 mnemonic. Derives all 10 chain accounts via HD paths.
 
 ```python
 wallet = import_wallet_mnemonic("imported", "goose puzzle decorate ...")
@@ -170,7 +170,7 @@ wallet = import_wallet_mnemonic("imported", "goose puzzle decorate ...")
 
 #### `import_wallet_private_key(name, private_key_hex, chain=None, passphrase=None, vault_path=None, secp256k1_key=None, ed25519_key=None)`
 
-Import a wallet from a hex-encoded private key. All 9 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
+Import a wallet from a hex-encoded private key. All 10 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
 
 The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
 
@@ -179,13 +179,13 @@ Alternatively, provide explicit keys for each curve via `secp256k1_key` and `ed2
 ```python
 # Import an EVM private key — generates a random Ed25519 key for Solana/Sui/TON
 wallet = import_wallet_private_key("from-evm", "4c0883a691...")
-print(len(wallet["accounts"]))  # => 9
+print(len(wallet["accounts"]))  # => 10
 
 # Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
 wallet = import_wallet_private_key(
     "from-solana", "9d61b19d...", chain="solana"
 )
-print(len(wallet["accounts"]))  # => 9
+print(len(wallet["accounts"]))  # => 10
 
 # Import explicit keys for both curves
 wallet = import_wallet_private_key(
@@ -193,14 +193,14 @@ wallet = import_wallet_private_key(
     secp256k1_key="4c0883a691...",
     ed25519_key="9d61b19d..."
 )
-print(len(wallet["accounts"]))  # => 9
+print(len(wallet["accounts"]))  # => 10
 ```
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `name` | `str` | &mdash; | Wallet name |
 | `private_key_hex` | `str` | &mdash; | Hex-encoded private key. Ignored when both curve keys are provided. |
-| `chain` | `str` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"` (Ed25519) |
+| `chain` | `str` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"`, `"stellar"` (Ed25519) |
 | `passphrase` | `str` | `None` | Encryption passphrase |
 | `vault_path` | `str` | `None` | Custom vault directory |
 | `secp256k1_key` | `str` | `None` | Explicit secp256k1 private key (hex) |

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -1632,6 +1632,9 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
+ "stellar-strkey 0.0.16",
+ "stellar-xdr",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -344,6 +344,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cfg_eval"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +509,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +617,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -769,6 +797,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "escape-bytes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
+
+[[package]]
+name = "ethnum"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "fastrand"
@@ -1572,6 +1612,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
+ "stellar-xdr",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1622,6 +1663,8 @@ dependencies = [
  "sha2",
  "sha3",
  "signal-hook",
+ "stellar-strkey 0.0.16",
+ "stellar-xdr",
  "thiserror 2.0.18",
  "xrpl-rust",
  "zeroize",
@@ -2456,6 +2499,42 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+ "heapless",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "26.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea3195594b044ea3a5b05906f81d945480825f00db4e3ae7d77526bf546ff3a"
+dependencies = [
+ "cfg_eval",
+ "crate-git-revision",
+ "escape-bytes",
+ "ethnum",
+ "hex",
+ "sha2",
+ "stellar-strkey 0.0.13",
+]
 
 [[package]]
 name = "strsim"

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -323,9 +323,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -812,9 +812,9 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -988,7 +988,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1115,9 +1115,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1130,7 +1130,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1215,12 +1214,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1228,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1255,15 +1255,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1275,15 +1275,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1340,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1398,9 +1398,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1445,9 +1445,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -1463,9 +1463,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -1633,7 +1633,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "stellar-strkey 0.0.16",
+ "stellar-strkey",
  "stellar-xdr",
  "thiserror 2.0.18",
  "tokio",
@@ -1666,7 +1666,7 @@ dependencies = [
  "sha2",
  "sha3",
  "signal-hook",
- "stellar-strkey 0.0.16",
+ "stellar-strkey",
  "stellar-xdr",
  "thiserror 2.0.18",
  "xrpl-rust",
@@ -1727,12 +1727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2297,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2377,7 +2371,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2427,9 +2421,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2514,17 +2508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stellar-strkey"
-version = "0.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
-dependencies = [
- "crate-git-revision",
- "data-encoding",
- "heapless",
-]
-
-[[package]]
 name = "stellar-xdr"
 version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,7 +2519,7 @@ dependencies = [
  "ethnum",
  "hex",
  "sha2",
- "stellar-strkey 0.0.13",
+ "stellar-strkey",
 ]
 
 [[package]]
@@ -2724,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2749,9 +2732,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -2764,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3055,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3069,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3079,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3089,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3102,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3126,7 +3109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3139,15 +3122,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3424,7 +3407,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -3455,7 +3438,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -3474,7 +3457,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -3486,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -3516,7 +3499,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "lazy_static",
  "rand 0.8.5",
  "rand_hc",
@@ -3550,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3561,9 +3544,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3593,18 +3576,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3634,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3645,9 +3628,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3656,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ows/Cargo.toml
+++ b/ows/Cargo.toml
@@ -4,4 +4,4 @@ members = ["crates/ows-core", "crates/ows-signer", "crates/ows-lib", "crates/ows
 
 [workspace.dependencies]
 stellar-xdr = { version = "26.0.0", features = ["curr"] }
-stellar-strkey = "0.0.16"
+stellar-strkey = "0.0.13"

--- a/ows/Cargo.toml
+++ b/ows/Cargo.toml
@@ -4,3 +4,4 @@ members = ["crates/ows-core", "crates/ows-signer", "crates/ows-lib", "crates/ows
 
 [workspace.dependencies]
 stellar-xdr = { version = "26.0.0", features = ["curr"] }
+stellar-strkey = "0.0.16"

--- a/ows/Cargo.toml
+++ b/ows/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "2"
 members = ["crates/ows-core", "crates/ows-signer", "crates/ows-lib", "crates/ows-pay", "crates/ows-cli"]
+
+[workspace.dependencies]
+stellar-xdr = { version = "26.0.0", features = ["curr"] }

--- a/ows/crates/ows-cli/src/commands/derive.rs
+++ b/ows/crates/ows-cli/src/commands/derive.rs
@@ -12,7 +12,7 @@ pub fn run(chain_str: Option<&str>, index: u32) -> Result<(), CliError> {
     if let Some(cs) = chain_str {
         // Derive for a single chain
         let chain = parse_chain(cs)?;
-        let signer = signer_for_chain(chain.chain_type);
+        let signer = signer_for_chain(&chain);
         let path = signer.default_derivation_path(index);
         let curve = signer.curve();
 
@@ -24,7 +24,7 @@ pub fn run(chain_str: Option<&str>, index: u32) -> Result<(), CliError> {
         // Derive for all chains
         for ct in &ALL_CHAIN_TYPES {
             let chain = default_chain_for_type(*ct);
-            let signer = signer_for_chain(*ct);
+            let signer = signer_for_chain(&chain);
             let path = signer.default_derivation_path(index);
             let curve = signer.curve();
 

--- a/ows/crates/ows-cli/src/commands/fund.rs
+++ b/ows/crates/ows-cli/src/commands/fund.rs
@@ -6,14 +6,13 @@ fn find_account_for_chain<'a>(
     accounts: &'a [AccountInfo],
     chain: &str,
 ) -> Result<&'a AccountInfo, CliError> {
-    let chain_prefix = match chain {
-        "solana" => "solana:",
-        _ => "eip155:",
-    };
+    let parsed = ows_core::chain::parse_chain(chain)
+        .map_err(|_| CliError::InvalidArgs(format!("unknown chain: {chain}")))?;
+    let prefix = format!("{}:", parsed.chain_type.namespace());
 
     accounts
         .iter()
-        .find(|a| a.chain_id.starts_with(chain_prefix))
+        .find(|a| a.chain_id.starts_with(&prefix))
         .ok_or_else(|| {
             CliError::InvalidArgs(format!("wallet has no account for chain \"{chain}\""))
         })

--- a/ows/crates/ows-cli/src/commands/pay.rs
+++ b/ows/crates/ows-cli/src/commands/pay.rs
@@ -79,14 +79,51 @@ impl ows_pay::WalletAccess for OwsLibWallet {
             )),
         }
     }
+
+    fn sign_stellar_auth(
+        &self,
+        network: &str,
+        preimage_xdr: &str,
+    ) -> Result<String, ows_pay::PayError> {
+        use base64::{engine::general_purpose::STANDARD as B64, Engine};
+
+        let preimage_bytes = B64.decode(preimage_xdr).map_err(|e| {
+            ows_pay::PayError::new(
+                ows_pay::PayErrorCode::ProtocolMalformed,
+                format!("invalid base64 auth preimage: {e}"),
+            )
+        })?;
+
+        let result = ows_lib::sign_stellar_auth_entry(
+            &self.wallet_name,
+            network,
+            &preimage_bytes,
+            Some(&self.passphrase),
+            None,
+            None,
+        )
+        .map_err(|e| {
+            ows_pay::PayError::new(ows_pay::PayErrorCode::SigningFailed, e.to_string())
+        })?;
+
+        let sig_bytes = hex::decode(&result.signature).map_err(|e| {
+            ows_pay::PayError::new(
+                ows_pay::PayErrorCode::SigningFailed,
+                format!("invalid hex from signer: {e}"),
+            )
+        })?;
+
+        Ok(B64.encode(&sig_bytes))
+    }
 }
 
-/// `ows pay request <url> --wallet <name> [--method GET] [--body '{}']`
+/// `ows pay request <url> --wallet <name> [--method GET] [--body '{}'] [--network <net>]`
 pub fn run(
     url: &str,
     wallet_name: &str,
     method: &str,
     body: Option<&str>,
+    network: Option<&str>,
     skip_passphrase: bool,
 ) -> Result<(), CliError> {
     let passphrase = if skip_passphrase {
@@ -103,7 +140,7 @@ pub fn run(
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| CliError::InvalidArgs(format!("tokio: {e}")))?;
 
-    let result = rt.block_on(ows_pay::pay(&wallet, url, method, body))?;
+    let result = rt.block_on(ows_pay::pay(&wallet, url, method, body, network))?;
 
     if result.status < 400 {
         if let Some(ref payment) = result.payment {

--- a/ows/crates/ows-cli/src/commands/sign_message.rs
+++ b/ows/crates/ows-cli/src/commands/sign_message.rs
@@ -45,7 +45,7 @@ pub fn run(
     let chain = parse_chain(chain_str)?;
     let key = super::resolve_signing_key(wallet_name, chain.chain_type, index)?;
 
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
 
     let output = if let Some(td_json) = typed_data {
         if chain.chain_type != ows_core::ChainType::Evm {

--- a/ows/crates/ows-cli/src/commands/sign_transaction.rs
+++ b/ows/crates/ows-cli/src/commands/sign_transaction.rs
@@ -34,7 +34,7 @@ pub fn run(
     let tx_bytes = hex::decode(tx_hex_clean)
         .map_err(|e| CliError::InvalidArgs(format!("invalid hex transaction: {e}")))?;
 
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
     let signable = signer.extract_signable_bytes(&tx_bytes)?;
     let output = signer.sign_transaction(key.expose(), signable)?;
 

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -260,6 +260,9 @@ enum PayCommands {
         /// Request body (JSON)
         #[arg(long)]
         body: Option<String>,
+        /// Preferred network (e.g. "eip155:84532", "stellar:testnet")
+        #[arg(long)]
+        network: Option<String>,
         /// Skip passphrase prompt (use empty passphrase)
         #[arg(long)]
         no_passphrase: bool,
@@ -477,8 +480,9 @@ fn run(cli: Cli) -> Result<(), CliError> {
                 wallet,
                 method,
                 body,
+                network,
                 no_passphrase,
-            } => commands::pay::run(&url, &wallet, &method, body.as_deref(), no_passphrase),
+            } => commands::pay::run(&url, &wallet, &method, body.as_deref(), network.as_deref(), no_passphrase),
             PayCommands::Discover {
                 query,
                 limit,

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -28,6 +28,7 @@ pub const ALL_CHAIN_TYPES: [ChainType; 12] = [
     ChainType::Cosmos,
     ChainType::Tron,
     ChainType::Ton,
+    ChainType::Spark,
     ChainType::Filecoin,
     ChainType::Sui,
     ChainType::Xrpl,

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -17,10 +17,11 @@ pub enum ChainType {
     Sui,
     Xrpl,
     Nano,
+    Stellar,
 }
 
 /// All supported chain families, used for universal wallet derivation.
-pub const ALL_CHAIN_TYPES: [ChainType; 10] = [
+pub const ALL_CHAIN_TYPES: [ChainType; 12] = [
     ChainType::Evm,
     ChainType::Solana,
     ChainType::Bitcoin,
@@ -31,6 +32,7 @@ pub const ALL_CHAIN_TYPES: [ChainType; 10] = [
     ChainType::Sui,
     ChainType::Xrpl,
     ChainType::Nano,
+    ChainType::Stellar,
 ];
 
 /// A specific chain (e.g. "ethereum", "arbitrum") with its family type and CAIP-2 ID.
@@ -190,7 +192,27 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_type: ChainType::Evm,
         chain_id: "eip155:999",
     },
+    Chain {
+        name: "stellar",
+        chain_type: ChainType::Stellar,
+        chain_id: "stellar:pubnet",
+    },
+    Chain {
+        name: "stellar-testnet",
+        chain_type: ChainType::Stellar,
+        chain_id: "stellar:testnet",
+    },
+    Chain {
+        name: "stellar-futurenet",
+        chain_type: ChainType::Stellar,
+        chain_id: "stellar:futurenet",
+    },
 ];
+
+/// Stellar network passphrases — used for transaction signing.
+pub const STELLAR_PASSPHRASE_PUBNET: &str = "Public Global Stellar Network ; September 2015";
+pub const STELLAR_PASSPHRASE_TESTNET: &str = "Test SDF Network ; September 2015";
+pub const STELLAR_PASSPHRASE_FUTURENET: &str = "Test SDF Future Network ; October 2022";
 
 /// Parse a chain string into a `Chain`. Accepts:
 /// - Friendly names: "ethereum", "base", "arbitrum", "solana", etc.
@@ -254,7 +276,7 @@ pub fn parse_chain(s: &str) -> Result<Chain, String> {
            EVM:     ethereum, base, arbitrum, optimism, polygon, bsc, avalanche, plasma, etherlink\n  \
            Solana:  solana\n  \
            Bitcoin: bitcoin\n  \
-           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl, nano\n\n\
+           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl, nano, stellar\n\n\
          Or use a CAIP-2 ID (eip155:8453) or bare EVM chain ID (8453)"
     ))
 }
@@ -279,6 +301,7 @@ impl ChainType {
             ChainType::Sui => "sui",
             ChainType::Xrpl => "xrpl",
             ChainType::Nano => "nano",
+            ChainType::Stellar => "stellar",
         }
     }
 
@@ -296,6 +319,7 @@ impl ChainType {
             ChainType::Sui => 784,
             ChainType::Xrpl => 144,
             ChainType::Nano => 165,
+            ChainType::Stellar => 148,
         }
     }
 
@@ -313,6 +337,7 @@ impl ChainType {
             "sui" => Some(ChainType::Sui),
             "xrpl" => Some(ChainType::Xrpl),
             "nano" => Some(ChainType::Nano),
+            "stellar" => Some(ChainType::Stellar),
             _ => None,
         }
     }
@@ -332,6 +357,7 @@ impl fmt::Display for ChainType {
             ChainType::Sui => "sui",
             ChainType::Xrpl => "xrpl",
             ChainType::Nano => "nano",
+            ChainType::Stellar => "stellar",
         };
         write!(f, "{}", s)
     }
@@ -353,6 +379,7 @@ impl FromStr for ChainType {
             "sui" => Ok(ChainType::Sui),
             "xrpl" => Ok(ChainType::Xrpl),
             "nano" => Ok(ChainType::Nano),
+            "stellar" => Ok(ChainType::Stellar),
             _ => Err(format!("unknown chain type: {}", s)),
         }
     }
@@ -385,6 +412,7 @@ mod tests {
             (ChainType::Sui, "\"sui\""),
             (ChainType::Xrpl, "\"xrpl\""),
             (ChainType::Nano, "\"nano\""),
+            (ChainType::Stellar, "\"stellar\""),
         ] {
             let json = serde_json::to_string(&chain).unwrap();
             assert_eq!(json, expected);
@@ -406,6 +434,7 @@ mod tests {
         assert_eq!(ChainType::Sui.namespace(), "sui");
         assert_eq!(ChainType::Xrpl.namespace(), "xrpl");
         assert_eq!(ChainType::Nano.namespace(), "nano");
+        assert_eq!(ChainType::Stellar.namespace(), "stellar");
     }
 
     #[test]
@@ -421,6 +450,7 @@ mod tests {
         assert_eq!(ChainType::Sui.default_coin_type(), 784);
         assert_eq!(ChainType::Xrpl.default_coin_type(), 144);
         assert_eq!(ChainType::Nano.default_coin_type(), 165);
+        assert_eq!(ChainType::Stellar.default_coin_type(), 148);
     }
 
     #[test]
@@ -439,6 +469,10 @@ mod tests {
         assert_eq!(ChainType::from_namespace("sui"), Some(ChainType::Sui));
         assert_eq!(ChainType::from_namespace("xrpl"), Some(ChainType::Xrpl));
         assert_eq!(ChainType::from_namespace("nano"), Some(ChainType::Nano));
+        assert_eq!(
+            ChainType::from_namespace("stellar"),
+            Some(ChainType::Stellar)
+        );
         assert_eq!(ChainType::from_namespace("unknown"), None);
     }
 
@@ -581,6 +615,26 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_chain_stellar() {
+        let chain = parse_chain("stellar").unwrap();
+        assert_eq!(chain.chain_type, ChainType::Stellar);
+        assert_eq!(chain.chain_id, "stellar:pubnet");
+
+        let testnet = parse_chain("stellar-testnet").unwrap();
+        assert_eq!(testnet.chain_type, ChainType::Stellar);
+        assert_eq!(testnet.chain_id, "stellar:testnet");
+
+        let futurenet = parse_chain("stellar-futurenet").unwrap();
+        assert_eq!(futurenet.chain_type, ChainType::Stellar);
+        assert_eq!(futurenet.chain_id, "stellar:futurenet");
+
+        // CAIP-2 IDs also accepted directly
+        let via_caip2 = parse_chain("stellar:testnet").unwrap();
+        assert_eq!(via_caip2.chain_type, ChainType::Stellar);
+        assert_eq!(via_caip2.chain_id, "stellar:testnet");
+    }
+
+    #[test]
     fn test_parse_chain_unknown() {
         assert!(parse_chain("unknown_chain").is_err());
     }
@@ -619,7 +673,7 @@ mod tests {
 
     #[test]
     fn test_all_chain_types() {
-        assert_eq!(ALL_CHAIN_TYPES.len(), 10);
+        assert_eq!(ALL_CHAIN_TYPES.len(), 12);
     }
 
     #[test]

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -79,6 +79,14 @@ impl Config {
             "eip155:999".into(),
             "https://rpc.hyperliquid.xyz/evm".into(),
         );
+        rpc.insert(
+            "stellar:testnet".into(),
+            "https://soroban-testnet.stellar.org".into(),
+        );
+        rpc.insert(
+            "stellar:futurenet".into(),
+            "https://rpc-futurenet.stellar.org".into(),
+        );
         rpc
     }
 }

--- a/ows/crates/ows-core/src/lib.rs
+++ b/ows/crates/ows-core/src/lib.rs
@@ -11,6 +11,7 @@ pub use api_key::ApiKeyFile;
 pub use caip::ChainId;
 pub use chain::{
     default_chain_for_type, parse_chain, Chain, ChainType, ALL_CHAIN_TYPES, KNOWN_CHAINS,
+    STELLAR_PASSPHRASE_FUTURENET, STELLAR_PASSPHRASE_PUBNET, STELLAR_PASSPHRASE_TESTNET,
 };
 pub use config::Config;
 pub use error::{OwsError, OwsErrorCode};

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -24,6 +24,7 @@ base64 = "0.22"
 getrandom = "0.2"
 zeroize = "1"
 sha2 = "0.10"
+stellar-xdr = { workspace = true }
 rand = "0.8"
 prost = "0.13"
 tonic = { version = "0.12", features = ["transport"] }

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -138,7 +138,7 @@ pub fn sign_with_api_key(
     let key = decrypt_key_from_api_key(&key_file, &wallet, token, chain.chain_type, index)?;
 
     // 7. Sign (extract signable portion first — e.g. strips Solana sig-slot headers)
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(chain);
     let signable = signer.extract_signable_bytes(tx_bytes)?;
     let output = signer.sign_transaction(key.expose(), signable)?;
 
@@ -198,7 +198,7 @@ pub fn sign_message_with_api_key(
     }
 
     let key = decrypt_key_from_api_key(&key_file, &wallet, token, chain.chain_type, index)?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(chain);
     let output = signer.sign_message(key.expose(), msg_bytes)?;
 
     Ok(crate::types::SignResult {

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -321,6 +321,78 @@ pub fn sign_typed_data_with_api_key(
     })
 }
 
+/// Sign a Stellar Soroban auth entry preimage using an API token (agent mode).
+pub fn sign_stellar_auth_with_api_key(
+    token: &str,
+    wallet_name_or_id: &str,
+    chain: &ows_core::Chain,
+    preimage_bytes: &[u8],
+    index: Option<u32>,
+    vault_path: Option<&Path>,
+) -> Result<crate::types::SignResult, OwsLibError> {
+    // 1. Look up key file
+    let token_hash = key_store::hash_token(token);
+    let key_file = key_store::load_api_key_by_token_hash(&token_hash, vault_path)?;
+
+    // 2. Check expiry
+    check_expiry(&key_file)?;
+
+    // 3. Resolve wallet and check scope
+    let wallet = vault::load_wallet_by_name_or_id(wallet_name_or_id, vault_path)?;
+    if !key_file.wallet_ids.contains(&wallet.id) {
+        return Err(OwsLibError::InvalidInput(format!(
+            "API key '{}' does not have access to wallet '{}'",
+            key_file.name, wallet.id,
+        )));
+    }
+
+    // 4. Load policies and build context
+    let policies = load_policies_for_key(&key_file, vault_path)?;
+    let now = chrono::Utc::now();
+    let date = now.format("%Y-%m-%d").to_string();
+
+    let context = ows_core::PolicyContext {
+        chain_id: chain.chain_id.to_string(),
+        wallet_id: wallet.id.clone(),
+        api_key_id: key_file.id.clone(),
+        transaction: ows_core::policy::TransactionContext {
+            to: None,
+            value: None,
+            raw_hex: hex::encode(preimage_bytes),
+            data: None,
+        },
+        spending: noop_spending_context(&date),
+        timestamp: now.to_rfc3339(),
+        typed_data: None,
+    };
+
+    // 5. Evaluate policies
+    let result = policy_engine::evaluate_policies(&policies, &context);
+    if !result.allow {
+        return Err(OwsLibError::Core(OwsError::PolicyDenied {
+            policy_id: result.policy_id.unwrap_or_default(),
+            reason: result.reason.unwrap_or_else(|| "denied".into()),
+        }));
+    }
+
+    // 6. Decrypt wallet secret from key file using HKDF(token)
+    let key = decrypt_key_from_api_key(&key_file, &wallet, token, chain.chain_type, index)?;
+
+    // 7. Sign with Stellar signer
+    let signer = match &*chain.chain_id {
+        "stellar:testnet" => ows_signer::chains::StellarSigner::testnet(),
+        "stellar:futurenet" => ows_signer::chains::StellarSigner::futurenet(),
+        _ => ows_signer::chains::StellarSigner::pubnet(),
+    };
+
+    let output = signer.sign_soroban_auth(key.expose(), preimage_bytes)?;
+
+    Ok(crate::types::SignResult {
+        signature: hex::encode(&output.signature),
+        recovery_id: None,
+    })
+}
+
 /// Enforce policies for a token-based transaction and return the decrypted
 /// signing key. Used by `sign_and_send` which needs the raw key for broadcast.
 pub fn enforce_policy_and_decrypt_key(

--- a/ows/crates/ows-lib/src/lib.rs
+++ b/ows/crates/ows-lib/src/lib.rs
@@ -6,6 +6,7 @@ pub mod nano_rpc;
 pub mod ops;
 pub mod policy_engine;
 pub mod policy_store;
+pub mod stellar_errors;
 mod sui_grpc;
 pub mod types;
 pub mod vault;

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -41,7 +41,7 @@ fn derive_all_accounts(mnemonic: &Mnemonic, index: u32) -> Result<Vec<WalletAcco
     let mut accounts = Vec::with_capacity(ALL_CHAIN_TYPES.len());
     for ct in &ALL_CHAIN_TYPES {
         let chain = default_chain_for_type(*ct);
-        let signer = signer_for_chain(*ct);
+        let signer = signer_for_chain(&chain);
         let path = signer.default_derivation_path(index);
         let curve = signer.curve();
         let key = HdDeriver::derive_from_mnemonic(mnemonic, "", &path, curve)?;
@@ -114,10 +114,10 @@ impl KeyPair {
 fn derive_all_accounts_from_keys(keys: &KeyPair) -> Result<Vec<WalletAccount>, OwsLibError> {
     let mut accounts = Vec::with_capacity(ALL_CHAIN_TYPES.len());
     for ct in &ALL_CHAIN_TYPES {
-        let signer = signer_for_chain(*ct);
+        let chain = default_chain_for_type(*ct);
+        let signer = signer_for_chain(&chain);
         let key = keys.key_for_curve(signer.curve());
         let address = signer.derive_address(key)?;
-        let chain = default_chain_for_type(*ct);
         accounts.push(WalletAccount {
             account_id: format!("{}:{}", chain.chain_id, address),
             address,
@@ -141,7 +141,7 @@ pub(crate) fn secret_to_signing_key(
                 OwsLibError::InvalidInput("wallet contains invalid UTF-8 mnemonic".into())
             })?;
             let mnemonic = Mnemonic::from_phrase(phrase)?;
-            let signer = signer_for_chain(chain_type);
+            let signer = signer_for_chain(&default_chain_for_type(chain_type));
             let path = signer.default_derivation_path(index.unwrap_or(0));
             let curve = signer.curve();
             Ok(HdDeriver::derive_from_mnemonic_cached(
@@ -151,7 +151,7 @@ pub(crate) fn secret_to_signing_key(
         KeyType::PrivateKey => {
             // JSON key pair — extract the right key for this chain's curve
             let keys = KeyPair::from_json_bytes(secret.expose())?;
-            let signer = signer_for_chain(chain_type);
+            let signer = signer_for_chain(&default_chain_for_type(chain_type));
             Ok(SecretBytes::from_slice(keys.key_for_curve(signer.curve())))
         }
     }
@@ -179,7 +179,7 @@ pub fn derive_address(
 ) -> Result<String, OwsLibError> {
     let chain = parse_chain(chain)?;
     let mnemonic = Mnemonic::from_phrase(mnemonic_phrase)?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
     let path = signer.default_derivation_path(index.unwrap_or(0));
     let curve = signer.curve();
 
@@ -309,7 +309,7 @@ pub fn import_wallet_private_key(
             let source_curve = match chain {
                 Some(c) => {
                     let parsed = parse_chain(c)?;
-                    signer_for_chain(parsed.chain_type).curve()
+                    signer_for_chain(&parsed).curve()
                 }
                 None => ows_signer::Curve::Secp256k1,
             };
@@ -453,7 +453,7 @@ pub fn sign_transaction(
     // Owner mode: existing passphrase-based signing (unchanged)
     let chain = parse_chain(chain)?;
     let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
     let signable = signer.extract_signable_bytes(&tx_bytes)?;
     let output = signer.sign_transaction(key.expose(), signable)?;
 
@@ -501,7 +501,7 @@ pub fn sign_message(
     // Owner mode
     let chain = parse_chain(chain)?;
     let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
     let output = signer.sign_message(key.expose(), &msg_bytes)?;
 
     Ok(SignResult {
@@ -607,7 +607,7 @@ pub fn sign_encode_and_broadcast(
     rpc_url: Option<&str>,
 ) -> Result<SendResult, OwsLibError> {
     let chain = parse_chain(chain)?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
 
     // 1. Extract signable portion (strips signature-slot headers for Solana; no-op for others)
     let signable = signer.extract_signable_bytes(tx_bytes)?;
@@ -703,6 +703,7 @@ fn broadcast(chain: ChainType, rpc_url: &str, signed_bytes: &[u8]) -> Result<Str
         ChainType::Sui => broadcast_sui(rpc_url, signed_bytes),
         ChainType::Xrpl => broadcast_xrpl(rpc_url, signed_bytes),
         ChainType::Nano => broadcast_nano(rpc_url, signed_bytes),
+        ChainType::Stellar => broadcast_stellar(rpc_url, signed_bytes),
     }
 }
 
@@ -732,6 +733,52 @@ fn broadcast_xrpl(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibEr
         .ok_or_else(|| {
             OwsLibError::BroadcastFailed(format!("no hash in XRPL response: {resp_str}"))
         })
+}
+
+fn build_stellar_rpc_body(signed_bytes: &[u8]) -> serde_json::Value {
+    use base64::Engine;
+    let b64_tx = base64::engine::general_purpose::STANDARD.encode(signed_bytes);
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "sendTransaction",
+        "params": {"transaction": b64_tx}
+    })
+}
+
+fn broadcast_stellar(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibError> {
+    let body = build_stellar_rpc_body(signed_bytes);
+    let resp_str = curl_post_json(rpc_url, &body.to_string())?;
+    let resp: serde_json::Value = serde_json::from_str(&resp_str)?;
+
+    let status = resp["result"]["status"].as_str().unwrap_or("");
+    match status {
+        "PENDING" => resp["result"]["hash"]
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                OwsLibError::BroadcastFailed("no hash in Stellar response".into())
+            }),
+        "DUPLICATE" => Err(OwsLibError::BroadcastFailed(
+            "transaction already submitted".into(),
+        )),
+        "TRY_AGAIN_LATER" => Err(OwsLibError::BroadcastFailed(
+            "Stellar network busy, retry".into(),
+        )),
+        "ERROR" => {
+            let detail = resp["result"]["errorResultXdr"]
+                .as_str()
+                .unwrap_or("unknown");
+            // Try to extract a human-readable tx error code
+            let enriched = crate::stellar_errors::enrich_error_xdr(detail);
+            Err(OwsLibError::BroadcastFailed(format!(
+                "Stellar tx error: {enriched}"
+            )))
+        }
+        _ => Err(OwsLibError::BroadcastFailed(format!(
+            "unexpected Stellar status: {status}"
+        ))),
+    }
 }
 
 fn broadcast_evm(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibError> {
@@ -1170,12 +1217,40 @@ mod tests {
         solana_tx.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]); // message payload
         let solana_tx_hex = hex::encode(&solana_tx);
 
+        // Stellar requires a valid TransactionEnvelope XDR
+        // NOTE: duplicated in crates/ows-signer/src/chains/stellar.rs (build_test_envelope) — keep in sync
+        let stellar_tx_hex = {
+            use stellar_xdr::curr::*;
+            let tx = Transaction {
+                source_account: MuxedAccount::Ed25519(Uint256([0xAA; 32])),
+                fee: 100,
+                seq_num: SequenceNumber(1),
+                cond: Preconditions::None,
+                memo: Memo::None,
+                operations: vec![Operation {
+                    source_account: None,
+                    body: OperationBody::Inflation,
+                }]
+                .try_into()
+                .unwrap(),
+                ext: TransactionExt::V0,
+            };
+            let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+                tx,
+                signatures: vec![].try_into().unwrap(),
+            });
+            hex::encode(envelope.to_xdr(Limits::none()).unwrap())
+        };
+
         let chains = [
             "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "xrpl",
+            "stellar",
         ];
         for chain in &chains {
             let tx = if *chain == "solana" {
                 &solana_tx_hex
+            } else if *chain == "stellar" {
+                &stellar_tx_hex
             } else {
                 generic_tx_hex
             };
@@ -1754,7 +1829,7 @@ mod tests {
 
         // Now encode the full signed transaction (what the library does correctly)
         let key = decrypt_signing_key("send-bug", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Evm);
+        let signer = signer_for_chain(&default_chain_for_type(ChainType::Evm));
         let output = signer.sign_transaction(key.expose(), &unsigned_tx).unwrap();
         let full_signed_tx = signer
             .encode_signed_transaction(&unsigned_tx, &output)
@@ -2471,7 +2546,7 @@ mod tests {
         // by manually calling the signer's extract/sign/encode chain:
         let key =
             decrypt_signing_key("char-sol-sig", ChainType::Solana, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Solana);
+        let signer = signer_for_chain(&default_chain_for_type(ChainType::Solana));
 
         let signable = signer.extract_signable_bytes(&tx_bytes).unwrap();
         assert_eq!(
@@ -2537,7 +2612,7 @@ mod tests {
         // Path B: the internal pipeline (what sign_and_send uses)
         let key =
             decrypt_signing_key("char-encode", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Evm);
+        let signer = signer_for_chain(&default_chain_for_type(ChainType::Evm));
         let output = signer.sign_transaction(key.expose(), &unsigned_tx).unwrap();
         let full_signed_tx = signer
             .encode_signed_transaction(&unsigned_tx, &output)
@@ -2658,7 +2733,7 @@ mod tests {
 
         // Path B: direct signer call (no credential branch)
         let key = decrypt_signing_key("reg-owner", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Evm);
+        let signer = signer_for_chain(&default_chain_for_type(ChainType::Evm));
         let tx_bytes = hex::decode(tx_hex).unwrap();
         let direct_output = signer.sign_transaction(key.expose(), &tx_bytes).unwrap();
 
@@ -2728,7 +2803,7 @@ mod tests {
 
         // Direct signer
         let key = decrypt_signing_key("reg-msg", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Evm);
+        let signer = signer_for_chain(&default_chain_for_type(ChainType::Evm));
         let direct = signer.sign_message(key.expose(), b"hello").unwrap();
 
         assert_eq!(
@@ -2859,7 +2934,7 @@ mod tests {
         // Path B: manual extract + sign
         let key =
             decrypt_signing_key("sol-match", ChainType::Solana, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Solana);
+        let signer = signer_for_chain(&default_chain_for_type(ChainType::Solana));
         let signable = signer.extract_signable_bytes(&full_tx).unwrap();
         let direct = signer.sign_transaction(key.expose(), signable).unwrap();
 
@@ -2995,5 +3070,62 @@ mod tests {
                 // We expect errors like "insufficient funds" or simulation failure
             }
         }
+    }
+
+    // ================================================================
+    // STELLAR BROADCAST ENCODING
+    // ================================================================
+
+    #[test]
+    fn stellar_broadcast_body_jsonrpc_structure() {
+        let body = build_stellar_rpc_body(&[0u8; 10]);
+        assert_eq!(body["jsonrpc"], "2.0");
+        assert_eq!(body["id"], 1);
+        assert_eq!(body["method"], "sendTransaction");
+        assert!(
+            body["params"].is_object(),
+            "Soroban RPC uses named params (object), not positional (array)"
+        );
+        assert!(
+            body["params"]["transaction"].is_string(),
+            "params.transaction should be a string"
+        );
+    }
+
+    #[test]
+    fn stellar_broadcast_body_uses_base64_encoding() {
+        use base64::Engine;
+        let dummy_tx = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03];
+        let body = build_stellar_rpc_body(&dummy_tx);
+
+        let encoded = body["params"]["transaction"].as_str().unwrap();
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .expect("params.transaction should be valid base64");
+        assert_eq!(
+            decoded, dummy_tx,
+            "base64 should round-trip to original bytes"
+        );
+    }
+
+    #[test]
+    fn stellar_broadcast_body_is_not_hex() {
+        let dummy_tx = vec![0xFF; 50];
+        let body = build_stellar_rpc_body(&dummy_tx);
+
+        let encoded = body["params"]["transaction"].as_str().unwrap();
+        let hex_encoded = hex::encode(&dummy_tx);
+        assert_ne!(encoded, hex_encoded, "broadcast should use base64, not hex");
+    }
+
+    #[test]
+    fn stellar_broadcast_body_uses_named_params_not_array() {
+        let body = build_stellar_rpc_body(&[0u8; 5]);
+        // Soroban RPC uses named params: {"transaction": "..."}, not positional: ["..."]
+        assert!(
+            body["params"].is_object(),
+            "Stellar sendTransaction uses named params, not array"
+        );
+        assert!(body["params"]["transaction"].is_string());
     }
 }

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -553,6 +553,52 @@ pub fn sign_typed_data(
     })
 }
 
+/// Sign a Stellar Soroban authorization entry preimage. Returns hex-encoded signature.
+///
+/// The `passphrase` parameter accepts either the owner's passphrase or an
+/// API token (`ows_key_...`). When a token is provided, policy enforcement
+/// occurs before signing.
+pub fn sign_stellar_auth_entry(
+    wallet: &str,
+    chain: &str,
+    preimage_bytes: &[u8],
+    passphrase: Option<&str>,
+    index: Option<u32>,
+    vault_path: Option<&Path>,
+) -> Result<SignResult, OwsLibError> {
+    let credential = passphrase.unwrap_or("");
+    let chain = parse_chain(chain)?;
+
+    if chain.chain_type != ows_core::ChainType::Stellar {
+        return Err(OwsLibError::InvalidInput(
+            "sign_stellar_auth_entry requires a Stellar chain".into(),
+        ));
+    }
+
+    // Agent mode: token-based signing with policy enforcement
+    if credential.starts_with(crate::key_store::TOKEN_PREFIX) {
+        return crate::key_ops::sign_stellar_auth_with_api_key(
+            credential, wallet, &chain, preimage_bytes, index, vault_path,
+        );
+    }
+
+    // Owner mode
+    let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
+
+    let signer = match &*chain.chain_id {
+        "stellar:testnet" => ows_signer::chains::StellarSigner::testnet(),
+        "stellar:futurenet" => ows_signer::chains::StellarSigner::futurenet(),
+        _ => ows_signer::chains::StellarSigner::pubnet(),
+    };
+
+    let output = signer.sign_soroban_auth(key.expose(), preimage_bytes)?;
+
+    Ok(SignResult {
+        signature: hex::encode(&output.signature),
+        recovery_id: None,
+    })
+}
+
 /// Sign and broadcast a transaction. Returns the transaction hash.
 ///
 /// The `passphrase` parameter accepts either the owner's passphrase or an

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -655,19 +655,22 @@ pub fn sign_encode_and_broadcast(
     let chain = parse_chain(chain)?;
     let signer = signer_for_chain(&chain);
 
-    // 1. Extract signable portion (strips signature-slot headers for Solana; no-op for others)
-    let signable = signer.extract_signable_bytes(tx_bytes)?;
+    // 1. Sign inner authorizations if present (Soroban auth entries on Stellar; no-op for others)
+    let tx_bytes = signer.sign_inner_authorizations(private_key, tx_bytes)?;
 
-    // 2. Sign
+    // 2. Extract signable portion (strips signature-slot headers for Solana; no-op for others)
+    let signable = signer.extract_signable_bytes(&tx_bytes)?;
+
+    // 3. Sign the outer transaction envelope
     let output = signer.sign_transaction(private_key, signable)?;
 
-    // 3. Encode the full signed transaction
-    let signed_tx = signer.encode_signed_transaction(tx_bytes, &output)?;
+    // 4. Encode the full signed transaction
+    let signed_tx = signer.encode_signed_transaction(&tx_bytes, &output)?;
 
-    // 4. Resolve RPC URL using exact chain_id
+    // 5. Resolve RPC URL using exact chain_id
     let rpc = resolve_rpc_url(chain.chain_id, chain.chain_type, rpc_url)?;
 
-    // 5. Broadcast the full signed transaction
+    // 6. Broadcast the full signed transaction
     let tx_hash = broadcast(chain.chain_type, &rpc, &signed_tx)?;
 
     Ok(SendResult { tx_hash })

--- a/ows/crates/ows-lib/src/stellar_errors.rs
+++ b/ows/crates/ows-lib/src/stellar_errors.rs
@@ -1,0 +1,213 @@
+use stellar_xdr::curr::{Limits, ReadXdr, TransactionResult, TransactionResultCode};
+
+/// Enrich a Stellar transaction-level result code with a human-readable explanation.
+pub fn enrich_tx_error<'a>(code: &'a str) -> &'a str {
+    match code {
+        "tx_failed" => "One of the operations failed (none applied). Check per-operation errors.",
+        "tx_too_early" => "Transaction submitted too early (before minTime). Wait or set minTime to 0.",
+        "tx_too_late" => "Transaction expired (after maxTime). Rebuild with a longer timeout.",
+        "tx_bad_seq" => "Wrong sequence number. Re-fetch the account sequence and rebuild.",
+        "tx_bad_auth" => "Invalid signature(s) or wrong network passphrase. Re-sign with the correct key.",
+        "tx_insufficient_balance" => "Fee would drop the account below the XLM reserve. Add more XLM.",
+        "tx_no_source_account" => "Source account does not exist. Fund it with CreateAccount (min 1 XLM).",
+        "tx_insufficient_fee" => "Fee too low. Increase the fee (min 100 stroops/op, more during congestion).",
+        "tx_bad_auth_extra" => "Extra unused signatures attached. Remove signatures not matching any signer.",
+        "tx_internal_error" => "Unknown Stellar Core error. Retry; if persistent, the network may have issues.",
+        "tx_not_supported" => "Transaction type not supported at this protocol version.",
+        "tx_fee_bump_inner_failed" => "Fee bump failed because the inner transaction failed. Check inner results.",
+        "tx_bad_sponsorship" => "Sponsorship not confirmed. Pair BeginSponsoring with EndSponsoring.",
+        "tx_malformed" => "Transaction preconditions are malformed. Validate timebounds, ledger bounds, etc.",
+        "tx_soroban_invalid" => "Soroban preconditions not met. Run simulateTransaction first to set resources.",
+        _ => code,
+    }
+}
+
+/// Enrich a Stellar operation-level result code with a human-readable explanation.
+pub fn enrich_op_error<'a>(code: &'a str) -> &'a str {
+    match code {
+        // Generic
+        "op_bad_auth" => "Operation needs more signatures or was signed for wrong network.",
+        "op_no_source_account" => "The operation's source account does not exist on the ledger.",
+        "op_too_many_subentries" => "Account has 1000 subentries (max). Remove trustlines/offers/data first.",
+        // Payment
+        "op_underfunded" => "Not enough funds (after reserves). Add more or reduce amount.",
+        "op_src_no_trust" => "Sender has no trustline for this asset. Add one with ChangeTrust first.",
+        "op_no_destination" => "Destination account does not exist. Create it first with CreateAccount.",
+        "op_no_trust" => "Receiver has no trustline for this asset. They must add one first.",
+        "op_not_authorized" => "Receiver is not authorized to hold this asset. Issuer must authorize.",
+        "op_line_full" => "Receiver's trustline limit would be exceeded. They must raise the limit.",
+        "op_no_issuer" => "The asset issuer does not exist. Check asset code and issuer address.",
+        // CreateAccount
+        "op_already_exists" => "Destination account already exists. Use Payment instead of CreateAccount.",
+        "op_low_reserve" => "Starting balance is below the minimum reserve (1 XLM). Increase it.",
+        // ChangeTrust
+        "op_invalid_limit" => "Trustline limit too low for current balance + buying liabilities.",
+        "op_self_not_allowed" => "Cannot create a trustline to yourself.",
+        // Catch-all
+        "op_malformed" => "Operation input is malformed. Check addresses, amounts, and asset codes.",
+        _ => code,
+    }
+}
+
+/// Map a `TransactionResultCode` enum to its canonical string name.
+fn tx_result_code_to_str(code: &TransactionResultCode) -> &'static str {
+    match code {
+        TransactionResultCode::TxFeeBumpInnerSuccess => "tx_fee_bump_inner_success",
+        TransactionResultCode::TxSuccess => "tx_success",
+        TransactionResultCode::TxFailed => "tx_failed",
+        TransactionResultCode::TxTooEarly => "tx_too_early",
+        TransactionResultCode::TxTooLate => "tx_too_late",
+        TransactionResultCode::TxMissingOperation => "tx_missing_operation",
+        TransactionResultCode::TxBadSeq => "tx_bad_seq",
+        TransactionResultCode::TxBadAuth => "tx_bad_auth",
+        TransactionResultCode::TxInsufficientBalance => "tx_insufficient_balance",
+        TransactionResultCode::TxNoAccount => "tx_no_source_account",
+        TransactionResultCode::TxInsufficientFee => "tx_insufficient_fee",
+        TransactionResultCode::TxBadAuthExtra => "tx_bad_auth_extra",
+        TransactionResultCode::TxInternalError => "tx_internal_error",
+        TransactionResultCode::TxNotSupported => "tx_not_supported",
+        TransactionResultCode::TxFeeBumpInnerFailed => "tx_fee_bump_inner_failed",
+        TransactionResultCode::TxBadSponsorship => "tx_bad_sponsorship",
+        TransactionResultCode::TxBadMinSeqAgeOrGap => "tx_malformed",
+        TransactionResultCode::TxMalformed => "tx_malformed",
+        TransactionResultCode::TxSorobanInvalid => "tx_soroban_invalid",
+        _ => "tx_unknown",
+    }
+}
+
+/// Decode a base64-encoded `errorResultXdr` and return an enriched error string.
+/// Falls back to the raw XDR string if decoding fails.
+pub fn enrich_error_xdr(error_xdr: &str) -> String {
+    use base64::Engine;
+
+    let bytes = match base64::engine::general_purpose::STANDARD.decode(error_xdr) {
+        Ok(b) => b,
+        Err(_) => return format!("{error_xdr} (decode at lab.stellar.org/xdr/view)"),
+    };
+
+    let tx_result = match TransactionResult::from_xdr(&bytes, Limits::none()) {
+        Ok(r) => r,
+        Err(_) => return format!("{error_xdr} (decode at lab.stellar.org/xdr/view)"),
+    };
+
+    let code_str = tx_result_code_to_str(&tx_result.result.discriminant());
+    let enriched = enrich_tx_error(code_str);
+    format!("{code_str}: {enriched}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enrich_tx_error_known_codes() {
+        assert_eq!(
+            enrich_tx_error("tx_bad_seq"),
+            "Wrong sequence number. Re-fetch the account sequence and rebuild."
+        );
+        assert_eq!(
+            enrich_tx_error("tx_no_source_account"),
+            "Source account does not exist. Fund it with CreateAccount (min 1 XLM)."
+        );
+        assert_eq!(
+            enrich_tx_error("tx_too_late"),
+            "Transaction expired (after maxTime). Rebuild with a longer timeout."
+        );
+        assert_eq!(
+            enrich_tx_error("tx_insufficient_fee"),
+            "Fee too low. Increase the fee (min 100 stroops/op, more during congestion)."
+        );
+    }
+
+    #[test]
+    fn test_enrich_tx_error_unknown_passthrough() {
+        assert_eq!(enrich_tx_error("tx_some_future_code"), "tx_some_future_code");
+        assert_eq!(enrich_tx_error(""), "");
+    }
+
+    #[test]
+    fn test_enrich_op_error_known_codes() {
+        assert_eq!(
+            enrich_op_error("op_no_trust"),
+            "Receiver has no trustline for this asset. They must add one first."
+        );
+        assert_eq!(
+            enrich_op_error("op_no_destination"),
+            "Destination account does not exist. Create it first with CreateAccount."
+        );
+        assert_eq!(
+            enrich_op_error("op_low_reserve"),
+            "Starting balance is below the minimum reserve (1 XLM). Increase it."
+        );
+    }
+
+    #[test]
+    fn test_enrich_op_error_unknown_passthrough() {
+        assert_eq!(enrich_op_error("op_future_code"), "op_future_code");
+    }
+
+    #[test]
+    fn test_enrich_error_xdr_invalid_base64_fallback() {
+        let result = enrich_error_xdr("not-valid-base64!!!");
+        assert!(result.contains("not-valid-base64!!!"));
+        assert!(result.contains("lab.stellar.org"));
+    }
+
+    #[test]
+    fn test_enrich_error_xdr_invalid_xdr_fallback() {
+        use base64::Engine;
+        // Valid base64 but not valid TransactionResult XDR
+        let b64 = base64::engine::general_purpose::STANDARD.encode(b"not xdr");
+        let result = enrich_error_xdr(&b64);
+        assert!(result.contains("lab.stellar.org"));
+    }
+
+    #[test]
+    fn test_enrich_error_xdr_valid_tx_bad_seq() {
+        // Build a minimal TransactionResult with TxBadSeq
+        use stellar_xdr::curr::{
+            TransactionResult, TransactionResultExt, TransactionResultResult, WriteXdr,
+        };
+
+        let tx_result = TransactionResult {
+            fee_charged: 100,
+            result: TransactionResultResult::TxBadSeq,
+            ext: TransactionResultExt::V0,
+        };
+        let xdr_bytes = tx_result.to_xdr(Limits::none()).unwrap();
+
+        use base64::Engine;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&xdr_bytes);
+
+        let enriched = enrich_error_xdr(&b64);
+        assert!(
+            enriched.contains("tx_bad_seq"),
+            "should contain error code, got: {enriched}"
+        );
+        assert!(
+            enriched.contains("sequence number"),
+            "should contain enriched explanation, got: {enriched}"
+        );
+    }
+
+    #[test]
+    fn test_enrich_error_xdr_valid_tx_no_account() {
+        use stellar_xdr::curr::{
+            TransactionResult, TransactionResultExt, TransactionResultResult, WriteXdr,
+        };
+
+        let tx_result = TransactionResult {
+            fee_charged: 100,
+            result: TransactionResultResult::TxNoAccount,
+            ext: TransactionResultExt::V0,
+        };
+        let xdr_bytes = tx_result.to_xdr(Limits::none()).unwrap();
+
+        use base64::Engine;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&xdr_bytes);
+
+        let enriched = enrich_error_xdr(&b64);
+        assert!(enriched.contains("tx_no_source_account"));
+        assert!(enriched.contains("Fund it with CreateAccount"));
+    }
+}

--- a/ows/crates/ows-pay/Cargo.toml
+++ b/ows/crates/ows-pay/Cargo.toml
@@ -27,3 +27,10 @@ thiserror = "2"
 
 # Random nonce generation
 getrandom = "0.2"
+
+# Stellar XDR types + strkey encoding
+stellar-xdr = { workspace = true }
+stellar-strkey = { workspace = true }
+
+# Hashing (Stellar network ID)
+sha2 = "0.10"

--- a/ows/crates/ows-pay/src/discovery.rs
+++ b/ows/crates/ows-pay/src/discovery.rs
@@ -211,10 +211,15 @@ pub(crate) fn format_price(amount_str: &str, network: &str) -> String {
 }
 
 pub(crate) fn format_usdc(amount_str: &str) -> String {
+    format_usdc_decimals(amount_str, 6)
+}
+
+pub(crate) fn format_usdc_decimals(amount_str: &str, decimals: u32) -> String {
     let amount: u128 = amount_str.parse().unwrap_or(0);
-    let whole = amount / 1_000_000;
-    let frac = amount % 1_000_000;
-    let frac_str = format!("{frac:06}");
+    let divisor: u128 = 10u128.pow(decimals);
+    let whole = amount / divisor;
+    let frac = amount % divisor;
+    let frac_str = format!("{frac:0>width$}", width = decimals as usize);
     let trimmed = frac_str.trim_end_matches('0');
     let trimmed = if trimmed.is_empty() { "00" } else { trimmed };
     format!("${whole}.{trimmed}")

--- a/ows/crates/ows-pay/src/fund.rs
+++ b/ows/crates/ows-pay/src/fund.rs
@@ -79,6 +79,13 @@ const MOONPAY_CHAINS: &[(&str, MoonPayChain)] = &[
             moonpay_name: "solana",
         },
     ),
+    (
+        "stellar",
+        MoonPayChain {
+            display_name: "Stellar",
+            moonpay_name: "stellar",
+        },
+    ),
 ];
 
 const DEFAULT_MOONPAY_CHAIN: &MoonPayChain = &MoonPayChain {

--- a/ows/crates/ows-pay/src/lib.rs
+++ b/ows/crates/ows-pay/src/lib.rs
@@ -5,7 +5,7 @@
 //! based on the x402 `scheme` field.
 //!
 //! ```ignore
-//! let result = ows_pay::pay(&wallet, "https://api.example.com/data", "GET", None).await?;
+//! let result = ows_pay::pay(&wallet, "https://api.example.com/data", "GET", None, None).await?;
 //! let services = ows_pay::discover(None, None, None).await?;
 //! ```
 
@@ -32,6 +32,7 @@ pub async fn pay(
     url: &str,
     method: &str,
     body: Option<&str>,
+    network: Option<&str>,
 ) -> Result<PayResult, PayError> {
     let client = reqwest::Client::new();
 
@@ -57,7 +58,7 @@ pub async fn pay(
     let body_402 = initial.text().await.unwrap_or_default();
 
     // Step 4: Handle x402 payment.
-    x402::handle_x402(wallet, url, method, body, &headers, &body_402).await
+    x402::handle_x402(wallet, url, method, body, &headers, &body_402, network).await
 }
 
 /// Discover payable services.

--- a/ows/crates/ows-pay/src/types.rs
+++ b/ows/crates/ows-pay/src/types.rs
@@ -114,6 +114,8 @@ pub struct X402Response {
     pub accepts: Vec<PaymentRequirements>,
     #[serde(default)]
     pub resource: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<serde_json::Value>,
 }
 
 /// The signed payment payload sent to the server in the payment header.
@@ -142,6 +144,8 @@ pub struct PaymentPayloadV2 {
     pub accepted: PaymentRequirements,
     pub resource: Option<serde_json::Value>,
     pub payload: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ows/crates/ows-pay/src/wallet.rs
+++ b/ows/crates/ows-pay/src/wallet.rs
@@ -1,4 +1,4 @@
-use crate::error::PayError;
+use crate::error::{PayError, PayErrorCode};
 use ows_core::ChainType;
 
 /// An account on any chain.
@@ -29,4 +29,22 @@ pub trait WalletAccess: Send + Sync {
     ///
     /// Returns the signature as a hex string with `0x` prefix.
     fn sign_payload(&self, scheme: &str, network: &str, payload: &str) -> Result<String, PayError>;
+
+    /// Sign a Stellar Soroban auth entry preimage.
+    ///
+    /// `preimage_xdr` is base64-encoded XDR of the HashIdPreimage.
+    /// Returns base64-encoded 64-byte Ed25519 signature.
+    ///
+    /// Default: returns error (not all wallets support Stellar).
+    fn sign_stellar_auth(
+        &self,
+        network: &str,
+        preimage_xdr: &str,
+    ) -> Result<String, PayError> {
+        let _ = (network, preimage_xdr);
+        Err(PayError::new(
+            PayErrorCode::UnsupportedChain,
+            "stellar auth signing not supported by this wallet",
+        ))
+    }
 }

--- a/ows/crates/ows-pay/src/x402.rs
+++ b/ows/crates/ows-pay/src/x402.rs
@@ -23,11 +23,11 @@ pub(crate) async fn handle_x402(
     body_402: &str,
     preferred_network: Option<&str>,
 ) -> Result<PayResult, PayError> {
-    let (x402_version, resource, requirements) = parse_requirements(resp_headers, body_402)?;
+    let (x402_version, resource, requirements, extensions) = parse_requirements(resp_headers, body_402)?;
     let (req, network) = pick_payment_option(wallet, &requirements, preferred_network)?;
 
     let (payload, payment_info) =
-        build_signed_payment(wallet, req, &network, x402_version, resource).await?;
+        build_signed_payment(wallet, req, &network, x402_version, resource, extensions).await?;
 
     let payload_json = serde_json::to_string(&payload)?;
     let payload_b64 = B64.encode(payload_json.as_bytes());
@@ -59,16 +59,17 @@ async fn build_signed_payment(
     network: &str,
     x402_version: u32,
     resource: Option<serde_json::Value>,
+    extensions: Option<serde_json::Value>,
 ) -> Result<(PaymentPayload, PaymentInfo), PayError> {
     match req.scheme.as_str() {
         "exact" => {
             let chain_type = chains::resolve_chain_type(network);
             match chain_type {
                 Some(ows_core::ChainType::Stellar) => {
-                    build_stellar_exact(wallet, req, network, x402_version, resource).await
+                    build_stellar_exact(wallet, req, network, x402_version, resource, extensions).await
                 }
                 Some(ows_core::ChainType::Evm) | None => {
-                    build_evm_exact(wallet, req, network, x402_version, resource)
+                    build_evm_exact(wallet, req, network, x402_version, resource, extensions)
                 }
                 Some(_) => Err(PayError::new(
                     PayErrorCode::UnsupportedChain,
@@ -90,6 +91,7 @@ fn build_evm_exact(
     network: &str,
     x402_version: u32,
     resource: Option<serde_json::Value>,
+    extensions: Option<serde_json::Value>,
 ) -> Result<(PaymentPayload, PaymentInfo), PayError> {
     let account = wallet.account(network)?;
 
@@ -177,6 +179,7 @@ fn build_evm_exact(
             accepted: req.clone(),
             resource,
             payload: inner,
+            extensions,
         })
     } else {
         PaymentPayload::V1(PaymentPayloadV1 {
@@ -228,6 +231,7 @@ async fn build_stellar_exact(
     network: &str,
     x402_version: u32,
     resource: Option<serde_json::Value>,
+    extensions: Option<serde_json::Value>,
 ) -> Result<(PaymentPayload, PaymentInfo), PayError> {
     let account = wallet.account(network)?;
     let rpc_url = stellar_rpc_url(network)?;
@@ -376,6 +380,7 @@ async fn build_stellar_exact(
             accepted: req.clone(),
             resource,
             payload: inner,
+            extensions,
         })
     } else {
         PaymentPayload::V1(PaymentPayloadV1 {
@@ -808,7 +813,7 @@ fn assemble_stellar_tx(
 fn parse_requirements(
     headers: &reqwest::header::HeaderMap,
     body_text: &str,
-) -> Result<(u32, Option<serde_json::Value>, Vec<PaymentRequirements>), PayError> {
+) -> Result<(u32, Option<serde_json::Value>, Vec<PaymentRequirements>, Option<serde_json::Value>), PayError> {
     for header_name in &[HEADER_PAYMENT_REQUIRED_V2, HEADER_PAYMENT_REQUIRED] {
         if let Some(header_val) = headers.get(*header_name) {
             if let Ok(header_str) = header_val.to_str() {
@@ -819,7 +824,7 @@ fn parse_requirements(
                                 HEADER_PAYMENT_REQUIRED_V2 => parsed.x402_version.unwrap_or(2),
                                 _ => parsed.x402_version.unwrap_or(1),
                             };
-                            return Ok((version, parsed.resource, parsed.accepts));
+                            return Ok((version, parsed.resource, parsed.accepts, parsed.extensions));
                         }
                     }
                 }
@@ -845,6 +850,7 @@ fn parse_requirements(
         parsed.x402_version.unwrap_or(1),
         parsed.resource,
         parsed.accepts,
+        parsed.extensions,
     ))
 }
 
@@ -1207,7 +1213,7 @@ mod tests {
         })
         .to_string();
 
-        let (_, _, reqs) = parse_requirements(&headers, &body).unwrap();
+        let (_, _, reqs, _) = parse_requirements(&headers, &body).unwrap();
         assert_eq!(reqs.len(), 1);
         assert_eq!(reqs[0].scheme, "exact");
         assert_eq!(reqs[0].network, "eip155:8453");
@@ -1229,7 +1235,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-payment-required", encoded.parse().unwrap());
 
-        let (_, _, reqs) = parse_requirements(&headers, "not json").unwrap();
+        let (_, _, reqs, _) = parse_requirements(&headers, "not json").unwrap();
         assert_eq!(reqs.len(), 1);
         assert_eq!(reqs[0].pay_to, "0xdef");
     }
@@ -1250,7 +1256,7 @@ mod tests {
         })
         .to_string();
 
-        let (_, _, reqs) = parse_requirements(&headers, &body).unwrap();
+        let (_, _, reqs, _) = parse_requirements(&headers, &body).unwrap();
         assert_eq!(reqs[0].pay_to, "0xbbb");
     }
 
@@ -1270,7 +1276,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("payment-required", encoded.parse().unwrap());
 
-        let (_, _, reqs) = parse_requirements(&headers, "not json").unwrap();
+        let (_, _, reqs, _) = parse_requirements(&headers, "not json").unwrap();
         assert_eq!(reqs.len(), 1);
         assert_eq!(reqs[0].pay_to, "0xv2");
     }
@@ -1291,7 +1297,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("payment-required", encoded.parse().unwrap());
 
-        let (version, _, reqs) = parse_requirements(&headers, "not json").unwrap();
+        let (version, _, reqs, _) = parse_requirements(&headers, "not json").unwrap();
         assert_eq!(version, 2);
         assert_eq!(reqs.len(), 1);
         assert_eq!(reqs[0].pay_to, "0xv2");
@@ -1317,10 +1323,10 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("payment-required", encoded.parse().unwrap());
 
-        let (version, resource, reqs) = parse_requirements(&headers, "not json").unwrap();
+        let (version, resource, reqs, extensions) = parse_requirements(&headers, "not json").unwrap();
         let (req, network) = pick_payment_option(&EvmWallet, &reqs, None).unwrap();
         let (payload, _) =
-            build_signed_payment(&EvmWallet, req, &network, version, resource).await.unwrap();
+            build_signed_payment(&EvmWallet, req, &network, version, resource, extensions).await.unwrap();
 
         match payload {
             PaymentPayload::V2(v2) => {
@@ -1353,7 +1359,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let (_, _, reqs) = parse_requirements(&headers, "not json").unwrap();
+        let (_, _, reqs, _) = parse_requirements(&headers, "not json").unwrap();
         assert_eq!(reqs[0].pay_to, "0xv2");
     }
 
@@ -1504,7 +1510,7 @@ mod tests {
     #[test]
     fn build_evm_exact_produces_valid_payload() {
         let req = base_requirement();
-        let (payload, info) = build_evm_exact(&EvmWallet, &req, "eip155:8453", 1, None).unwrap();
+        let (payload, info) = build_evm_exact(&EvmWallet, &req, "eip155:8453", 1, None, None).unwrap();
 
         let v1 = match &payload {
             PaymentPayload::V1(p) => p,
@@ -1534,7 +1540,7 @@ mod tests {
             "mimeType": "application/json"
         });
         let (payload, _) =
-            build_evm_exact(&EvmWallet, &req, "eip155:8453", 2, Some(resource.clone())).unwrap();
+            build_evm_exact(&EvmWallet, &req, "eip155:8453", 2, Some(resource.clone()), None).unwrap();
 
         let v2 = match &payload {
             PaymentPayload::V2(p) => p,
@@ -1556,7 +1562,7 @@ mod tests {
     #[test]
     fn build_evm_exact_v2_with_no_resource() {
         let req = base_requirement();
-        let (payload, _) = build_evm_exact(&EvmWallet, &req, "eip155:8453", 2, None).unwrap();
+        let (payload, _) = build_evm_exact(&EvmWallet, &req, "eip155:8453", 2, None, None).unwrap();
 
         let v2 = match &payload {
             PaymentPayload::V2(p) => p,
@@ -1573,7 +1579,7 @@ mod tests {
         req.description = None;
         req.resource = None;
 
-        let (payload, _) = build_evm_exact(&EvmWallet, &req, "eip155:8453", 2, None).unwrap();
+        let (payload, _) = build_evm_exact(&EvmWallet, &req, "eip155:8453", 2, None, None).unwrap();
         let encoded = serde_json::to_value(payload).unwrap();
         let accepted = &encoded["accepted"];
 
@@ -1585,7 +1591,7 @@ mod tests {
     #[test]
     fn build_evm_exact_fails_for_non_numeric_chain_id() {
         let req = base_requirement();
-        let err = build_evm_exact(&EvmWallet, &req, "solana:mainnet", 1, None).unwrap_err();
+        let err = build_evm_exact(&EvmWallet, &req, "solana:mainnet", 1, None, None).unwrap_err();
         assert_eq!(err.code, PayErrorCode::ProtocolMalformed);
     }
 
@@ -1610,7 +1616,7 @@ mod tests {
         .to_string();
 
         let headers = HeaderMap::new();
-        let (_, _, reqs) = parse_requirements(&headers, &body).unwrap();
+        let (_, _, reqs, _) = parse_requirements(&headers, &body).unwrap();
         let (req, network) = pick_payment_option(&EvmWallet, &reqs, None).unwrap();
         assert_eq!(req.pay_to, "0x7d9d1821d15B9e0b8Ab98A058361233E255E405D");
         assert_eq!(network, "eip155:8453"); // "base" resolved to CAIP-2

--- a/ows/crates/ows-pay/src/x402.rs
+++ b/ows/crates/ows-pay/src/x402.rs
@@ -21,12 +21,13 @@ pub(crate) async fn handle_x402(
     req_body: Option<&str>,
     resp_headers: &reqwest::header::HeaderMap,
     body_402: &str,
+    preferred_network: Option<&str>,
 ) -> Result<PayResult, PayError> {
     let (x402_version, resource, requirements) = parse_requirements(resp_headers, body_402)?;
-    let (req, network) = pick_payment_option(wallet, &requirements)?;
+    let (req, network) = pick_payment_option(wallet, &requirements, preferred_network)?;
 
     let (payload, payment_info) =
-        build_signed_payment(wallet, req, &network, x402_version, resource)?;
+        build_signed_payment(wallet, req, &network, x402_version, resource).await?;
 
     let payload_json = serde_json::to_string(&payload)?;
     let payload_b64 = B64.encode(payload_json.as_bytes());
@@ -52,7 +53,7 @@ pub(crate) async fn handle_x402(
 // ---------------------------------------------------------------------------
 
 /// Build a signed payment payload, dispatching on the scheme.
-fn build_signed_payment(
+async fn build_signed_payment(
     wallet: &dyn WalletAccess,
     req: &PaymentRequirements,
     network: &str,
@@ -60,7 +61,21 @@ fn build_signed_payment(
     resource: Option<serde_json::Value>,
 ) -> Result<(PaymentPayload, PaymentInfo), PayError> {
     match req.scheme.as_str() {
-        "exact" => build_evm_exact(wallet, req, network, x402_version, resource),
+        "exact" => {
+            let chain_type = chains::resolve_chain_type(network);
+            match chain_type {
+                Some(ows_core::ChainType::Stellar) => {
+                    build_stellar_exact(wallet, req, network, x402_version, resource).await
+                }
+                Some(ows_core::ChainType::Evm) | None => {
+                    build_evm_exact(wallet, req, network, x402_version, resource)
+                }
+                Some(_) => Err(PayError::new(
+                    PayErrorCode::UnsupportedChain,
+                    format!("exact scheme not yet supported for {network}"),
+                )),
+            }
+        }
         scheme => Err(PayError::new(
             PayErrorCode::ProtocolUnknown,
             format!("unsupported payment scheme: {scheme}"),
@@ -183,6 +198,610 @@ fn build_evm_exact(
 }
 
 // ---------------------------------------------------------------------------
+// Stellar "exact" (Soroban token transfer)
+// ---------------------------------------------------------------------------
+
+use stellar_xdr::curr::{
+    self as xdr, ContractId, Hash, HostFunction, Int128Parts, InvokeContractArgs,
+    InvokeHostFunctionOp, LedgerEntryData, Limits, MuxedAccount, Operation, OperationBody,
+    Preconditions, ReadXdr, ScAddress, ScSymbol, ScVal, SequenceNumber,
+    SorobanAuthorizationEntry, SorobanCredentials, SorobanTransactionData, TimeBounds,
+    TimePoint, Transaction, TransactionEnvelope, TransactionExt, TransactionV1Envelope,
+    Uint256, VecM, WriteXdr,
+};
+
+/// Parsed result from `simulateTransaction` JSON-RPC.
+struct SimulationResult {
+    /// Base64-encoded `SorobanTransactionData` XDR.
+    transaction_data: String,
+    /// Minimum resource fee (stroops).
+    min_resource_fee: u32,
+    /// Base64-encoded `SorobanAuthorizationEntry` XDR strings.
+    auth_entries: Vec<String>,
+    /// Latest ledger seen by the RPC node.
+    latest_ledger: u32,
+}
+
+async fn build_stellar_exact(
+    wallet: &dyn WalletAccess,
+    req: &PaymentRequirements,
+    network: &str,
+    x402_version: u32,
+    resource: Option<serde_json::Value>,
+) -> Result<(PaymentPayload, PaymentInfo), PayError> {
+    let account = wallet.account(network)?;
+    let rpc_url = stellar_rpc_url(network)?;
+    let client = reqwest::Client::new();
+
+    // 1. Parse addresses
+    let from_addr = stellar_address_to_sc_address(&account.address)?;
+    let to_addr = stellar_address_to_sc_address(&req.pay_to)?;
+    let contract_addr = stellar_contract_to_sc_address(&req.asset)?;
+
+    // 3. Build amount as ScVal::I128
+    let amount: i128 = req.amount.parse().map_err(|_| {
+        PayError::new(PayErrorCode::ProtocolMalformed, "invalid amount")
+    })?;
+    let amount_val = i128_to_sc_val(amount);
+
+    // 4. Build InvokeHostFunctionOp for transfer(from, to, amount)
+    let invoke_args = InvokeContractArgs {
+        contract_address: match contract_addr {
+            ScAddress::Contract(_) => contract_addr,
+            _ => {
+                return Err(PayError::new(
+                    PayErrorCode::ProtocolMalformed,
+                    "asset must be a contract address",
+                ))
+            }
+        },
+        function_name: ScSymbol("transfer".try_into().map_err(|_| {
+            PayError::new(PayErrorCode::ProtocolMalformed, "bad function name")
+        })?),
+        args: vec![
+            ScVal::Address(from_addr),
+            ScVal::Address(to_addr),
+            amount_val,
+        ]
+        .try_into()
+        .map_err(|_| {
+            PayError::new(PayErrorCode::ProtocolMalformed, "too many args")
+        })?,
+    };
+
+    let op = Operation {
+        source_account: None,
+        body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+            host_function: HostFunction::InvokeContract(invoke_args),
+            auth: VecM::default(),
+        }),
+    };
+
+    // 5. Build transaction.
+    // Use the null account (all-zero key) as source so Soroban issues Address credentials
+    // for the payer rather than SourceAccount credentials. The facilitator fee-bumps with
+    // its own source/sequence; this inner tx only needs to be simulatable.
+    let tx = Transaction {
+        source_account: MuxedAccount::Ed25519(Uint256([0u8; 32])),
+        fee: 100_000,
+        seq_num: SequenceNumber(0),
+        cond: Preconditions::Time(TimeBounds {
+            min_time: TimePoint(0),
+            max_time: TimePoint(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs()
+                    + req.max_timeout_seconds as u64,
+            ),
+        }),
+        memo: xdr::Memo::None,
+        operations: vec![op].try_into().map_err(|_| {
+            PayError::new(PayErrorCode::ProtocolMalformed, "bad ops")
+        })?,
+        ext: TransactionExt::V0,
+    };
+
+    let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx: tx.clone(),
+        signatures: VecM::default(),
+    });
+    let tx_xdr_b64 = B64.encode(
+        envelope
+            .to_xdr(Limits::none())
+            .map_err(|e| PayError::new(PayErrorCode::ProtocolMalformed, format!("xdr encode: {e}")))?,
+    );
+
+    // 6. Simulate transaction via Soroban RPC
+    let sim = soroban_rpc_simulate(&client, &rpc_url, &tx_xdr_b64).await?;
+
+    // 7. Sign auth entries from simulation
+    // Use a conservative ledger-close estimate (6s) so the expiration doesn't exceed
+    // the facilitator's dynamically-computed maxLedger (which samples real close times).
+    // A too-generous estimate (e.g. 5s) causes "signature_expiration_too_far" rejections.
+    let estimated_ledger_secs: u32 = 6;
+    let max_ledger = sim.latest_ledger
+        + (req.max_timeout_seconds as u32 + estimated_ledger_secs - 1) / estimated_ledger_secs;
+    let signed_auth = sign_sim_auth_entries(wallet, network, &sim.auth_entries, max_ledger)?;
+
+    // 8. Assemble transaction with footprint + signed auth (use first sim fee for now)
+    let assembled_tx = assemble_stellar_tx(tx, &sim, signed_auth)?;
+
+    // 9. Re-simulate with the fully assembled transaction to get an accurate resource fee.
+    //    The first simulation overestimates because auth entries aren't signed yet;
+    //    the second simulation accounts for the actual signed auth XDR size.
+    let assembled_envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx: assembled_tx.clone(),
+        signatures: VecM::default(),
+    });
+    let assembled_b64 = B64.encode(
+        assembled_envelope
+            .to_xdr(Limits::none())
+            .map_err(|e| PayError::new(PayErrorCode::ProtocolMalformed, format!("assembled xdr: {e}")))?,
+    );
+    let sim2 = soroban_rpc_simulate(&client, &rpc_url, &assembled_b64).await?;
+
+    // Update both the sorobanData ext AND the fee from the second simulation.
+    // The first sim overestimates sorobanData.resourceFee (auth entries aren't signed yet).
+    // If we keep sim1's sorobanData but use sim2's fee, the network rejects the tx because
+    // tx.fee < sorobanData.resourceFee + base_fee (33148 < 141529 + 100).
+    // sim2 has the same footprint but an accurate resourceFee for the signed-auth tx.
+    let soroban_data2_bytes = B64.decode(&sim2.transaction_data).map_err(|e| {
+        PayError::new(PayErrorCode::ProtocolMalformed, format!("bad sim2 soroban tx data: {e}"))
+    })?;
+    let soroban_data2 =
+        SorobanTransactionData::from_xdr(&soroban_data2_bytes, Limits::none()).map_err(|e| {
+            PayError::new(PayErrorCode::ProtocolMalformed, format!("bad sim2 soroban data xdr: {e}"))
+        })?;
+    let mut final_tx = assembled_tx;
+    final_tx.ext = TransactionExt::V1(soroban_data2);
+    final_tx.fee = 100u32.saturating_add(sim2.min_resource_fee);
+
+    let final_envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+        tx: final_tx,
+        signatures: VecM::default(),
+    });
+    let xdr_base64 = B64.encode(
+        final_envelope
+            .to_xdr(Limits::none())
+            .map_err(|e| PayError::new(PayErrorCode::ProtocolMalformed, format!("final xdr: {e}")))?,
+    );
+
+    // 9. Build payment payload
+    let inner = serde_json::json!({ "transaction": xdr_base64 });
+
+    let payload = if x402_version >= 2 {
+        PaymentPayload::V2(PaymentPayloadV2 {
+            x402_version,
+            accepted: req.clone(),
+            resource,
+            payload: inner,
+        })
+    } else {
+        PaymentPayload::V1(PaymentPayloadV1 {
+            x402_version,
+            scheme: req.scheme.clone(),
+            network: req.network.clone(),
+            payload: inner,
+        })
+    };
+
+    let amount_display = crate::discovery::format_usdc(&req.amount);
+    let payment_info = PaymentInfo {
+        amount: amount_display,
+        network: chains::display_name(network).to_string(),
+        token: "USDC".to_string(),
+    };
+
+    Ok((payload, payment_info))
+}
+
+// ---------------------------------------------------------------------------
+// Stellar helpers
+// ---------------------------------------------------------------------------
+
+fn stellar_rpc_url(network: &str) -> Result<String, PayError> {
+    if let Ok(url) = std::env::var("OWS_STELLAR_RPC_URL") {
+        return Ok(url);
+    }
+    match network {
+        "stellar:pubnet" => Ok("https://soroban-rpc.mainnet.stellar.gateway.fm".into()),
+        "stellar:testnet" => Ok("https://soroban-testnet.stellar.org".into()),
+        "stellar:futurenet" => Ok("https://rpc-futurenet.stellar.org".into()),
+        _ => Err(PayError::new(
+            PayErrorCode::UnsupportedChain,
+            format!("no known Soroban RPC for network: {network}"),
+        )),
+    }
+}
+
+fn stellar_network_passphrase(network: &str) -> Result<&'static str, PayError> {
+    match network {
+        "stellar:pubnet" => Ok(ows_core::STELLAR_PASSPHRASE_PUBNET),
+        "stellar:testnet" => Ok(ows_core::STELLAR_PASSPHRASE_TESTNET),
+        "stellar:futurenet" => Ok(ows_core::STELLAR_PASSPHRASE_FUTURENET),
+        _ => Err(PayError::new(
+            PayErrorCode::UnsupportedChain,
+            format!("no known passphrase for network: {network}"),
+        )),
+    }
+}
+
+fn stellar_address_to_sc_address(addr: &str) -> Result<ScAddress, PayError> {
+    let pk = stellar_strkey::ed25519::PublicKey::from_string(addr).map_err(|e| {
+        PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            format!("invalid Stellar address '{addr}': {e}"),
+        )
+    })?;
+    Ok(ScAddress::Account(xdr::AccountId(
+        xdr::PublicKey::PublicKeyTypeEd25519(Uint256(pk.0)),
+    )))
+}
+
+fn stellar_contract_to_sc_address(addr: &str) -> Result<ScAddress, PayError> {
+    let contract = stellar_strkey::Contract::from_string(addr).map_err(|e| {
+        PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            format!("invalid Stellar contract '{addr}': {e}"),
+        )
+    })?;
+    Ok(ScAddress::Contract(ContractId(Hash(contract.0))))
+}
+
+fn i128_to_sc_val(amount: i128) -> ScVal {
+    ScVal::I128(Int128Parts {
+        hi: (amount >> 64) as i64,
+        lo: amount as u64,
+    })
+}
+
+async fn soroban_rpc_get_account(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    address: &str,
+) -> Result<i64, PayError> {
+    let pk = stellar_strkey::ed25519::PublicKey::from_string(address).map_err(|e| {
+        PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            format!("bad address for getAccount: {e}"),
+        )
+    })?;
+
+    // Build the LedgerKey::Account XDR, then base64-encode it for getLedgerEntries
+    let account_id = xdr::AccountId(xdr::PublicKey::PublicKeyTypeEd25519(Uint256(pk.0)));
+    let ledger_key = xdr::LedgerKey::Account(xdr::LedgerKeyAccount { account_id });
+    let key_xdr_b64 = B64.encode(
+        ledger_key
+            .to_xdr(Limits::none())
+            .map_err(|e| PayError::new(PayErrorCode::ProtocolMalformed, format!("xdr key: {e}")))?,
+    );
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getLedgerEntries",
+        "params": {
+            "keys": [key_xdr_b64]
+        }
+    });
+
+    let resp: serde_json::Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| PayError::new(PayErrorCode::HttpTransport, format!("rpc getAccount: {e}")))?
+        .json()
+        .await
+        .map_err(|e| {
+            PayError::new(
+                PayErrorCode::ProtocolMalformed,
+                format!("rpc getAccount parse: {e}"),
+            )
+        })?;
+
+    if let Some(err) = resp.get("error") {
+        return Err(PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            format!("rpc getAccount error: {err}"),
+        ));
+    }
+
+    // Parse the account entry to extract sequence number
+    let entry_xdr_b64 = resp
+        .pointer("/result/entries/0/xdr")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            PayError::new(
+                PayErrorCode::ProtocolMalformed,
+                format!("account not found on ledger: {address}"),
+            )
+        })?;
+
+    let entry_bytes = B64.decode(entry_xdr_b64).map_err(|e| {
+        PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            format!("bad ledger entry base64: {e}"),
+        )
+    })?;
+    let entry_data = LedgerEntryData::from_xdr(&entry_bytes, Limits::none()).map_err(|e| {
+        PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            format!("bad ledger entry xdr: {e}"),
+        )
+    })?;
+
+    match entry_data {
+        LedgerEntryData::Account(acct) => Ok(acct.seq_num.0),
+        _ => Err(PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            "expected account ledger entry",
+        )),
+    }
+}
+
+async fn soroban_rpc_simulate(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    tx_xdr_b64: &str,
+) -> Result<SimulationResult, PayError> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "simulateTransaction",
+        "params": {
+            "transaction": tx_xdr_b64
+        }
+    });
+
+    let resp: serde_json::Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| PayError::new(PayErrorCode::HttpTransport, format!("rpc simulate: {e}")))?
+        .json()
+        .await
+        .map_err(|e| {
+            PayError::new(
+                PayErrorCode::ProtocolMalformed,
+                format!("rpc simulate parse: {e}"),
+            )
+        })?;
+
+    if let Some(err) = resp.get("error") {
+        return Err(PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            format!("rpc simulate error: {err}"),
+        ));
+    }
+
+    let result = resp
+        .get("result")
+        .ok_or_else(|| {
+            PayError::new(
+                PayErrorCode::ProtocolMalformed,
+                "simulateTransaction: missing result",
+            )
+        })?;
+
+    // Check for restore/error in the simulation result itself
+    if let Some(err_str) = result.get("error").and_then(|v| v.as_str()) {
+        return Err(PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            format!("simulation failed: {err_str}"),
+        ));
+    }
+
+    let transaction_data = result
+        .get("transactionData")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let min_resource_fee: u32 = result
+        .get("minResourceFee")
+        .and_then(|v| v.as_str().or_else(|| v.as_u64().map(|_| "")))
+        .and_then(|s| {
+            if s.is_empty() {
+                result
+                    .get("minResourceFee")
+                    .and_then(|v| v.as_u64())
+                    .map(|n| n as u32)
+            } else {
+                s.parse().ok()
+            }
+        })
+        .unwrap_or(0);
+
+    // Auth entries from results[0].auth[]
+    let auth_entries: Vec<String> = result
+        .pointer("/results/0/auth")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let latest_ledger: u32 = result
+        .get("latestLedger")
+        .and_then(|v| v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok())))
+        .unwrap_or(0) as u32;
+
+    Ok(SimulationResult {
+        transaction_data,
+        min_resource_fee,
+        auth_entries,
+        latest_ledger,
+    })
+}
+
+fn sign_sim_auth_entries(
+    wallet: &dyn WalletAccess,
+    network: &str,
+    entries: &[String],
+    max_ledger: u32,
+) -> Result<Vec<SorobanAuthorizationEntry>, PayError> {
+    let mut signed = Vec::with_capacity(entries.len());
+
+    for entry_b64 in entries {
+        let entry_bytes = B64.decode(entry_b64).map_err(|e| {
+            PayError::new(
+                PayErrorCode::ProtocolMalformed,
+                format!("bad auth entry base64: {e}"),
+            )
+        })?;
+        let mut entry =
+            SorobanAuthorizationEntry::from_xdr(&entry_bytes, Limits::none()).map_err(|e| {
+                PayError::new(
+                    PayErrorCode::ProtocolMalformed,
+                    format!("bad auth entry xdr: {e}"),
+                )
+            })?;
+
+        match &mut entry.credentials {
+            SorobanCredentials::Address(ref mut addr_creds) => {
+                // Set expiration ledger
+                addr_creds.signature_expiration_ledger = max_ledger;
+
+                // Build the preimage that needs signing
+                let passphrase = stellar_network_passphrase(network)?;
+                let network_id = Hash(
+                    <sha2::Sha256 as sha2::Digest>::digest(passphrase.as_bytes()).into(),
+                );
+
+                let preimage = xdr::HashIdPreimage::SorobanAuthorization(
+                    xdr::HashIdPreimageSorobanAuthorization {
+                        network_id,
+                        nonce: addr_creds.nonce,
+                        signature_expiration_ledger: max_ledger,
+                        invocation: entry.root_invocation.clone(),
+                    },
+                );
+
+                let preimage_xdr_bytes = preimage.to_xdr(Limits::none()).map_err(|e| {
+                    PayError::new(
+                        PayErrorCode::ProtocolMalformed,
+                        format!("preimage xdr: {e}"),
+                    )
+                })?;
+                let preimage_b64 = B64.encode(&preimage_xdr_bytes);
+
+                // Sign via wallet
+                let sig_b64 = wallet.sign_stellar_auth(network, &preimage_b64)?;
+                let sig_bytes = B64.decode(&sig_b64).map_err(|e| {
+                    PayError::new(
+                        PayErrorCode::SigningFailed,
+                        format!("bad signature base64: {e}"),
+                    )
+                })?;
+
+                // Get the public key for the account
+                let account_address = match &addr_creds.address {
+                    ScAddress::Account(acct_id) => match &acct_id.0 {
+                        xdr::PublicKey::PublicKeyTypeEd25519(Uint256(bytes)) => bytes.clone(),
+                    },
+                    _ => {
+                        // Contract or other address auth — no signing needed, keep as-is
+                        signed.push(entry);
+                        continue;
+                    }
+                };
+
+                // Soroban expects: ScVal::Vec([ScVal::Map({public_key: Bytes, signature: Bytes})])
+                // A Vec of signature entries — same format as stellar-base authorizeEntry().
+                let sig_map = ScVal::Map(Some(
+                    vec![
+                        xdr::ScMapEntry {
+                            key: ScVal::Symbol(ScSymbol("public_key".try_into().map_err(
+                                |_| PayError::new(PayErrorCode::ProtocolMalformed, "bad symbol"),
+                            )?)),
+                            val: ScVal::Bytes(
+                                account_address.to_vec().try_into().map_err(|_| {
+                                    PayError::new(
+                                        PayErrorCode::ProtocolMalformed,
+                                        "bad pubkey bytes",
+                                    )
+                                })?,
+                            ),
+                        },
+                        xdr::ScMapEntry {
+                            key: ScVal::Symbol(ScSymbol("signature".try_into().map_err(
+                                |_| PayError::new(PayErrorCode::ProtocolMalformed, "bad symbol"),
+                            )?)),
+                            val: ScVal::Bytes(sig_bytes.try_into().map_err(|_| {
+                                PayError::new(PayErrorCode::SigningFailed, "signature too large")
+                            })?),
+                        },
+                    ]
+                    .try_into()
+                    .map_err(|_| PayError::new(PayErrorCode::ProtocolMalformed, "bad sig map"))?,
+                ));
+
+                addr_creds.signature = ScVal::Vec(Some(
+                    vec![sig_map]
+                        .try_into()
+                        .map_err(|_| PayError::new(PayErrorCode::ProtocolMalformed, "bad sig vec"))?,
+                ));
+            }
+            SorobanCredentials::SourceAccount => {
+                // Source account auth — no additional signing needed
+            }
+        }
+
+        signed.push(entry);
+    }
+
+    Ok(signed)
+}
+
+fn assemble_stellar_tx(
+    mut tx: Transaction,
+    sim: &SimulationResult,
+    signed_auth: Vec<SorobanAuthorizationEntry>,
+) -> Result<Transaction, PayError> {
+    // Parse the simulation's SorobanTransactionData
+    let soroban_data_bytes = B64.decode(&sim.transaction_data).map_err(|e| {
+        PayError::new(
+            PayErrorCode::ProtocolMalformed,
+            format!("bad soroban tx data base64: {e}"),
+        )
+    })?;
+    let soroban_data =
+        SorobanTransactionData::from_xdr(&soroban_data_bytes, Limits::none()).map_err(|e| {
+            PayError::new(
+                PayErrorCode::ProtocolMalformed,
+                format!("bad soroban tx data: {e}"),
+            )
+        })?;
+
+    // Update fee: base fee + resource fee
+    let base_fee = 100u32;
+    tx.fee = base_fee.saturating_add(sim.min_resource_fee);
+
+    // Set the SorobanTransactionData in the transaction ext
+    tx.ext = TransactionExt::V1(soroban_data);
+
+    // Replace the auth in the operation with signed auth entries
+    if let Some(op) = tx.operations.to_vec().first() {
+        let mut new_op = op.clone();
+        if let OperationBody::InvokeHostFunction(ref mut ihf) = new_op.body {
+            ihf.auth = signed_auth.try_into().map_err(|_| {
+                PayError::new(PayErrorCode::ProtocolMalformed, "too many auth entries")
+            })?;
+        }
+        tx.operations = vec![new_op].try_into().map_err(|_| {
+            PayError::new(PayErrorCode::ProtocolMalformed, "bad ops")
+        })?;
+    }
+
+    Ok(tx)
+}
+
+// ---------------------------------------------------------------------------
 // Requirement parsing & chain selection
 // ---------------------------------------------------------------------------
 
@@ -244,12 +863,14 @@ fn parsed_amount(req: &PaymentRequirements) -> Option<u128> {
     req.amount.parse().ok()
 }
 
-/// Pick the first payment option whose scheme we support and whose
-/// network the wallet supports. Returns the requirement and its
-/// resolved CAIP-2 network string.
+/// Pick the best payment option whose scheme we support and whose
+/// network the wallet supports. If `preferred_network` is set, only
+/// options matching that network are considered. Returns the requirement
+/// and its resolved CAIP-2 network string.
 fn pick_payment_option<'a>(
     wallet: &dyn WalletAccess,
     requirements: &'a [PaymentRequirements],
+    preferred_network: Option<&str>,
 ) -> Result<(&'a PaymentRequirements, String), PayError> {
     let supported = wallet.supported_chains();
     let mut candidates = Vec::new();
@@ -279,6 +900,13 @@ fn pick_payment_option<'a>(
             Ok(c) => c.chain_id.to_string(),
             Err(_) => req.network.clone(), // Already CAIP-2 (unknown to registry but namespace matched).
         };
+
+        // If the user specified a preferred network, skip non-matching options.
+        if let Some(pref) = preferred_network {
+            if !req.network.eq_ignore_ascii_case(pref) && !network.eq_ignore_ascii_case(pref) {
+                continue;
+            }
+        }
 
         candidates.push((req, network));
     }
@@ -669,8 +1297,8 @@ mod tests {
         assert_eq!(reqs[0].pay_to, "0xv2");
     }
 
-    #[test]
-    fn v2_header_without_version_builds_v2_payment_payload() {
+    #[tokio::test]
+    async fn v2_header_without_version_builds_v2_payment_payload() {
         let x402 = serde_json::json!({
             "accepts": [{
                 "scheme": "exact",
@@ -690,9 +1318,9 @@ mod tests {
         headers.insert("payment-required", encoded.parse().unwrap());
 
         let (version, resource, reqs) = parse_requirements(&headers, "not json").unwrap();
-        let (req, network) = pick_payment_option(&EvmWallet, &reqs).unwrap();
+        let (req, network) = pick_payment_option(&EvmWallet, &reqs, None).unwrap();
         let (payload, _) =
-            build_signed_payment(&EvmWallet, req, &network, version, resource).unwrap();
+            build_signed_payment(&EvmWallet, req, &network, version, resource).await.unwrap();
 
         match payload {
             PaymentPayload::V2(v2) => {
@@ -769,7 +1397,7 @@ mod tests {
     #[test]
     fn pick_evm_by_caip2() {
         let reqs = vec![base_requirement()];
-        let (req, network) = pick_payment_option(&EvmWallet, &reqs).unwrap();
+        let (req, network) = pick_payment_option(&EvmWallet, &reqs, None).unwrap();
         assert_eq!(req.network, "eip155:8453");
         assert_eq!(network, "eip155:8453");
     }
@@ -779,7 +1407,7 @@ mod tests {
         let mut req = base_requirement();
         req.network = "base".into();
         let reqs = [req];
-        let (_, network) = pick_payment_option(&EvmWallet, &reqs).unwrap();
+        let (_, network) = pick_payment_option(&EvmWallet, &reqs, None).unwrap();
         // Human name resolved to CAIP-2.
         assert_eq!(network, "eip155:8453");
     }
@@ -789,7 +1417,7 @@ mod tests {
         let mut req = base_requirement();
         req.network = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".into();
         let reqs = [req];
-        let err = pick_payment_option(&EvmWallet, &reqs).unwrap_err();
+        let err = pick_payment_option(&EvmWallet, &reqs, None).unwrap_err();
         assert_eq!(err.code, PayErrorCode::UnsupportedChain);
     }
 
@@ -798,7 +1426,7 @@ mod tests {
         let mut req = base_requirement();
         req.network = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".into();
         let reqs = [req];
-        let (_, network) = pick_payment_option(&SolanaWallet, &reqs).unwrap();
+        let (_, network) = pick_payment_option(&SolanaWallet, &reqs, None).unwrap();
         assert!(network.starts_with("solana:"));
     }
 
@@ -808,7 +1436,7 @@ mod tests {
         let mut sol_req = base_requirement();
         sol_req.network = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp".into();
         let reqs = [sol_req, evm_req];
-        let (_, network) = pick_payment_option(&MultiWallet, &reqs).unwrap();
+        let (_, network) = pick_payment_option(&MultiWallet, &reqs, None).unwrap();
         assert!(network.starts_with("solana:"));
     }
 
@@ -818,7 +1446,7 @@ mod tests {
         let mut cheap = base_requirement();
         cheap.amount = "1000".into();
         let reqs = [expensive, cheap];
-        let (req, network) = pick_payment_option(&EvmWallet, &reqs).unwrap();
+        let (req, network) = pick_payment_option(&EvmWallet, &reqs, None).unwrap();
         assert_eq!(network, "eip155:8453");
         assert_eq!(req.amount, "1000");
     }
@@ -836,7 +1464,7 @@ mod tests {
         regular.amount = "1000".into();
 
         let reqs = [gateway, regular];
-        let (req, _) = pick_payment_option(&EvmWallet, &reqs).unwrap();
+        let (req, _) = pick_payment_option(&EvmWallet, &reqs, None).unwrap();
         assert_eq!(req.amount, "1000");
         assert_eq!(req.extra["name"], "USD Coin");
     }
@@ -846,7 +1474,7 @@ mod tests {
         let mut req = base_requirement();
         req.network = "foochain:1".into();
         let reqs = [req];
-        let err = pick_payment_option(&EvmWallet, &reqs).unwrap_err();
+        let err = pick_payment_option(&EvmWallet, &reqs, None).unwrap_err();
         assert_eq!(err.code, PayErrorCode::UnsupportedChain);
     }
 
@@ -855,7 +1483,7 @@ mod tests {
         let mut req = base_requirement();
         req.scheme = "subscription".into();
         let reqs = [req];
-        let err = pick_payment_option(&EvmWallet, &reqs).unwrap_err();
+        let err = pick_payment_option(&EvmWallet, &reqs, None).unwrap_err();
         assert_eq!(err.code, PayErrorCode::UnsupportedChain);
     }
 
@@ -865,7 +1493,7 @@ mod tests {
         let mut req = base_requirement();
         req.network = "eip155:999999".into();
         let reqs = [req];
-        let (_, network) = pick_payment_option(&EvmWallet, &reqs).unwrap();
+        let (_, network) = pick_payment_option(&EvmWallet, &reqs, None).unwrap();
         assert_eq!(network, "eip155:999999");
     }
 
@@ -983,7 +1611,7 @@ mod tests {
 
         let headers = HeaderMap::new();
         let (_, _, reqs) = parse_requirements(&headers, &body).unwrap();
-        let (req, network) = pick_payment_option(&EvmWallet, &reqs).unwrap();
+        let (req, network) = pick_payment_option(&EvmWallet, &reqs, None).unwrap();
         assert_eq!(req.pay_to, "0x7d9d1821d15B9e0b8Ab98A058361233E255E405D");
         assert_eq!(network, "eip155:8453"); // "base" resolved to CAIP-2
     }

--- a/ows/crates/ows-pay/src/x402.rs
+++ b/ows/crates/ows-pay/src/x402.rs
@@ -1650,7 +1650,7 @@ mod tests {
         let encoded = B64.encode(serde_json::to_string(&x402).unwrap().as_bytes());
         let (url, rx, handle) = spawn_x402_flow_server("x-payment-required", encoded);
 
-        let result = crate::pay(&EvmWallet, &url, "GET", None).await.unwrap();
+        let result = crate::pay(&EvmWallet, &url, "GET", None, None).await.unwrap();
         let retry_request = rx.recv_timeout(Duration::from_secs(3)).unwrap();
         handle.join().unwrap();
 
@@ -1693,7 +1693,7 @@ mod tests {
         let encoded = B64.encode(serde_json::to_string(&x402).unwrap().as_bytes());
         let (url, rx, handle) = spawn_x402_flow_server("payment-required", encoded);
 
-        let result = crate::pay(&EvmWallet, &url, "GET", None).await.unwrap();
+        let result = crate::pay(&EvmWallet, &url, "GET", None, None).await.unwrap();
         let retry_request = rx.recv_timeout(Duration::from_secs(3)).unwrap();
         handle.join().unwrap();
 

--- a/ows/crates/ows-pay/src/x402.rs
+++ b/ows/crates/ows-pay/src/x402.rs
@@ -386,7 +386,7 @@ async fn build_stellar_exact(
         })
     };
 
-    let amount_display = crate::discovery::format_usdc(&req.amount);
+    let amount_display = crate::discovery::format_usdc_decimals(&req.amount, 7);
     let payment_info = PaymentInfo {
         amount: amount_display,
         network: chains::display_name(network).to_string(),

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -38,7 +38,7 @@ blake2 = "0.10"
 digest = "0.10"
 libc = "0.2"
 signal-hook = "0.4"
-stellar-strkey = "0.0.16"
+stellar-strkey = { workspace = true }
 stellar-xdr = { workspace = true }
 
 [dev-dependencies]

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -38,5 +38,7 @@ blake2 = "0.10"
 digest = "0.10"
 libc = "0.2"
 signal-hook = "0.4"
+stellar-strkey = "0.0.16"
+stellar-xdr = { workspace = true }
 
 [dev-dependencies]

--- a/ows/crates/ows-signer/src/chains/mod.rs
+++ b/ows/crates/ows-signer/src/chains/mod.rs
@@ -5,6 +5,7 @@ pub mod filecoin;
 pub mod nano;
 pub mod solana;
 pub mod spark;
+pub mod stellar;
 pub mod sui;
 pub mod ton;
 pub mod tron;
@@ -17,6 +18,7 @@ pub use self::filecoin::FilecoinSigner;
 pub use self::nano::NanoSigner;
 pub use self::solana::SolanaSigner;
 pub use self::spark::SparkSigner;
+pub use self::stellar::StellarSigner;
 pub use self::sui::SuiSigner;
 pub use self::ton::TonSigner;
 pub use self::tron::TronSigner;
@@ -25,9 +27,15 @@ pub use self::xrpl::XrplSigner;
 use crate::traits::ChainSigner;
 use ows_core::ChainType;
 
-/// Get a default signer for a given chain type.
-pub fn signer_for_chain(chain: ChainType) -> Box<dyn ChainSigner> {
-    match chain {
+/// Backward-compatible wrapper — dispatches to the default (mainnet) signer for a chain type.
+/// Prefer `signer_for_chain(&Chain)` when you have a full Chain with a specific network.
+pub fn signer_for_chain_type(chain_type: ChainType) -> Box<dyn ChainSigner> {
+    signer_for_chain(&ows_core::default_chain_for_type(chain_type))
+}
+
+/// Get a default signer for a given chain.
+pub fn signer_for_chain(chain: &ows_core::Chain) -> Box<dyn ChainSigner> {
+    match chain.chain_type {
         ChainType::Evm => Box::new(EvmSigner),
         ChainType::Solana => Box::new(SolanaSigner),
         ChainType::Bitcoin => Box::new(BitcoinSigner::mainnet()),
@@ -39,5 +47,10 @@ pub fn signer_for_chain(chain: ChainType) -> Box<dyn ChainSigner> {
         ChainType::Sui => Box::new(SuiSigner),
         ChainType::Xrpl => Box::new(XrplSigner),
         ChainType::Nano => Box::new(NanoSigner),
+        ChainType::Stellar => match chain.chain_id {
+            "stellar:testnet" => Box::new(StellarSigner::testnet()),
+            "stellar:futurenet" => Box::new(StellarSigner::futurenet()),
+            _ => Box::new(StellarSigner::pubnet()),
+        },
     }
 }

--- a/ows/crates/ows-signer/src/chains/stellar.rs
+++ b/ows/crates/ows-signer/src/chains/stellar.rs
@@ -7,8 +7,9 @@ use ows_core::{
 };
 use sha2::{Digest, Sha256};
 use stellar_xdr::curr::{
-    DecoratedSignature, Limits, ReadXdr, Signature, SignatureHint, TransactionEnvelope,
-    TransactionSignaturePayload, TransactionSignaturePayloadTaggedTransaction, WriteXdr,
+    DecoratedSignature, Limits, OperationBody, ReadXdr, ScAddress, ScVal, Signature,
+    SignatureHint, SorobanAuthorizationEntry, SorobanCredentials, TransactionEnvelope,
+    TransactionSignaturePayload, TransactionSignaturePayloadTaggedTransaction, VecM, WriteXdr,
 };
 
 /// Stellar chain signer (Ed25519).
@@ -263,6 +264,148 @@ impl ChainSigner for StellarSigner {
         }
 
         // Re-serialize to XDR
+        envelope
+            .to_xdr(Limits::none())
+            .map_err(|e| SignerError::InvalidTransaction(format!("XDR serialize failed: {e}")))
+    }
+
+    /// Sign Soroban authorization entries embedded in an `InvokeHostFunction` operation.
+    ///
+    /// For each `SorobanAuthorizationEntry` with `Address` credentials that match
+    /// the public key derived from `private_key` and have not yet been signed,
+    /// this builds the `HashIdPreimage::SorobanAuthorization`, signs it, and
+    /// attaches the standard `__check_auth` signature map.
+    ///
+    /// Returns the modified transaction envelope as XDR bytes.
+    fn sign_inner_authorizations(
+        &self,
+        private_key: &[u8],
+        tx_bytes: &[u8],
+    ) -> Result<Vec<u8>, SignerError> {
+        use stellar_xdr::curr::Operation;
+
+        let envelope = TransactionEnvelope::from_xdr(tx_bytes, Limits::none())
+            .map_err(|e| SignerError::InvalidTransaction(format!("XDR parse failed: {e}")))?;
+
+        // Extract the operations as a Vec so we can mutate them.
+        let ops: Vec<Operation> = match &envelope {
+            TransactionEnvelope::TxV0(v0) => v0.tx.operations.to_vec(),
+            TransactionEnvelope::Tx(v1) => v1.tx.operations.to_vec(),
+            TransactionEnvelope::TxFeeBump(fb) => match &fb.tx.inner_tx {
+                stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+                    inner.tx.operations.to_vec()
+                }
+            },
+        };
+
+        // Check if any operation is InvokeHostFunction; if not, return unchanged.
+        let has_invoke = ops.iter().any(|op| {
+            matches!(&op.body, OperationBody::InvokeHostFunction(_))
+        });
+        if !has_invoke {
+            return Ok(tx_bytes.to_vec());
+        }
+
+        // Derive our public key from the private key for comparison.
+        let signing_key = Self::signing_key(private_key)?;
+        let our_pubkey = signing_key.verifying_key().to_bytes();
+
+        let mut modified_ops = Vec::with_capacity(ops.len());
+        for mut op in ops {
+            if let OperationBody::InvokeHostFunction(ref mut invoke_op) = op.body {
+                let auth_entries: Vec<SorobanAuthorizationEntry> = invoke_op.auth.to_vec();
+                let mut new_auth = Vec::with_capacity(auth_entries.len());
+
+                for mut entry in auth_entries {
+                    if let SorobanCredentials::Address(ref mut addr_creds) = entry.credentials {
+                        // Extract the ed25519 pubkey bytes from the account address.
+                        let entry_pubkey = match &addr_creds.address {
+                            ScAddress::Account(account_id) => match &account_id.0 {
+                                stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(
+                                    ref uint256,
+                                ) => uint256.0,
+                                #[allow(unreachable_patterns)]
+                                _ => {
+                                    // Unsupported public key type, skip.
+                                    new_auth.push(entry);
+                                    continue;
+                                }
+                            },
+                            _ => {
+                                // Not an account address (e.g. Contract), skip.
+                                new_auth.push(entry);
+                                continue;
+                            }
+                        };
+
+                        // Check if this entry belongs to our signer.
+                        if entry_pubkey != our_pubkey {
+                            new_auth.push(entry);
+                            continue;
+                        }
+
+                        // Skip if already signed (signature is not Void).
+                        if !matches!(addr_creds.signature, ScVal::Void) {
+                            new_auth.push(entry);
+                            continue;
+                        }
+
+                        // Build the preimage and sign it.
+                        let preimage_xdr = crate::soroban_auth::build_auth_preimage_xdr(
+                            self.network_passphrase,
+                            addr_creds.nonce,
+                            addr_creds.signature_expiration_ledger,
+                            &entry.root_invocation,
+                        )?;
+
+                        let sign_output = self.sign_soroban_auth(private_key, &preimage_xdr)?;
+
+                        // Format and assign the signature using our verified pubkey.
+                        addr_creds.signature = crate::soroban_auth::format_auth_signature(
+                            &our_pubkey,
+                            &sign_output.signature,
+                        )?;
+                    }
+                    // SorobanCredentials::SourceAccount — skip, nothing to sign.
+                    new_auth.push(entry);
+                }
+
+                // Patch the auth entries back into the operation.
+                invoke_op.auth = new_auth.try_into().map_err(|_| {
+                    SignerError::SigningFailed(
+                        "failed to convert auth entries back to VecM".into(),
+                    )
+                })?;
+            }
+            modified_ops.push(op);
+        }
+
+        // Convert operations back to VecM and patch into the envelope.
+        let ops_vecm: VecM<Operation, 100> = modified_ops.try_into().map_err(|_| {
+            SignerError::SigningFailed("failed to convert operations back to VecM".into())
+        })?;
+
+        // Only one match arm executes, so moving ops_vecm in each arm is valid.
+        let envelope = match envelope {
+            TransactionEnvelope::TxV0(mut v0) => {
+                v0.tx.operations = ops_vecm;
+                TransactionEnvelope::TxV0(v0)
+            }
+            TransactionEnvelope::Tx(mut v1) => {
+                v1.tx.operations = ops_vecm;
+                TransactionEnvelope::Tx(v1)
+            }
+            TransactionEnvelope::TxFeeBump(mut fb) => {
+                match &mut fb.tx.inner_tx {
+                    stellar_xdr::curr::FeeBumpTransactionInnerTx::Tx(inner) => {
+                        inner.tx.operations = ops_vecm;
+                    }
+                }
+                TransactionEnvelope::TxFeeBump(fb)
+            }
+        };
+
+        // Re-serialize the modified envelope to XDR.
         envelope
             .to_xdr(Limits::none())
             .map_err(|e| SignerError::InvalidTransaction(format!("XDR serialize failed: {e}")))
@@ -947,24 +1090,40 @@ mod tests {
 
     #[test]
     fn test_sign_soroban_auth_equivalence() {
-        // Verify that sign_soroban_auth produces the same result as manually computing
-        // SHA256(network_id || 0x00000009 || preimage) and Ed25519 signing that hash.
+        // Verify that sign_soroban_auth produces a correct Ed25519 signature
+        // over SHA256(preimage_xdr), where preimage_xdr is the full XDR output
+        // of HashIdPreimage::SorobanAuthorization (which already contains the
+        // network id and discriminant internally).
+        use stellar_xdr::curr::{
+            ContractId, Hash, InvokeContractArgs, ScAddress, ScSymbol,
+            SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
+        };
+
         let privkey = test_privkey();
         let signer = StellarSigner::testnet();
-        let preimage = b"equivalence test soroban auth preimage";
 
-        let result = signer.sign_soroban_auth(&privkey, preimage).unwrap();
+        // Build a real preimage using the shared helper.
+        let invocation = SorobanAuthorizedInvocation {
+            function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                contract_address: ScAddress::Contract(ContractId(Hash([0xAB; 32]))),
+                function_name: ScSymbol("transfer".try_into().unwrap()),
+                args: vec![].try_into().unwrap(),
+            }),
+            sub_invocations: vec![].try_into().unwrap(),
+        };
 
-        // Manually compute the expected signature
-        let network_id: [u8; 32] =
-            Sha256::digest(STELLAR_PASSPHRASE_TESTNET.as_bytes()).into();
+        let preimage_xdr = crate::soroban_auth::build_auth_preimage_xdr(
+            STELLAR_PASSPHRASE_TESTNET,
+            42,
+            1000,
+            &invocation,
+        )
+        .unwrap();
 
-        let mut payload = Vec::new();
-        payload.extend_from_slice(&network_id);
-        payload.extend_from_slice(&0x00000009u32.to_be_bytes());
-        payload.extend_from_slice(preimage);
+        let result = signer.sign_soroban_auth(&privkey, &preimage_xdr).unwrap();
 
-        let hash: [u8; 32] = Sha256::digest(&payload).into();
+        // Manually verify: sign_soroban_auth should have signed SHA256(preimage_xdr).
+        let hash: [u8; 32] = Sha256::digest(&preimage_xdr).into();
 
         let signing_key = SigningKey::from_bytes(&privkey.try_into().unwrap());
         let expected_sig = signing_key.sign(&hash);
@@ -972,14 +1131,466 @@ mod tests {
         assert_eq!(
             result.signature,
             expected_sig.to_bytes().to_vec(),
-            "sign_soroban_auth must match manual SHA256(network_id || ENVELOPE_TYPE_SOROBAN_AUTHORIZATION || preimage) signing"
+            "sign_soroban_auth must match manual Ed25519 signing of SHA256(preimage_xdr)"
         );
 
-        // Also verify the signature is valid using the verifying key
+        // Also verify the signature is valid using the verifying key.
         let verifying_key = signing_key.verifying_key();
         let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
         verifying_key
             .verify(&hash, &sig)
-            .expect("soroban auth signature should verify against the computed hash");
+            .expect("soroban auth signature should verify against SHA256(preimage_xdr)");
+    }
+
+    // -----------------------------------------------------------------------
+    // sign_inner_authorizations tests
+    // -----------------------------------------------------------------------
+
+    use stellar_xdr::curr::{
+        ContractId, Hash, HostFunction, InvokeContractArgs, InvokeHostFunctionOp, MuxedAccount,
+        Operation, OperationBody, Preconditions, ScSymbol, SequenceNumber,
+        SorobanAddressCredentials, SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
+        Transaction, TransactionEnvelope, TransactionExt, TransactionV1Envelope, Uint256,
+    };
+
+    /// Build a minimal Soroban auth entry for a given pubkey with an unsigned (Void) signature.
+    fn make_unsigned_auth_entry(pubkey: [u8; 32], nonce: i64) -> SorobanAuthorizationEntry {
+        let invocation = SorobanAuthorizedInvocation {
+            function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                contract_address: ScAddress::Contract(ContractId(Hash([0xAB; 32]))),
+                function_name: ScSymbol("transfer".try_into().unwrap()),
+                args: vec![].try_into().unwrap(),
+            }),
+            sub_invocations: vec![].try_into().unwrap(),
+        };
+
+        SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address: ScAddress::Account(stellar_xdr::curr::AccountId(
+                    stellar_xdr::curr::PublicKey::PublicKeyTypeEd25519(Uint256(pubkey)),
+                )),
+                nonce,
+                signature_expiration_ledger: 1000,
+                signature: ScVal::Void,
+            }),
+            root_invocation: invocation,
+        }
+    }
+
+    /// Build a signed auth entry (signature is non-Void).
+    fn make_signed_auth_entry(pubkey: [u8; 32]) -> SorobanAuthorizationEntry {
+        let mut entry = make_unsigned_auth_entry(pubkey, 99);
+        if let SorobanCredentials::Address(ref mut creds) = entry.credentials {
+            creds.signature = ScVal::Vec(Some(vec![ScVal::Void].try_into().unwrap()));
+        }
+        entry
+    }
+
+    /// Build a contract-address auth entry.
+    fn make_contract_auth_entry() -> SorobanAuthorizationEntry {
+        let invocation = SorobanAuthorizedInvocation {
+            function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                contract_address: ScAddress::Contract(ContractId(Hash([0xCD; 32]))),
+                function_name: ScSymbol("approve".try_into().unwrap()),
+                args: vec![].try_into().unwrap(),
+            }),
+            sub_invocations: vec![].try_into().unwrap(),
+        };
+
+        SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::Address(SorobanAddressCredentials {
+                address: ScAddress::Contract(ContractId(Hash([0xEF; 32]))),
+                nonce: 0,
+                signature_expiration_ledger: 500,
+                signature: ScVal::Void,
+            }),
+            root_invocation: invocation,
+        }
+    }
+
+    /// Build a SourceAccount auth entry.
+    fn make_source_account_auth_entry() -> SorobanAuthorizationEntry {
+        let invocation = SorobanAuthorizedInvocation {
+            function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                contract_address: ScAddress::Contract(ContractId(Hash([0x11; 32]))),
+                function_name: ScSymbol("test".try_into().unwrap()),
+                args: vec![].try_into().unwrap(),
+            }),
+            sub_invocations: vec![].try_into().unwrap(),
+        };
+
+        SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::SourceAccount,
+            root_invocation: invocation,
+        }
+    }
+
+    /// Wrap auth entries in a V1 InvokeHostFunction transaction envelope XDR.
+    fn wrap_in_invoke_envelope(auth_entries: Vec<SorobanAuthorizationEntry>) -> Vec<u8> {
+        let op = Operation {
+            source_account: None,
+            body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+                host_function: HostFunction::InvokeContract(InvokeContractArgs {
+                    contract_address: ScAddress::Contract(ContractId(Hash([0x00; 32]))),
+                    function_name: ScSymbol("noop".try_into().unwrap()),
+                    args: vec![].try_into().unwrap(),
+                }),
+                auth: auth_entries.try_into().unwrap(),
+            }),
+        };
+
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([0u8; 32])),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: stellar_xdr::curr::Memo::None,
+            operations: vec![op].try_into().unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        });
+
+        envelope.to_xdr(Limits::none()).unwrap()
+    }
+
+    /// Wrap an operation in a non-Soroban (e.g. Payment) envelope.
+    fn wrap_non_soroban_envelope() -> Vec<u8> {
+        let op = Operation {
+            source_account: None,
+            body: OperationBody::Inflation,
+        };
+
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([0u8; 32])),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: stellar_xdr::curr::Memo::None,
+            operations: vec![op].try_into().unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        });
+
+        envelope.to_xdr(Limits::none()).unwrap()
+    }
+
+    /// Extract the first auth entry's signature from a signed envelope.
+    fn extract_auth_signature(tx_bytes: &[u8], index: usize) -> ScVal {
+        let envelope = TransactionEnvelope::from_xdr(tx_bytes, Limits::none()).unwrap();
+        let ops = match &envelope {
+            TransactionEnvelope::Tx(v1) => v1.tx.operations.to_vec(),
+            _ => panic!("expected V1 envelope"),
+        };
+        match &ops[0].body {
+            OperationBody::InvokeHostFunction(ihf) => {
+                let entry = &ihf.auth.to_vec()[index];
+                match &entry.credentials {
+                    SorobanCredentials::Address(creds) => creds.signature.clone(),
+                    SorobanCredentials::SourceAccount => ScVal::Void,
+                }
+            }
+            _ => panic!("expected InvokeHostFunction"),
+        }
+    }
+
+    fn our_pubkey_bytes() -> [u8; 32] {
+        let privkey = test_privkey();
+        let signing_key = SigningKey::from_bytes(&privkey.try_into().unwrap());
+        signing_key.verifying_key().to_bytes()
+    }
+
+    #[test]
+    fn test_sign_inner_auth_passthrough_no_invoke() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let envelope = wrap_non_soroban_envelope();
+
+        let result = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+        assert_eq!(result, envelope, "non-Soroban tx should pass through unchanged");
+    }
+
+    #[test]
+    fn test_sign_inner_auth_empty_auth_entries() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let envelope = wrap_in_invoke_envelope(vec![]);
+
+        let result = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+
+        // Should still parse correctly, with empty auth
+        let env = TransactionEnvelope::from_xdr(&result, Limits::none()).unwrap();
+        match &env {
+            TransactionEnvelope::Tx(v1) => match &v1.tx.operations[0].body {
+                OperationBody::InvokeHostFunction(ihf) => {
+                    assert!(ihf.auth.is_empty());
+                }
+                _ => panic!("expected InvokeHostFunction"),
+            },
+            _ => panic!("expected V1"),
+        }
+    }
+
+    #[test]
+    fn test_sign_inner_auth_signs_matching_entry() {
+        let privkey = test_privkey();
+        let pubkey = our_pubkey_bytes();
+        let signer = StellarSigner::testnet();
+
+        let entry = make_unsigned_auth_entry(pubkey, 42);
+        let envelope = wrap_in_invoke_envelope(vec![entry]);
+
+        let result = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+
+        let sig = extract_auth_signature(&result, 0);
+        assert!(!matches!(sig, ScVal::Void), "auth entry should be signed");
+
+        // Verify it's the correct format: Vec([Map({public_key, signature})])
+        match sig {
+            ScVal::Vec(Some(vec)) => {
+                assert_eq!(vec.len(), 1);
+                match &vec[0] {
+                    ScVal::Map(Some(map)) => {
+                        assert_eq!(map.len(), 2);
+                        assert_eq!(map[0].key, ScVal::Symbol("public_key".try_into().unwrap()));
+                        assert_eq!(map[1].key, ScVal::Symbol("signature".try_into().unwrap()));
+                        // Verify public key matches our key
+                        if let ScVal::Bytes(pk_bytes) = &map[0].val {
+                            assert_eq!(pk_bytes.as_slice(), &pubkey);
+                        } else {
+                            panic!("expected Bytes for public_key");
+                        }
+                        // Verify signature is 64 bytes
+                        if let ScVal::Bytes(sig_bytes) = &map[1].val {
+                            assert_eq!(sig_bytes.len(), 64);
+                        } else {
+                            panic!("expected Bytes for signature");
+                        }
+                    }
+                    _ => panic!("expected Map inside Vec"),
+                }
+            }
+            _ => panic!("expected Vec"),
+        }
+    }
+
+    #[test]
+    fn test_sign_inner_auth_skips_non_matching_key() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let other_pubkey = [0xFFu8; 32];
+
+        let entry = make_unsigned_auth_entry(other_pubkey, 42);
+        let envelope = wrap_in_invoke_envelope(vec![entry]);
+
+        let result = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+
+        let sig = extract_auth_signature(&result, 0);
+        assert!(matches!(sig, ScVal::Void), "other key's entry should remain unsigned");
+    }
+
+    #[test]
+    fn test_sign_inner_auth_skips_already_signed() {
+        let privkey = test_privkey();
+        let pubkey = our_pubkey_bytes();
+        let signer = StellarSigner::testnet();
+
+        let entry = make_signed_auth_entry(pubkey);
+        let envelope = wrap_in_invoke_envelope(vec![entry]);
+
+        let result = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+
+        let sig = extract_auth_signature(&result, 0);
+        // Should still be the original non-Void signature, not re-signed
+        assert!(!matches!(sig, ScVal::Void));
+        // Original was Vec([Void]) — verify it's preserved, not overwritten
+        match sig {
+            ScVal::Vec(Some(vec)) => {
+                assert_eq!(vec.len(), 1);
+                assert!(matches!(vec[0], ScVal::Void), "original signature payload should be preserved");
+            }
+            _ => panic!("expected original Vec signature"),
+        }
+    }
+
+    #[test]
+    fn test_sign_inner_auth_skips_contract_address() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+
+        let entry = make_contract_auth_entry();
+        let envelope = wrap_in_invoke_envelope(vec![entry]);
+
+        let result = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+
+        let sig = extract_auth_signature(&result, 0);
+        assert!(matches!(sig, ScVal::Void), "contract address entry should remain unsigned");
+    }
+
+    #[test]
+    fn test_sign_inner_auth_skips_source_account() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+
+        let entry = make_source_account_auth_entry();
+        let envelope = wrap_in_invoke_envelope(vec![entry]);
+
+        let result = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+
+        let sig = extract_auth_signature(&result, 0);
+        assert!(matches!(sig, ScVal::Void), "source account entry needs no auth signing");
+    }
+
+    #[test]
+    fn test_sign_inner_auth_mixed_entries() {
+        let privkey = test_privkey();
+        let pubkey = our_pubkey_bytes();
+        let other_pubkey = [0xAAu8; 32];
+        let signer = StellarSigner::testnet();
+
+        let entries = vec![
+            make_unsigned_auth_entry(pubkey, 1),       // 0: ours, unsigned → SIGN
+            make_unsigned_auth_entry(other_pubkey, 2),  // 1: other key → SKIP
+            make_signed_auth_entry(pubkey),             // 2: ours, already signed → SKIP
+            make_contract_auth_entry(),                 // 3: contract address → SKIP
+            make_unsigned_auth_entry(pubkey, 3),       // 4: ours, unsigned → SIGN
+        ];
+
+        let envelope = wrap_in_invoke_envelope(entries);
+        let result = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+
+        // Entry 0: should be signed
+        let sig0 = extract_auth_signature(&result, 0);
+        assert!(!matches!(sig0, ScVal::Void), "entry 0 should be signed");
+
+        // Entry 1: should remain unsigned
+        let sig1 = extract_auth_signature(&result, 1);
+        assert!(matches!(sig1, ScVal::Void), "entry 1 should remain unsigned");
+
+        // Entry 2: should preserve original signature
+        let sig2 = extract_auth_signature(&result, 2);
+        match sig2 {
+            ScVal::Vec(Some(vec)) => assert!(matches!(vec[0], ScVal::Void)),
+            _ => panic!("entry 2 should preserve original"),
+        }
+
+        // Entry 3: contract address, should remain unsigned
+        let sig3 = extract_auth_signature(&result, 3);
+        assert!(matches!(sig3, ScVal::Void), "entry 3 should remain unsigned");
+
+        // Entry 4: should be signed
+        let sig4 = extract_auth_signature(&result, 4);
+        assert!(!matches!(sig4, ScVal::Void), "entry 4 should be signed");
+
+        // Entries 0 and 4 should have DIFFERENT signatures (different nonces)
+        assert_ne!(sig0, sig4, "different nonces must produce different signatures");
+    }
+
+    #[test]
+    fn test_sign_inner_auth_idempotent() {
+        let privkey = test_privkey();
+        let pubkey = our_pubkey_bytes();
+        let signer = StellarSigner::testnet();
+
+        let entry = make_unsigned_auth_entry(pubkey, 42);
+        let envelope = wrap_in_invoke_envelope(vec![entry]);
+
+        let first = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+        let second = signer.sign_inner_authorizations(&privkey, &first).unwrap();
+
+        assert_eq!(first, second, "signing twice should produce identical output");
+    }
+
+    #[test]
+    fn test_sign_inner_auth_invalid_xdr() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+
+        let result = signer.sign_inner_authorizations(&privkey, b"not valid xdr");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sign_inner_auth_invalid_private_key() {
+        let signer = StellarSigner::testnet();
+        let pubkey = [0u8; 32]; // won't match anyway
+        let entry = make_unsigned_auth_entry(pubkey, 1);
+        let envelope = wrap_in_invoke_envelope(vec![entry]);
+
+        // Too-short key
+        let result = signer.sign_inner_authorizations(&[0u8; 16], &envelope);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sign_inner_auth_different_networks_different_sigs() {
+        let privkey = test_privkey();
+        let pubkey = our_pubkey_bytes();
+
+        let entry = make_unsigned_auth_entry(pubkey, 42);
+        let envelope = wrap_in_invoke_envelope(vec![entry]);
+
+        let testnet_result = StellarSigner::testnet()
+            .sign_inner_authorizations(&privkey, &envelope)
+            .unwrap();
+        let pubnet_result = StellarSigner::pubnet()
+            .sign_inner_authorizations(&privkey, &envelope)
+            .unwrap();
+
+        assert_ne!(
+            testnet_result, pubnet_result,
+            "different networks must produce different signatures (replay protection)"
+        );
+    }
+
+    #[test]
+    fn test_sign_inner_auth_signature_verifies() {
+        let privkey = test_privkey();
+        let pubkey = our_pubkey_bytes();
+        let signer = StellarSigner::testnet();
+        let nonce = 42i64;
+        let expiration = 1000u32;
+
+        let entry = make_unsigned_auth_entry(pubkey, nonce);
+        let envelope = wrap_in_invoke_envelope(vec![entry.clone()]);
+
+        let result = signer.sign_inner_authorizations(&privkey, &envelope).unwrap();
+
+        // Extract the signature bytes
+        let sig_val = extract_auth_signature(&result, 0);
+        let sig_bytes: Vec<u8> = match sig_val {
+            ScVal::Vec(Some(vec)) => match &vec[0] {
+                ScVal::Map(Some(map)) => match &map[1].val {
+                    ScVal::Bytes(b) => b.to_vec(),
+                    _ => panic!("expected Bytes"),
+                },
+                _ => panic!("expected Map"),
+            },
+            _ => panic!("expected Vec"),
+        };
+
+        // Rebuild the preimage that should have been signed
+        let preimage_xdr = crate::soroban_auth::build_auth_preimage_xdr(
+            STELLAR_PASSPHRASE_TESTNET,
+            nonce,
+            expiration,
+            &entry.root_invocation,
+        )
+        .unwrap();
+
+        // Verify: SHA256(preimage_xdr), then check Ed25519 signature
+        let hash: [u8; 32] = Sha256::digest(&preimage_xdr).into();
+        let verifying_key = VerifyingKey::from_bytes(&pubkey).unwrap();
+        let sig = ed25519_dalek::Signature::from_bytes(&sig_bytes.try_into().unwrap());
+        verifying_key
+            .verify(&hash, &sig)
+            .expect("auth entry signature must verify against the correct preimage");
     }
 }

--- a/ows/crates/ows-signer/src/chains/stellar.rs
+++ b/ows/crates/ows-signer/src/chains/stellar.rs
@@ -293,6 +293,42 @@ impl ChainSigner for StellarSigner {
     }
 }
 
+impl StellarSigner {
+    /// Sign a Soroban authorization entry preimage.
+    ///
+    /// Signs a Soroban authorization entry preimage.
+    ///
+    /// `preimage_xdr` must be the full `HashIdPreimage::SorobanAuthorization` XDR
+    /// (i.e. the output of `HashIdPreimage::SorobanAuthorization(...).to_xdr()`),
+    /// which starts with the `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION` discriminant and
+    /// includes the network_id field.
+    ///
+    /// Computes: Ed25519_sign(SHA256(preimage_xdr))
+    /// This matches stellar-base's `authorizeEntry` which does `hash(HashIdPreimage.toXDR())`.
+    pub fn sign_soroban_auth(
+        &self,
+        private_key: &[u8],
+        preimage_xdr: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        if preimage_xdr.is_empty() {
+            return Err(SignerError::InvalidTransaction(
+                "auth entry preimage must not be empty".into(),
+            ));
+        }
+
+        let signing_key = Self::signing_key(private_key)?;
+        let hash: [u8; 32] = Sha256::digest(preimage_xdr).into();
+        let signature = signing_key.sign(&hash);
+        let pubkey_bytes = signing_key.verifying_key().to_bytes().to_vec();
+
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: Some(pubkey_bytes),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -867,5 +903,83 @@ mod tests {
 
         let futurenet = StellarSigner::futurenet();
         assert_eq!(futurenet.network_passphrase, STELLAR_PASSPHRASE_FUTURENET);
+    }
+
+    // --- sign_soroban_auth tests ---
+
+    #[test]
+    fn test_sign_soroban_auth_empty_input_errors() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        assert!(signer.sign_soroban_auth(&privkey, b"").is_err());
+    }
+
+    #[test]
+    fn test_sign_soroban_auth_produces_64_byte_sig() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let preimage = b"fake soroban auth preimage xdr bytes";
+
+        let result = signer.sign_soroban_auth(&privkey, preimage).unwrap();
+        assert_eq!(result.signature.len(), 64);
+        assert!(result.recovery_id.is_none());
+        assert!(result.public_key.is_some());
+        assert_eq!(result.public_key.as_ref().unwrap().len(), 32);
+    }
+
+    #[test]
+    fn test_sign_soroban_auth_deterministic() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let preimage = b"deterministic test preimage";
+
+        let sig1 = signer.sign_soroban_auth(&privkey, preimage).unwrap();
+        let sig2 = signer.sign_soroban_auth(&privkey, preimage).unwrap();
+        assert_eq!(sig1.signature, sig2.signature);
+    }
+
+    #[test]
+    fn test_sign_soroban_auth_invalid_key() {
+        let signer = StellarSigner::testnet();
+        assert!(signer.sign_soroban_auth(&[], b"some preimage").is_err());
+        assert!(signer.sign_soroban_auth(&[0u8; 16], b"some preimage").is_err());
+    }
+
+    #[test]
+    fn test_sign_soroban_auth_equivalence() {
+        // Verify that sign_soroban_auth produces the same result as manually computing
+        // SHA256(network_id || 0x00000009 || preimage) and Ed25519 signing that hash.
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let preimage = b"equivalence test soroban auth preimage";
+
+        let result = signer.sign_soroban_auth(&privkey, preimage).unwrap();
+
+        // Manually compute the expected signature
+        let network_id: [u8; 32] =
+            Sha256::digest(STELLAR_PASSPHRASE_TESTNET.as_bytes()).into();
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&network_id);
+        payload.extend_from_slice(&0x00000009u32.to_be_bytes());
+        payload.extend_from_slice(preimage);
+
+        let hash: [u8; 32] = Sha256::digest(&payload).into();
+
+        let signing_key = SigningKey::from_bytes(&privkey.try_into().unwrap());
+        let expected_sig = signing_key.sign(&hash);
+
+        assert_eq!(
+            result.signature,
+            expected_sig.to_bytes().to_vec(),
+            "sign_soroban_auth must match manual SHA256(network_id || ENVELOPE_TYPE_SOROBAN_AUTHORIZATION || preimage) signing"
+        );
+
+        // Also verify the signature is valid using the verifying key
+        let verifying_key = signing_key.verifying_key();
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        verifying_key
+            .verify(&hash, &sig)
+            .expect("soroban auth signature should verify against the computed hash");
     }
 }

--- a/ows/crates/ows-signer/src/chains/stellar.rs
+++ b/ows/crates/ows-signer/src/chains/stellar.rs
@@ -1,0 +1,871 @@
+use crate::curve::Curve;
+use crate::traits::{ChainSigner, SignOutput, SignerError};
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use ows_core::{
+    ChainType, STELLAR_PASSPHRASE_FUTURENET, STELLAR_PASSPHRASE_PUBNET,
+    STELLAR_PASSPHRASE_TESTNET,
+};
+use sha2::{Digest, Sha256};
+use stellar_xdr::curr::{
+    DecoratedSignature, Limits, ReadXdr, Signature, SignatureHint, TransactionEnvelope,
+    TransactionSignaturePayload, TransactionSignaturePayloadTaggedTransaction, WriteXdr,
+};
+
+/// Stellar chain signer (Ed25519).
+///
+/// Stateful struct storing the network passphrase, which is required for
+/// building the `TransactionSignaturePayload` during transaction signing.
+/// Follows the same pattern as `BitcoinSigner` (HRP) and `CosmosSigner` (HRP).
+pub struct StellarSigner {
+    network_passphrase: &'static str,
+}
+
+impl StellarSigner {
+    pub fn pubnet() -> Self {
+        StellarSigner {
+            network_passphrase: STELLAR_PASSPHRASE_PUBNET,
+        }
+    }
+
+    pub fn testnet() -> Self {
+        StellarSigner {
+            network_passphrase: STELLAR_PASSPHRASE_TESTNET,
+        }
+    }
+
+    pub fn futurenet() -> Self {
+        StellarSigner {
+            network_passphrase: STELLAR_PASSPHRASE_FUTURENET,
+        }
+    }
+
+    fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
+        let key_bytes: [u8; 32] = private_key.try_into().map_err(|_| {
+            SignerError::InvalidPrivateKey(format!("expected 32 bytes, got {}", private_key.len()))
+        })?;
+        Ok(SigningKey::from_bytes(&key_bytes))
+    }
+}
+
+impl ChainSigner for StellarSigner {
+    fn chain_type(&self) -> ChainType {
+        ChainType::Stellar
+    }
+
+    fn curve(&self) -> Curve {
+        Curve::Ed25519
+    }
+
+    fn coin_type(&self) -> u32 {
+        148
+    }
+
+    fn default_derivation_path(&self, index: u32) -> String {
+        format!("m/44'/148'/{}'", index)
+    }
+
+    /// Derive a Stellar `G...` address from a private key.
+    ///
+    /// Uses Strkey encoding: `base32(versionByte + ed25519PublicKey + CRC16)`.
+    /// Version byte 48 (6 << 3) produces the `G` prefix.
+    fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key: VerifyingKey = signing_key.verifying_key();
+        let strkey =
+            stellar_strkey::ed25519::PublicKey(*verifying_key.as_bytes());
+        Ok(String::from(strkey.to_string().as_str()))
+    }
+
+    /// Sign raw bytes with Ed25519 (no prefixing, no hashing).
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let signature = signing_key.sign(message);
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: None,
+        })
+    }
+
+    /// Sign a Stellar transaction envelope (XDR bytes).
+    ///
+    /// 1. Parse the `TransactionEnvelope` from XDR
+    /// 2. Extract the transaction body
+    /// 3. Build `TransactionSignaturePayload` with `SHA256(network_passphrase)` as networkId
+    /// 4. Serialize the payload to XDR, SHA-256 hash it
+    /// 5. Ed25519 sign the hash
+    /// 6. Return signature + public key (needed for DecoratedSignature hint)
+    fn sign_transaction(
+        &self,
+        private_key: &[u8],
+        tx_bytes: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        if tx_bytes.is_empty() {
+            return Err(SignerError::InvalidTransaction(
+                "transaction bytes must not be empty".into(),
+            ));
+        }
+
+        let signing_key = Self::signing_key(private_key)?;
+
+        // Parse the envelope to extract the transaction body
+        let envelope = TransactionEnvelope::from_xdr(tx_bytes, Limits::none())
+            .map_err(|e| SignerError::InvalidTransaction(format!("XDR parse failed: {e}")))?;
+
+        // Build the tagged transaction for the signature payload
+        let tagged_tx = match &envelope {
+            TransactionEnvelope::TxV0(v0) => {
+                TransactionSignaturePayloadTaggedTransaction::Tx(
+                    // V0 envelopes contain a TransactionV0; we need to
+                    // convert to a Transaction for the payload. However,
+                    // stellar-xdr doesn't provide a direct conversion.
+                    // For V0, we build the payload using the Tx variant
+                    // after converting the V0 inner transaction.
+                    //
+                    // Actually, stellar-xdr has TxV0 variant in the payload tagged transaction:
+                    // Let's check... No, the XDR spec says the signature payload uses
+                    // ENVELOPE_TYPE_TX or ENVELOPE_TYPE_TX_FEE_BUMP.
+                    // For V0 envelopes, we still use ENVELOPE_TYPE_TX with the tx body.
+                    // The stellar SDK converts V0 to V1 for signing purposes.
+                    // We'll handle this by reading the V0 tx fields directly.
+                    {
+                        // Convert V0 to a Transaction struct for signing.
+                        // V0 transactions have the source as an ed25519 key (32 bytes)
+                        // while V1 uses a MuxedAccount. The signing payload should
+                        // use the Transaction (V1) form.
+                        use stellar_xdr::curr::{MuxedAccount, Transaction, Uint256};
+                        Transaction {
+                            source_account: MuxedAccount::Ed25519(Uint256(
+                                v0.tx.source_account_ed25519.0,
+                            )),
+                            fee: v0.tx.fee,
+                            seq_num: v0.tx.seq_num.clone(),
+                            cond: match &v0.tx.time_bounds {
+                                Some(tb) => stellar_xdr::curr::Preconditions::Time(tb.clone()),
+                                None => stellar_xdr::curr::Preconditions::None,
+                            },
+                            memo: v0.tx.memo.clone(),
+                            operations: v0.tx.operations.clone(),
+                            ext: stellar_xdr::curr::TransactionExt::V0,
+                        }
+                    },
+                )
+            }
+            TransactionEnvelope::Tx(v1) => {
+                TransactionSignaturePayloadTaggedTransaction::Tx(v1.tx.clone())
+            }
+            TransactionEnvelope::TxFeeBump(fb) => {
+                TransactionSignaturePayloadTaggedTransaction::TxFeeBump(fb.tx.clone())
+            }
+        };
+
+        // Compute networkId = SHA256(passphrase)
+        let network_id: [u8; 32] = Sha256::digest(self.network_passphrase.as_bytes()).into();
+
+        let payload = TransactionSignaturePayload {
+            network_id: stellar_xdr::curr::Hash(network_id),
+            tagged_transaction: tagged_tx,
+        };
+
+        // Serialize payload to XDR, then SHA-256 hash it
+        let payload_xdr = payload
+            .to_xdr(Limits::none())
+            .map_err(|e| SignerError::SigningFailed(format!("XDR serialize failed: {e}")))?;
+        let hash: [u8; 32] = Sha256::digest(&payload_xdr).into();
+
+        // Ed25519 sign the hash
+        let signature = signing_key.sign(&hash);
+        let pubkey_bytes = signing_key.verifying_key().to_bytes().to_vec();
+
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: Some(pubkey_bytes),
+        })
+    }
+
+    /// Encode a signed Stellar transaction: append a DecoratedSignature to the envelope.
+    ///
+    /// The `SignOutput` must contain `public_key` (32 bytes) for the signature hint
+    /// (last 4 bytes of the public key).
+    fn encode_signed_transaction(
+        &self,
+        tx_bytes: &[u8],
+        signature: &SignOutput,
+    ) -> Result<Vec<u8>, SignerError> {
+        if signature.signature.len() != 64 {
+            return Err(SignerError::InvalidTransaction(
+                "expected 64-byte Ed25519 signature".into(),
+            ));
+        }
+
+        let pubkey_bytes = signature
+            .public_key
+            .as_ref()
+            .ok_or_else(|| {
+                SignerError::InvalidTransaction(
+                    "public_key required for Stellar DecoratedSignature hint".into(),
+                )
+            })?;
+
+        if pubkey_bytes.len() != 32 {
+            return Err(SignerError::InvalidTransaction(format!(
+                "expected 32-byte public key, got {}",
+                pubkey_bytes.len()
+            )));
+        }
+
+        let mut envelope = TransactionEnvelope::from_xdr(tx_bytes, Limits::none())
+            .map_err(|e| SignerError::InvalidTransaction(format!("XDR parse failed: {e}")))?;
+
+        // Build the DecoratedSignature: hint (last 4 bytes of pubkey) + 64-byte sig
+        let hint = SignatureHint([
+            pubkey_bytes[28],
+            pubkey_bytes[29],
+            pubkey_bytes[30],
+            pubkey_bytes[31],
+        ]);
+
+        let sig_bytes: [u8; 64] = signature.signature[..64]
+            .try_into()
+            .map_err(|_| SignerError::InvalidTransaction("signature must be 64 bytes".into()))?;
+
+        let decorated = DecoratedSignature {
+            hint,
+            signature: Signature(sig_bytes.try_into().map_err(|_| {
+                SignerError::InvalidTransaction("failed to create Signature".into())
+            })?),
+        };
+
+        // Append to the envelope's signatures array.
+        // VecM doesn't support push directly; convert to Vec, push, convert back.
+        fn append_sig(
+            sigs: &stellar_xdr::curr::VecM<DecoratedSignature, 20>,
+            sig: DecoratedSignature,
+        ) -> Result<stellar_xdr::curr::VecM<DecoratedSignature, 20>, SignerError> {
+            let mut v = sigs.to_vec();
+            v.push(sig);
+            v.try_into().map_err(|_| {
+                SignerError::InvalidTransaction("too many signatures (max 20)".into())
+            })
+        }
+
+        match &mut envelope {
+            TransactionEnvelope::TxV0(ref mut v0) => {
+                v0.signatures = append_sig(&v0.signatures, decorated)?;
+            }
+            TransactionEnvelope::Tx(ref mut v1) => {
+                v1.signatures = append_sig(&v1.signatures, decorated)?;
+            }
+            TransactionEnvelope::TxFeeBump(ref mut fb) => {
+                fb.signatures = append_sig(&fb.signatures, decorated)?;
+            }
+        }
+
+        // Re-serialize to XDR
+        envelope
+            .to_xdr(Limits::none())
+            .map_err(|e| SignerError::InvalidTransaction(format!("XDR serialize failed: {e}")))
+    }
+
+    /// Sign a message using SEP-53: `SHA256("Stellar Signed Message:\n" + message)`.
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+
+        // SEP-53 payload: prefix + message
+        let mut payload = Vec::with_capacity(24 + message.len());
+        payload.extend_from_slice(b"Stellar Signed Message:\n");
+        payload.extend_from_slice(message);
+
+        let hash: [u8; 32] = Sha256::digest(&payload).into();
+        let signature = signing_key.sign(&hash);
+        let pubkey_bytes = signing_key.verifying_key().to_bytes().to_vec();
+
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: Some(pubkey_bytes),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hd::HdDeriver;
+    use crate::mnemonic::Mnemonic;
+    use ed25519_dalek::Verifier;
+
+    const ABANDON_PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn test_privkey() -> Vec<u8> {
+        let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
+        let signer = StellarSigner::pubnet();
+        let path = signer.default_derivation_path(0);
+        HdDeriver::derive_from_mnemonic(&mnemonic, "", &path, Curve::Ed25519)
+            .unwrap()
+            .expose()
+            .to_vec()
+    }
+
+    #[test]
+    fn test_chain_properties() {
+        let signer = StellarSigner::pubnet();
+        assert_eq!(signer.chain_type(), ChainType::Stellar);
+        assert_eq!(signer.curve(), Curve::Ed25519);
+        assert_eq!(signer.coin_type(), 148);
+    }
+
+    #[test]
+    fn test_derivation_path() {
+        let signer = StellarSigner::pubnet();
+        assert_eq!(signer.default_derivation_path(0), "m/44'/148'/0'");
+        assert_eq!(signer.default_derivation_path(1), "m/44'/148'/1'");
+        assert_eq!(signer.default_derivation_path(5), "m/44'/148'/5'");
+    }
+
+    #[test]
+    fn test_derive_address_format() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::pubnet();
+        let address = signer.derive_address(&privkey).unwrap();
+
+        assert!(
+            address.starts_with('G'),
+            "Stellar address must start with 'G', got: {}",
+            address
+        );
+        assert_eq!(
+            address.len(),
+            56,
+            "Stellar address must be 56 chars, got: {}",
+            address.len()
+        );
+        // Second character must be A, B, C, or D
+        let second = address.chars().nth(1).unwrap();
+        assert!(
+            "ABCD".contains(second),
+            "Second char must be A/B/C/D, got: {}",
+            second
+        );
+    }
+
+    /// SEP-0005 known vector: "abandon..." mnemonic at m/44'/148'/0'
+    /// produces address GB3JDWCQJCWMJ3IILWIGDTQJJC5567PGVEVXSCVPEQOTDN64VJBDQBYX
+    #[test]
+    fn test_derive_address_known_vector_sep0005() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::pubnet();
+        let address = signer.derive_address(&privkey).unwrap();
+        assert_eq!(
+            address, "GB3JDWCQJCWMJ3IILWIGDTQJJC5567PGVEVXSCVPEQOTDN64VJBDQBYX"
+        );
+    }
+
+    #[test]
+    fn test_derive_address_deterministic() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::pubnet();
+        let addr1 = signer.derive_address(&privkey).unwrap();
+        let addr2 = signer.derive_address(&privkey).unwrap();
+        assert_eq!(addr1, addr2);
+    }
+
+    #[test]
+    fn test_derive_address_invalid_key() {
+        let signer = StellarSigner::pubnet();
+        assert!(signer.derive_address(&[0u8; 16]).is_err());
+        assert!(signer.derive_address(&[]).is_err());
+    }
+
+    #[test]
+    fn test_sign_verify_roundtrip() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::pubnet();
+
+        let message = b"test message for stellar";
+        let result = signer.sign(&privkey, message).unwrap();
+        assert_eq!(result.signature.len(), 64);
+        assert!(result.recovery_id.is_none());
+
+        // Verify
+        let signing_key = SigningKey::from_bytes(&privkey.try_into().unwrap());
+        let verifying_key = signing_key.verifying_key();
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        verifying_key.verify(message, &sig).expect("should verify");
+    }
+
+    #[test]
+    fn test_deterministic_signature() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::pubnet();
+        let message = b"hello";
+
+        let sig1 = signer.sign(&privkey, message).unwrap();
+        let sig2 = signer.sign(&privkey, message).unwrap();
+        assert_eq!(sig1.signature, sig2.signature);
+    }
+
+    #[test]
+    fn test_extract_signable_bytes_passthrough() {
+        let signer = StellarSigner::pubnet();
+        let data = b"some envelope bytes";
+        let result = signer.extract_signable_bytes(data).unwrap();
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn test_sign_transaction_empty_input_errors() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        assert!(signer.sign_transaction(&privkey, b"").is_err());
+    }
+
+    #[test]
+    fn test_sign_transaction_invalid_xdr_errors() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        assert!(signer.sign_transaction(&privkey, b"not valid xdr").is_err());
+    }
+
+    #[test]
+    fn test_sign_transaction_invalid_privkey() {
+        let signer = StellarSigner::testnet();
+        // Need valid XDR for this test — we'll just verify invalid key is caught
+        assert!(signer.sign_transaction(&[], b"some bytes").is_err());
+        assert!(signer.sign_transaction(&[0u8; 16], b"some bytes").is_err());
+    }
+
+    /// Build a minimal valid V1 TransactionEnvelope XDR for testing.
+    // NOTE: duplicated in crates/ows-lib/src/ops.rs (mnemonic_wallet_sign_tx_all_chains) — keep in sync
+    fn build_test_envelope() -> Vec<u8> {
+        use stellar_xdr::curr::*;
+
+        let tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([0xAA; 32])),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::Inflation,
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let envelope = TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        });
+
+        envelope.to_xdr(Limits::none()).unwrap()
+    }
+
+    #[test]
+    fn test_sign_transaction_produces_64_byte_sig() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let envelope_xdr = build_test_envelope();
+
+        let result = signer.sign_transaction(&privkey, &envelope_xdr).unwrap();
+        assert_eq!(result.signature.len(), 64);
+        assert!(result.recovery_id.is_none());
+        assert!(result.public_key.is_some());
+        assert_eq!(result.public_key.as_ref().unwrap().len(), 32);
+    }
+
+    #[test]
+    fn test_sign_transaction_deterministic() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let envelope_xdr = build_test_envelope();
+
+        let sig1 = signer.sign_transaction(&privkey, &envelope_xdr).unwrap();
+        let sig2 = signer.sign_transaction(&privkey, &envelope_xdr).unwrap();
+        assert_eq!(sig1.signature, sig2.signature);
+    }
+
+    #[test]
+    fn test_sign_transaction_equivalence() {
+        // Verify that sign_transaction produces the same result as manually building
+        // the TransactionSignaturePayload, SHA-256 hashing, and ed25519 signing.
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let envelope_xdr = build_test_envelope();
+
+        let result = signer.sign_transaction(&privkey, &envelope_xdr).unwrap();
+
+        // Manually compute the expected signature
+        let envelope =
+            TransactionEnvelope::from_xdr(&envelope_xdr, Limits::none()).unwrap();
+        let tagged_tx = match &envelope {
+            TransactionEnvelope::Tx(v1) => {
+                TransactionSignaturePayloadTaggedTransaction::Tx(v1.tx.clone())
+            }
+            _ => panic!("expected V1 envelope"),
+        };
+
+        let network_id: [u8; 32] =
+            Sha256::digest(STELLAR_PASSPHRASE_TESTNET.as_bytes()).into();
+        let payload = TransactionSignaturePayload {
+            network_id: stellar_xdr::curr::Hash(network_id),
+            tagged_transaction: tagged_tx,
+        };
+        let payload_xdr = payload.to_xdr(Limits::none()).unwrap();
+        let hash: [u8; 32] = Sha256::digest(&payload_xdr).into();
+
+        let signing_key = SigningKey::from_bytes(&privkey.try_into().unwrap());
+        let expected_sig = signing_key.sign(&hash);
+
+        assert_eq!(
+            result.signature,
+            expected_sig.to_bytes().to_vec(),
+            "sign_transaction must match manual TransactionSignaturePayload signing"
+        );
+    }
+
+    #[test]
+    fn test_encode_signed_transaction_roundtrip() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let envelope_xdr = build_test_envelope();
+
+        let sign_output = signer.sign_transaction(&privkey, &envelope_xdr).unwrap();
+        let signed = signer
+            .encode_signed_transaction(&envelope_xdr, &sign_output)
+            .unwrap();
+
+        // Deserialize and verify
+        let signed_envelope =
+            TransactionEnvelope::from_xdr(&signed, Limits::none()).unwrap();
+        match signed_envelope {
+            TransactionEnvelope::Tx(v1) => {
+                assert_eq!(v1.signatures.len(), 1);
+                let dec_sig = &v1.signatures[0];
+                // Hint = last 4 bytes of pubkey
+                let pubkey = sign_output.public_key.as_ref().unwrap();
+                assert_eq!(dec_sig.hint.0, pubkey[28..32]);
+                assert_eq!(dec_sig.signature.0.as_slice(), &sign_output.signature[..]);
+            }
+            _ => panic!("expected V1 envelope"),
+        }
+    }
+
+    #[test]
+    fn test_encode_signed_transaction_multi_sig() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let envelope_xdr = build_test_envelope();
+
+        // First signature
+        let sig1 = signer.sign_transaction(&privkey, &envelope_xdr).unwrap();
+        let once_signed = signer
+            .encode_signed_transaction(&envelope_xdr, &sig1)
+            .unwrap();
+
+        // Second signature (same key, but tests multi-sig append)
+        let sig2 = signer.sign_transaction(&privkey, &envelope_xdr).unwrap();
+        let twice_signed = signer
+            .encode_signed_transaction(&once_signed, &sig2)
+            .unwrap();
+
+        let env = TransactionEnvelope::from_xdr(&twice_signed, Limits::none()).unwrap();
+        match env {
+            TransactionEnvelope::Tx(v1) => {
+                assert_eq!(v1.signatures.len(), 2, "should have 2 signatures");
+            }
+            _ => panic!("expected V1 envelope"),
+        }
+    }
+
+    #[test]
+    fn test_encode_signed_transaction_missing_pubkey_errors() {
+        let signer = StellarSigner::testnet();
+        let envelope_xdr = build_test_envelope();
+
+        let bad_output = SignOutput {
+            signature: vec![0u8; 64],
+            recovery_id: None,
+            public_key: None,
+        };
+        assert!(signer
+            .encode_signed_transaction(&envelope_xdr, &bad_output)
+            .is_err());
+    }
+
+    #[test]
+    fn test_full_pipeline() {
+        // extract → sign → encode → verify
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let envelope_xdr = build_test_envelope();
+
+        let signable = signer.extract_signable_bytes(&envelope_xdr).unwrap();
+        assert_eq!(signable, &envelope_xdr[..]); // passthrough
+
+        let output = signer.sign_transaction(&privkey, signable).unwrap();
+        let signed = signer
+            .encode_signed_transaction(&envelope_xdr, &output)
+            .unwrap();
+
+        // Verify signed envelope is valid XDR with 1 signature
+        let env = TransactionEnvelope::from_xdr(&signed, Limits::none()).unwrap();
+        match env {
+            TransactionEnvelope::Tx(v1) => assert_eq!(v1.signatures.len(), 1),
+            _ => panic!("expected V1 envelope"),
+        }
+    }
+
+    /// SEP-53 message signing test vector.
+    /// Seed: SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW
+    /// Address: GBXFXNDLV4LSWA4VB7YIL5GBD7BVNR22SGBTDKMO2SBZZHDXSKZYCP7L
+    /// Message: "Hello, World!"
+    /// Signature (base64): fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==
+    #[test]
+    fn test_sign_message_sep53_test_vector() {
+        // Decode the secret key from Stellar secret format (SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW)
+        let secret_strkey =
+            stellar_strkey::ed25519::PrivateKey::from_string(
+                "SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW",
+            )
+            .unwrap();
+        let privkey = secret_strkey.0;
+
+        let signer = StellarSigner::pubnet();
+        let result = signer.sign_message(&privkey, b"Hello, World!").unwrap();
+
+        // Verify signature matches the test vector
+        use base64::Engine;
+        let expected_sig = base64::engine::general_purpose::STANDARD
+            .decode("fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==")
+            .unwrap();
+
+        assert_eq!(
+            result.signature, expected_sig,
+            "SEP-53 signature must match test vector"
+        );
+
+        // Verify the public key matches the expected address
+        assert!(result.public_key.is_some());
+        let pubkey = result.public_key.unwrap();
+        let strkey = stellar_strkey::ed25519::PublicKey(pubkey.try_into().unwrap());
+        assert_eq!(
+            strkey.to_string(),
+            "GBXFXNDLV4LSWA4VB7YIL5GBD7BVNR22SGBTDKMO2SBZZHDXSKZYCP7L"
+        );
+    }
+
+    #[test]
+    fn test_sign_message_sep53_prefix() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::pubnet();
+        let message = b"test";
+
+        let result = signer.sign_message(&privkey, message).unwrap();
+        assert_eq!(result.signature.len(), 64);
+        assert!(result.public_key.is_some());
+
+        // Verify that the signature is over SHA256("Stellar Signed Message:\n" + message)
+        let mut payload = Vec::new();
+        payload.extend_from_slice(b"Stellar Signed Message:\n");
+        payload.extend_from_slice(message);
+        let hash: [u8; 32] = Sha256::digest(&payload).into();
+
+        let signing_key = SigningKey::from_bytes(&privkey.try_into().unwrap());
+        let verifying_key = signing_key.verifying_key();
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        verifying_key
+            .verify(&hash, &sig)
+            .expect("SEP-53 signature should verify against SHA256(prefix + message)");
+    }
+
+    #[test]
+    fn test_sign_message_invalid_key() {
+        let signer = StellarSigner::pubnet();
+        assert!(signer.sign_message(&[], b"hello").is_err());
+        assert!(signer.sign_message(&[0u8; 16], b"hello").is_err());
+    }
+
+    #[test]
+    fn test_hd_derivation_integration() {
+        let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
+        let signer = StellarSigner::pubnet();
+        let path = signer.default_derivation_path(0);
+        let key = HdDeriver::derive_from_mnemonic(&mnemonic, "", &path, Curve::Ed25519).unwrap();
+        let address = signer.derive_address(key.expose()).unwrap();
+
+        assert!(address.starts_with('G'));
+        assert_eq!(address.len(), 56);
+        // Known SEP-0005 vector
+        assert_eq!(address, "GB3JDWCQJCWMJ3IILWIGDTQJJC5567PGVEVXSCVPEQOTDN64VJBDQBYX");
+    }
+
+    /// Build a minimal valid V0 TransactionEnvelope XDR for testing the V0→V1 conversion path.
+    fn build_test_v0_envelope() -> Vec<u8> {
+        use stellar_xdr::curr::*;
+
+        let tx = TransactionV0 {
+            source_account_ed25519: Uint256([0xBB; 32]),
+            fee: 200,
+            seq_num: SequenceNumber(42),
+            time_bounds: Some(TimeBounds {
+                min_time: TimePoint(0),
+                max_time: TimePoint(1_700_000_000),
+            }),
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::Inflation,
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionV0Ext::V0,
+        };
+
+        let envelope = TransactionEnvelope::TxV0(TransactionV0Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        });
+
+        envelope.to_xdr(Limits::none()).unwrap()
+    }
+
+    #[test]
+    fn test_sign_transaction_v0_envelope() {
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let envelope_xdr = build_test_v0_envelope();
+
+        // sign_transaction should succeed on a V0 envelope
+        let result = signer.sign_transaction(&privkey, &envelope_xdr).unwrap();
+
+        // Output signature must be 64 bytes
+        assert_eq!(result.signature.len(), 64, "V0 signature should be 64 bytes");
+        assert!(result.public_key.is_some(), "V0 signing should return public key");
+
+        // Verify the signature against the manually-built V1-equivalent payload
+        let v0_env = match TransactionEnvelope::from_xdr(&envelope_xdr, Limits::none()).unwrap() {
+            TransactionEnvelope::TxV0(v0) => v0,
+            _ => panic!("expected V0 envelope"),
+        };
+
+        // Reconstruct the V1-equivalent Transaction (same logic as sign_transaction)
+        use stellar_xdr::curr::{MuxedAccount, Transaction, Uint256};
+        let v1_tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256(
+                v0_env.tx.source_account_ed25519.0,
+            )),
+            fee: v0_env.tx.fee,
+            seq_num: v0_env.tx.seq_num.clone(),
+            cond: match &v0_env.tx.time_bounds {
+                Some(tb) => stellar_xdr::curr::Preconditions::Time(tb.clone()),
+                None => stellar_xdr::curr::Preconditions::None,
+            },
+            memo: v0_env.tx.memo.clone(),
+            operations: v0_env.tx.operations.clone(),
+            ext: stellar_xdr::curr::TransactionExt::V0,
+        };
+
+        let tagged_tx = TransactionSignaturePayloadTaggedTransaction::Tx(v1_tx);
+        let network_id: [u8; 32] =
+            Sha256::digest(STELLAR_PASSPHRASE_TESTNET.as_bytes()).into();
+        let payload = TransactionSignaturePayload {
+            network_id: stellar_xdr::curr::Hash(network_id),
+            tagged_transaction: tagged_tx,
+        };
+        let payload_xdr = payload.to_xdr(Limits::none()).unwrap();
+        let hash: [u8; 32] = Sha256::digest(&payload_xdr).into();
+
+        // Verify the Ed25519 signature
+        let signing_key = SigningKey::from_bytes(&privkey.try_into().unwrap());
+        let verifying_key = signing_key.verifying_key();
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        verifying_key
+            .verify(&hash, &sig)
+            .expect("V0 envelope signature should verify against V1-equivalent payload");
+    }
+
+    #[test]
+    fn test_sign_transaction_v0_envelope_no_timebounds() {
+        // Test V0 envelope with time_bounds = None to exercise the None → Preconditions::None path
+        use stellar_xdr::curr::*;
+
+        let tx = TransactionV0 {
+            source_account_ed25519: Uint256([0xCC; 32]),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            time_bounds: None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::Inflation,
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionV0Ext::V0,
+        };
+
+        let envelope = TransactionEnvelope::TxV0(TransactionV0Envelope {
+            tx,
+            signatures: vec![].try_into().unwrap(),
+        });
+        let envelope_xdr = envelope.to_xdr(Limits::none()).unwrap();
+
+        let privkey = test_privkey();
+        let signer = StellarSigner::testnet();
+        let result = signer.sign_transaction(&privkey, &envelope_xdr).unwrap();
+        assert_eq!(result.signature.len(), 64, "V0 no-timebounds signature should be 64 bytes");
+
+        // Verify signature against manually-built payload with Preconditions::None
+        let v1_tx = Transaction {
+            source_account: MuxedAccount::Ed25519(Uint256([0xCC; 32])),
+            fee: 100,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: vec![Operation {
+                source_account: None,
+                body: OperationBody::Inflation,
+            }]
+            .try_into()
+            .unwrap(),
+            ext: TransactionExt::V0,
+        };
+
+        let tagged_tx = TransactionSignaturePayloadTaggedTransaction::Tx(v1_tx);
+        let network_id: [u8; 32] =
+            Sha256::digest(STELLAR_PASSPHRASE_TESTNET.as_bytes()).into();
+        let payload = TransactionSignaturePayload {
+            network_id: stellar_xdr::curr::Hash(network_id),
+            tagged_transaction: tagged_tx,
+        };
+        let payload_xdr = payload.to_xdr(Limits::none()).unwrap();
+        let hash: [u8; 32] = Sha256::digest(&payload_xdr).into();
+
+        let signing_key = SigningKey::from_bytes(&privkey.try_into().unwrap());
+        let verifying_key = signing_key.verifying_key();
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        verifying_key
+            .verify(&hash, &sig)
+            .expect("V0 no-timebounds signature should verify with Preconditions::None");
+    }
+
+    #[test]
+    fn test_network_passphrase_selection() {
+        let pubnet = StellarSigner::pubnet();
+        assert_eq!(pubnet.network_passphrase, STELLAR_PASSPHRASE_PUBNET);
+
+        let testnet = StellarSigner::testnet();
+        assert_eq!(testnet.network_passphrase, STELLAR_PASSPHRASE_TESTNET);
+
+        let futurenet = StellarSigner::futurenet();
+        assert_eq!(futurenet.network_passphrase, STELLAR_PASSPHRASE_FUTURENET);
+    }
+}

--- a/ows/crates/ows-signer/src/lib.rs
+++ b/ows/crates/ows-signer/src/lib.rs
@@ -7,6 +7,7 @@ pub mod key_cache;
 pub mod mnemonic;
 pub mod process_hardening;
 pub mod rlp;
+pub mod soroban_auth;
 pub mod traits;
 pub mod zeroizing;
 

--- a/ows/crates/ows-signer/src/lib.rs
+++ b/ows/crates/ows-signer/src/lib.rs
@@ -11,6 +11,7 @@ pub mod traits;
 pub mod zeroizing;
 
 pub use chains::signer_for_chain;
+pub use chains::signer_for_chain_type;
 pub use crypto::{
     decrypt, encrypt, encrypt_with_hkdf, CipherParams, CryptoEnvelope, CryptoError, HkdfKdfParams,
     KdfParams, KdfParamsVariant,
@@ -41,7 +42,7 @@ mod integration_tests {
     const ABANDON_PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     fn derive_address_for_chain(mnemonic: &Mnemonic, chain: ChainType) -> String {
-        let signer = signer_for_chain(chain);
+        let signer = signer_for_chain(&ows_core::default_chain_for_type(chain));
         let curve = signer.curve();
         let path = signer.default_derivation_path(0);
 
@@ -129,6 +130,23 @@ mod integration_tests {
     }
 
     #[test]
+    fn test_full_pipeline_stellar() {
+        let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
+        let address = derive_address_for_chain(&mnemonic, ChainType::Stellar);
+        assert!(
+            address.starts_with('G'),
+            "Stellar address must start with 'G', got: {}",
+            address
+        );
+        assert_eq!(
+            address.len(),
+            56,
+            "Stellar address must be 56 chars, got: {}",
+            address.len()
+        );
+    }
+
+    #[test]
     fn test_full_pipeline_filecoin() {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
         let address = derive_address_for_chain(&mnemonic, ChainType::Filecoin);
@@ -142,8 +160,8 @@ mod integration_tests {
     #[test]
     fn test_spark_uses_bitcoin_derivation_path() {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
-        let btc_signer = signer_for_chain(ChainType::Bitcoin);
-        let spark_signer = signer_for_chain(ChainType::Spark);
+        let btc_signer = signer_for_chain(&ows_core::default_chain_for_type(ChainType::Bitcoin));
+        let spark_signer = signer_for_chain(&ows_core::default_chain_for_type(ChainType::Spark));
 
         // Same derivation path
         assert_eq!(
@@ -182,6 +200,7 @@ mod integration_tests {
         let spark_addr = derive_address_for_chain(&mnemonic, ChainType::Spark);
         let fil_addr = derive_address_for_chain(&mnemonic, ChainType::Filecoin);
         let xrpl_addr = derive_address_for_chain(&mnemonic, ChainType::Xrpl);
+        let stellar_addr = derive_address_for_chain(&mnemonic, ChainType::Stellar);
 
         // All addresses should be different
         let addrs = [
@@ -194,6 +213,7 @@ mod integration_tests {
             &spark_addr,
             &fil_addr,
             &xrpl_addr,
+            &stellar_addr,
         ];
         for i in 0..addrs.len() {
             for j in (i + 1)..addrs.len() {
@@ -222,7 +242,7 @@ mod integration_tests {
             ChainType::Spark,
             ChainType::Filecoin,
         ] {
-            let signer = signer_for_chain(chain);
+            let signer = signer_for_chain(&ows_core::default_chain_for_type(chain));
             let path = signer.default_derivation_path(0);
             let key =
                 HdDeriver::derive_from_mnemonic(&mnemonic, "", &path, Curve::Secp256k1).unwrap();
@@ -239,8 +259,8 @@ mod integration_tests {
     fn test_sign_roundtrip_ed25519_chains() {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
 
-        for chain in [ChainType::Solana, ChainType::Ton] {
-            let signer = signer_for_chain(chain);
+        for chain in [ChainType::Solana, ChainType::Ton, ChainType::Stellar] {
+            let signer = signer_for_chain(&ows_core::default_chain_for_type(chain));
             let path = signer.default_derivation_path(0);
             let key =
                 HdDeriver::derive_from_mnemonic(&mnemonic, "", &path, Curve::Ed25519).unwrap();
@@ -264,8 +284,30 @@ mod integration_tests {
             ChainType::Spark,
             ChainType::Filecoin,
             ChainType::Xrpl,
+            ChainType::Stellar,
         ] {
-            let signer = signer_for_chain(chain);
+            let signer = signer_for_chain(&ows_core::default_chain_for_type(chain));
+            assert_eq!(signer.chain_type(), chain);
+        }
+    }
+
+    #[test]
+    fn test_signer_for_chain_type_backward_compat() {
+        // signer_for_chain_type is the backward-compatible wrapper that accepts
+        // ChainType directly (defaulting to mainnet), matching the old API shape.
+        for chain in [
+            ChainType::Evm,
+            ChainType::Solana,
+            ChainType::Bitcoin,
+            ChainType::Cosmos,
+            ChainType::Tron,
+            ChainType::Ton,
+            ChainType::Spark,
+            ChainType::Filecoin,
+            ChainType::Xrpl,
+            ChainType::Stellar,
+        ] {
+            let signer = signer_for_chain_type(chain);
             assert_eq!(signer.chain_type(), chain);
         }
     }

--- a/ows/crates/ows-signer/src/soroban_auth.rs
+++ b/ows/crates/ows-signer/src/soroban_auth.rs
@@ -1,0 +1,146 @@
+//! Shared helpers for Soroban authorization entry signing.
+//!
+//! These functions encapsulate the Soroban-specific data transformations that
+//! are needed by any code path that signs `SorobanAuthorizationEntry` values —
+//! whether the signing key is a raw `&[u8]` (as in `sign_inner_authorizations`)
+//! or abstracted behind a trait (as in the x402 payment flow).
+//!
+//! The caller is responsible for the actual Ed25519 signing step; these helpers
+//! handle everything around it: building the preimage and formatting the result.
+
+use crate::traits::SignerError;
+use sha2::{Digest, Sha256};
+use stellar_xdr::curr::{
+    Hash, HashIdPreimage, HashIdPreimageSorobanAuthorization, Limits, ScMapEntry, ScVal,
+    SorobanAuthorizedInvocation, WriteXdr,
+};
+
+/// Build the `HashIdPreimage::SorobanAuthorization` XDR bytes for a Soroban
+/// auth entry.
+///
+/// Returns the raw XDR bytes of the preimage. The caller hashes these with
+/// SHA-256 and signs the hash with Ed25519. Different callers may use different
+/// signing mechanisms (raw private key, WalletAccess trait, HSM, etc.).
+pub fn build_auth_preimage_xdr(
+    network_passphrase: &str,
+    nonce: i64,
+    signature_expiration_ledger: u32,
+    invocation: &SorobanAuthorizedInvocation,
+) -> Result<Vec<u8>, SignerError> {
+    let network_id = Hash(Sha256::digest(network_passphrase.as_bytes()).into());
+
+    let preimage = HashIdPreimage::SorobanAuthorization(HashIdPreimageSorobanAuthorization {
+        network_id,
+        nonce,
+        signature_expiration_ledger,
+        invocation: invocation.clone(),
+    });
+
+    preimage
+        .to_xdr(Limits::none())
+        .map_err(|e| SignerError::SigningFailed(format!("failed to serialize auth preimage: {e}")))
+}
+
+/// Format an Ed25519 public key and signature into the `ScVal` structure that
+/// Soroban's `__check_auth` expects.
+///
+/// Returns `ScVal::Vec([ScVal::Map({public_key: Bytes, signature: Bytes})])`,
+/// ready to assign to `SorobanAddressCredentials.signature`.
+pub fn format_auth_signature(
+    public_key: &[u8],
+    signature: &[u8],
+) -> Result<ScVal, SignerError> {
+    let pubkey_sc = ScVal::Bytes(
+        public_key
+            .to_vec()
+            .try_into()
+            .map_err(|_| SignerError::SigningFailed("failed to create ScBytes for public_key".into()))?,
+    );
+    let sig_sc = ScVal::Bytes(
+        signature
+            .to_vec()
+            .try_into()
+            .map_err(|_| SignerError::SigningFailed("failed to create ScBytes for signature".into()))?,
+    );
+
+    let sig_map = ScVal::Map(Some(
+        vec![
+            ScMapEntry {
+                key: ScVal::Symbol(
+                    "public_key"
+                        .try_into()
+                        .map_err(|_| SignerError::SigningFailed("failed to create ScSymbol".into()))?,
+                ),
+                val: pubkey_sc,
+            },
+            ScMapEntry {
+                key: ScVal::Symbol(
+                    "signature"
+                        .try_into()
+                        .map_err(|_| SignerError::SigningFailed("failed to create ScSymbol".into()))?,
+                ),
+                val: sig_sc,
+            },
+        ]
+        .try_into()
+        .map_err(|_| SignerError::SigningFailed("failed to create ScMap".into()))?,
+    ));
+
+    Ok(ScVal::Vec(Some(
+        vec![sig_map]
+            .try_into()
+            .map_err(|_| SignerError::SigningFailed("failed to create signature ScVec".into()))?,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stellar_xdr::curr::{
+        InvokeContractArgs, ScAddress, ScSymbol, SorobanAuthorizedInvocation,
+        SorobanAuthorizedFunction,
+    };
+
+    #[test]
+    fn test_build_auth_preimage_xdr_deterministic() {
+        let invocation = SorobanAuthorizedInvocation {
+            function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                contract_address: ScAddress::Contract(stellar_xdr::curr::ContractId(Hash([0u8; 32]))),
+                function_name: ScSymbol("transfer".try_into().unwrap()),
+                args: vec![].try_into().unwrap(),
+            }),
+            sub_invocations: vec![].try_into().unwrap(),
+        };
+
+        let xdr1 = build_auth_preimage_xdr("Test SDF Network ; September 2015", 42, 1000, &invocation).unwrap();
+        let xdr2 = build_auth_preimage_xdr("Test SDF Network ; September 2015", 42, 1000, &invocation).unwrap();
+        assert_eq!(xdr1, xdr2);
+        assert!(!xdr1.is_empty());
+    }
+
+    #[test]
+    fn test_format_auth_signature_structure() {
+        let pubkey = [1u8; 32];
+        let signature = [2u8; 64];
+
+        let result = format_auth_signature(&pubkey, &signature).unwrap();
+
+        // Should be ScVal::Vec containing one ScVal::Map
+        match result {
+            ScVal::Vec(Some(vec)) => {
+                assert_eq!(vec.len(), 1);
+                match &vec[0] {
+                    ScVal::Map(Some(map)) => {
+                        assert_eq!(map.len(), 2);
+                        // First entry: public_key
+                        assert_eq!(map[0].key, ScVal::Symbol("public_key".try_into().unwrap()));
+                        // Second entry: signature
+                        assert_eq!(map[1].key, ScVal::Symbol("signature".try_into().unwrap()));
+                    }
+                    _ => panic!("expected Map"),
+                }
+            }
+            _ => panic!("expected Vec"),
+        }
+    }
+}

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -77,6 +77,25 @@ pub trait ChainSigner: Send + Sync {
         )))
     }
 
+    /// Sign inner authorization entries within a transaction envelope.
+    ///
+    /// Some chains require signing authorization data embedded inside the
+    /// transaction (e.g. Soroban auth entries on Stellar, ERC-4337 UserOps
+    /// on EVM). This method inspects the transaction, signs any inner
+    /// authorizations that belong to the given private key, and returns the
+    /// modified transaction bytes.
+    ///
+    /// The default implementation returns the input unchanged — chains must
+    /// opt in by overriding this method.
+    fn sign_inner_authorizations(
+        &self,
+        private_key: &[u8],
+        tx_bytes: &[u8],
+    ) -> Result<Vec<u8>, SignerError> {
+        let _ = (private_key,);
+        Ok(tx_bytes.to_vec())
+    }
+
     /// Returns the default BIP-44 derivation path template for this chain.
     fn default_derivation_path(&self, index: u32) -> String;
 }

--- a/readme/partials/supported-chains.md
+++ b/readme/partials/supported-chains.md
@@ -10,5 +10,6 @@
 | TON | Ed25519 | raw/bounceable | `m/44'/607'/0'` |
 | Sui | Ed25519 | 0x + BLAKE2b-256 hex | `m/44'/784'/0'/0'/0'` |
 | XRPL | secp256k1 | Base58Check (`r...`) | `m/44'/144'/0'/0/0` |
+| Stellar | Ed25519 | Base32 Strkey (G...) | `m/44'/148'/0'` |
 | Spark (Bitcoin L2) | secp256k1 | spark: prefixed | `m/84'/0'/0'/0/0` |
 | Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |

--- a/readme/partials/why-ows.md
+++ b/readme/partials/why-ows.md
@@ -1,6 +1,6 @@
 ## Why OWS
 
 - **Local key custody.** Private keys stay encrypted at rest and are decrypted only inside the OWS signing path after the relevant checks pass. Current implementations harden in-process memory handling and wipe key material after use.
-- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
+- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Stellar, Spark, Filecoin — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
 - **Policy before signing.** A pre-signing policy engine gates agent (API key) operations before decryption — chain allowlists, expiry, and optional custom executables.
 - **Built for agents.** Native SDK and CLI today. A wallet created by one tool works in every other.

--- a/skills/ows/SKILL.md
+++ b/skills/ows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ows
-description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin via CLI, Node.js, or Python.
+description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Stellar, Spark, and Filecoin via CLI, Node.js, or Python.
 version: 1.2.4
 metadata:
   openclaw:
@@ -33,7 +33,7 @@ Use this skill when the user asks to:
 
 - Create, import, list, delete, or manage crypto wallets
 - Derive blockchain addresses from a mnemonic
-- Sign messages or transactions for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, or Filecoin
+- Sign messages or transactions for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Stellar, Spark, or Filecoin
 - Broadcast signed transactions to a chain
 - Generate BIP-39 mnemonic phrases
 - Fund a wallet with USDC (MoonPay) or check token balances
@@ -53,6 +53,7 @@ Use this skill when the user asks to:
 | Tron | `tron` | secp256k1 | base58check |
 | TON | `ton` | Ed25519 | raw/bounceable |
 | Sui | `sui` | Ed25519 | 0x + BLAKE2b-256 hex |
+| Stellar | `stellar` | Ed25519 | Base32 Strkey (`G...`) |
 | Spark (Bitcoin L2) | `spark` | secp256k1 | spark: prefixed |
 | XRPL | `xrpl` | secp256k1 | Base58Check (`r...`) |
 | Filecoin | `filecoin` | secp256k1 | f1 secp256k1 |
@@ -108,6 +109,7 @@ The `--wallet` flag can also be set via `OWS_WALLET` env var. Use `--json` for s
 # Sign a message
 ows sign message --wallet "my-wallet" --chain evm --message "hello world"
 ows sign message --wallet "my-wallet" --chain solana --message "hello" --json
+ows sign message --wallet "my-wallet" --chain stellar --message "hello"
 
 # Sign a message with EIP-712 typed data (EVM only)
 ows sign message --wallet "my-wallet" --chain evm --message "" --typed-data '{"types":...}'

--- a/skills/ows/references/node.md
+++ b/skills/ows/references/node.md
@@ -44,7 +44,7 @@ interface ApiKeyResult {
 import { generateMnemonic, deriveAddress } from "@open-wallet-standard/core";
 
 const phrase = generateMnemonic(12);       // or 24
-const addr = deriveAddress(phrase, "evm"); // any chain: evm, solana, sui, bitcoin, cosmos, tron, ton, spark, filecoin
+const addr = deriveAddress(phrase, "evm"); // any chain: evm, solana, sui, bitcoin, cosmos, tron, ton, stellar, spark, filecoin
 ```
 
 ## Wallet Management

--- a/skills/ows/references/python.md
+++ b/skills/ows/references/python.md
@@ -38,7 +38,7 @@ All functions return Python dicts:
 from open_wallet_standard import generate_mnemonic, derive_address
 
 phrase = generate_mnemonic(12)         # or 24
-addr = derive_address(phrase, "evm")   # any chain: evm, solana, sui, bitcoin, cosmos, tron, ton, spark, filecoin
+addr = derive_address(phrase, "evm")   # any chain: evm, solana, sui, bitcoin, cosmos, tron, ton, stellar, spark, filecoin
 # derive_address(mnemonic, chain, index=None)
 ```
 

--- a/website-docs/md/02-signing-interface.md
+++ b/website-docs/md/02-signing-interface.md
@@ -79,6 +79,7 @@ Message signing follows chain-specific conventions:
 - **Solana**: Ed25519 signature over the raw message bytes
 - **Sui**: Intent-prefixed (scope=3) BLAKE2b-256 digest, Ed25519 signature
 - **Cosmos**: ADR-036 off-chain signing
+- **Stellar**: SEP-53 message signing
 - **Filecoin**: Blake2b-256 hash then secp256k1 signing
 
 ### `signTypedData(request: SignTypedDataRequest): Promise<SignMessageResult>`

--- a/website-docs/md/07-supported-chains.md
+++ b/website-docs/md/07-supported-chains.md
@@ -21,7 +21,7 @@ type AssetId = `${ChainId}:${string}`;
 // e.g. "eip155:8453:native" (ETH on Base)
 ```
 
-The `native` token refers to the chain's native currency (ETH, SOL, SUI, BTC, ATOM, TRX, TON, etc.).
+The `native` token refers to the chain's native currency (ETH, SOL, SUI, XLM, BTC, ATOM, TRX, TON, etc.).
 
 ## Chain Families
 
@@ -36,6 +36,7 @@ OWS groups chains into families that share a cryptographic curve and address der
 | Tron | secp256k1 | 195 | `m/44'/195'/0'/0/{index}` | Base58Check (`T...`) | `tron` |
 | TON | ed25519 | 607 | `m/44'/607'/{index}'` | Base64url wallet v5r1 (`UQ...`) | `ton` |
 | Sui | ed25519 | 784 | `m/44'/784'/{index}'/0'/0'` | `0x` + BLAKE2b-256 hex (32 bytes) | `sui` |
+| Stellar | ed25519 | 148 | `m/44'/148'/0'` | Base32 Strkey (`G...`, 56 chars) | `stellar` |
 | Spark | secp256k1 | 8797555 | `m/84'/0'/0'/0/{index}` | `spark:` + compressed pubkey hex | `spark` |
 | Filecoin | secp256k1 | 461 | `m/44'/461'/0'/0/{index}` | `f1` + base32(blake2b-160) | `fil` |
 
@@ -65,6 +66,9 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | Tron | `tron:mainnet` |
 | TON | `ton:mainnet` |
 | Sui | `sui:mainnet` |
+| Stellar | `stellar:pubnet` |
+| Stellar Testnet | `stellar:testnet` |
+| Stellar Futurenet | `stellar:futurenet` |
 | Spark | `spark:mainnet` |
 | Filecoin | `fil:mainnet` |
 
@@ -88,6 +92,9 @@ cosmos    → cosmos:cosmoshub-4
 tron      → tron:mainnet
 ton       → ton:mainnet
 sui       → sui:mainnet
+stellar          → stellar:pubnet
+stellar-testnet  → stellar:testnet
+stellar-futurenet → stellar:futurenet
 spark     → spark:mainnet
 filecoin  → fil:mainnet
 ```
@@ -111,6 +118,7 @@ Master Seed (512 bits via PBKDF2)
     ├── m/44'/195'/0'/0/0   → Tron Account 0
     ├── m/44'/607'/0'       → TON Account 0
     ├── m/44'/784'/0'/0'/0' → Sui Account 0
+    ├── m/44'/148'/0'       → Stellar Account 0
     ├── m/84'/0'/0'/0/0     → Spark Account 0
     └── m/44'/461'/0'/0/0   → Filecoin Account 0
 ```

--- a/website-docs/md/sdk-cli.md
+++ b/website-docs/md/sdk-cli.md
@@ -44,6 +44,7 @@ Created wallet 3198bc9c-...
   bip122:000000000019d6689c085ae165831e93   bc1q...    m/84'/0'/0'/0/0
   cosmos:cosmoshub-4                     cosmos1... m/44'/118'/0'/0/0
   tron:mainnet                           TKLm...    m/44'/195'/0'/0/0
+  stellar:pubnet                         GABC...    m/44'/148'/0'
 ```
 
 ### `ows wallet import`
@@ -57,7 +58,7 @@ echo "goose puzzle decorate ..." | ows wallet import --name "imported" --mnemoni
 # Import from private key (reads from OWS_PRIVATE_KEY env or stdin)
 echo "4c0883a691..." | ows wallet import --name "from-evm" --private-key
 
-# Import an Ed25519 key (e.g. from Solana)
+# Import an Ed25519 key (e.g. from Solana or Stellar)
 echo "9d61b19d..." | ows wallet import --name "from-sol" --private-key --chain solana
 
 # Import explicit keys for both curves via environment variables
@@ -76,7 +77,7 @@ OWS_ED25519_KEY="9d61b19d..." \
 | `OWS_SECP256K1_KEY` | Explicit secp256k1 private key via environment variable |
 | `OWS_ED25519_KEY` | Explicit Ed25519 private key via environment variable |
 
-Private key imports generate all 8 chain accounts: the provided key is used for its curve's chains, and a random key is generated for the other curve. Use `OWS_SECP256K1_KEY` and `OWS_ED25519_KEY` together to supply both keys explicitly.
+Private key imports generate all 10 chain accounts: the provided key is used for its curve's chains, and a random key is generated for the other curve. Use `OWS_SECP256K1_KEY` and `OWS_ED25519_KEY` together to supply both keys explicitly.
 
 ### `ows wallet export`
 

--- a/website-docs/md/sdk-node.md
+++ b/website-docs/md/sdk-node.md
@@ -92,7 +92,7 @@ const solAddr = deriveAddress(mnemonic, "solana");
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mnemonic` | `string` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `string` | &mdash; | `"evm"`, `"solana"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` |
+| `chain` | `string` | &mdash; | `"evm"`, `"solana"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"stellar"`, `"filecoin"` |
 | `index` | `number` | `0` | Account index in derivation path |
 
 **Returns:** `string`
@@ -114,6 +114,7 @@ console.log(wallet.accounts);
 //   { chainId: "tron:mainnet", address: "TKLm...", derivationPath: "m/44'/195'/0'/0/0" },
 //   { chainId: "ton:mainnet", address: "UQ...", derivationPath: "m/44'/607'/0'" },
 //   { chainId: "sui:mainnet", address: "0x...", derivationPath: "m/44'/784'/0'/0'/0'" },
+//   { chainId: "stellar:pubnet", address: "GABC...", derivationPath: "m/44'/148'/0'" },
 //   { chainId: "fil:mainnet", address: "f1...", derivationPath: "m/44'/461'/0'/0/0" },
 // ]
 ```
@@ -188,7 +189,7 @@ const keys = JSON.parse(keysJson);
 
 #### `importWalletMnemonic(name, mnemonic, passphrase?, index?, vaultPath?)`
 
-Import a wallet from a BIP-39 mnemonic. Derives all 8 chain accounts via HD paths.
+Import a wallet from a BIP-39 mnemonic. Derives all 10 chain accounts via HD paths.
 
 ```javascript
 const wallet = importWalletMnemonic("imported", "goose puzzle decorate ...");
@@ -198,7 +199,7 @@ const wallet = importWalletMnemonic("imported", "goose puzzle decorate ...");
 
 #### `importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?)`
 
-Import a wallet from a hex-encoded private key. All 8 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
+Import a wallet from a hex-encoded private key. All 10 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
 
 The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
 
@@ -207,7 +208,7 @@ Alternatively, provide explicit keys for each curve via `secp256k1Key` and `ed25
 ```javascript
 // Import an EVM private key — generates a random Ed25519 key for Solana/Sui/TON
 const wallet = importWalletPrivateKey("from-evm", "4c0883a691...");
-console.log(wallet.accounts.length); // => 8
+console.log(wallet.accounts.length); // => 10
 
 // Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
 const wallet2 = importWalletPrivateKey(
@@ -230,7 +231,7 @@ console.log(wallet3.accounts.length); // => 8
 | `privateKeyHex` | `string` | &mdash; | Hex-encoded private key (with or without `0x` prefix). Ignored when both curve keys are provided. |
 | `passphrase` | `string` | `undefined` | Encryption passphrase |
 | `vaultPath` | `string` | `~/.ows` | Custom vault directory root |
-| `chain` | `string` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"` (Ed25519) |
+| `chain` | `string` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"`, `"stellar"` (Ed25519) |
 | `secp256k1Key` | `string` | `undefined` | Explicit secp256k1 private key (hex). Overrides random generation for secp256k1 chains. |
 | `ed25519Key` | `string` | `undefined` | Explicit Ed25519 private key (hex). Overrides random generation for Ed25519 chains. |
 

--- a/website-docs/md/sdk-python.md
+++ b/website-docs/md/sdk-python.md
@@ -92,7 +92,7 @@ sol_addr = derive_address(mnemonic, "solana")
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mnemonic` | `str` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `str` | &mdash; | `"evm"`, `"solana"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"ton"`, `"spark"`, `"filecoin"` |
+| `chain` | `str` | &mdash; | `"evm"`, `"solana"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"ton"`, `"stellar"`, `"spark"`, `"filecoin"` |
 | `index` | `int` | `0` | Account index in derivation path |
 
 ### Wallet Management
@@ -162,7 +162,7 @@ keys = json.loads(export_wallet("pk-wallet"))
 
 #### `import_wallet_mnemonic(name, mnemonic, passphrase=None, index=None, vault_path=None)`
 
-Import a wallet from a BIP-39 mnemonic. Derives all 8 chain accounts via HD paths.
+Import a wallet from a BIP-39 mnemonic. Derives all 10 chain accounts via HD paths.
 
 ```python
 wallet = import_wallet_mnemonic("imported", "goose puzzle decorate ...")
@@ -170,7 +170,7 @@ wallet = import_wallet_mnemonic("imported", "goose puzzle decorate ...")
 
 #### `import_wallet_private_key(name, private_key_hex, chain=None, passphrase=None, vault_path=None, secp256k1_key=None, ed25519_key=None)`
 
-Import a wallet from a hex-encoded private key. All 8 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
+Import a wallet from a hex-encoded private key. All 10 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
 
 The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
 
@@ -179,13 +179,13 @@ Alternatively, provide explicit keys for each curve via `secp256k1_key` and `ed2
 ```python
 # Import an EVM private key — generates a random Ed25519 key for Solana/Sui/TON
 wallet = import_wallet_private_key("from-evm", "4c0883a691...")
-print(len(wallet["accounts"]))  # => 8
+print(len(wallet["accounts"]))  # => 10
 
 # Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
 wallet = import_wallet_private_key(
     "from-solana", "9d61b19d...", chain="solana"
 )
-print(len(wallet["accounts"]))  # => 8
+print(len(wallet["accounts"]))  # => 10
 
 # Import explicit keys for both curves
 wallet = import_wallet_private_key(
@@ -193,14 +193,14 @@ wallet = import_wallet_private_key(
     secp256k1_key="4c0883a691...",
     ed25519_key="9d61b19d..."
 )
-print(len(wallet["accounts"]))  # => 8
+print(len(wallet["accounts"]))  # => 10
 ```
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `name` | `str` | &mdash; | Wallet name |
 | `private_key_hex` | `str` | &mdash; | Hex-encoded private key. Ignored when both curve keys are provided. |
-| `chain` | `str` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"` (Ed25519) |
+| `chain` | `str` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"`, `"stellar"` (Ed25519) |
 | `passphrase` | `str` | `None` | Encryption passphrase |
 | `vault_path` | `str` | `None` | Custom vault directory |
 | `secp256k1_key` | `str` | `None` | Explicit secp256k1 private key (hex) |


### PR DESCRIPTION
## Summary

Adds full Stellar support to OWS: wallet creation (G-address derivation), message signing (SEP-53), transaction signing, Soroban smart contract authorization, x402 USDC payments on Stellar, and pre-wired MoonPay funding.

- **Stellar as supported chain** — Ed25519 signing, BIP-44 `m/44'/148'/{index}'` derivation, three networks (pubnet, testnet, futurenet)
- **Soroban auth entry signing** — new `sign_inner_authorizations` trait method on `ChainSigner` with default no-op (zero impact on other chains). Stellar override transparently detects `InvokeHostFunction` ops and signs matching auth entries inside transaction envelopes
- **x402 USDC payments on Stellar** — Soroban `invokeHostFunction` calling `transfer(from, to, amount)` on USDC contract, with simulation, auth signing, and fee estimation
- **Shared Soroban auth helpers** — `soroban_auth` module with `build_auth_preimage_xdr` and `format_auth_signature` for reuse
- **MoonPay pre-wired** — `stellar` added to `MOONPAY_CHAINS`; will work with zero code changes when MoonPay Agents API adds Stellar
- **x402 v2 extensions forwarding** — payment payloads now include `extensions.bazaar` for Bazaar discovery indexing

## Stellar on OWS

### Supported Networks

| Network | Chain ID | CLI shorthand | Passphrase |
|---------|----------|---------------|------------|
| Mainnet | `stellar:pubnet` | `stellar` | `Public Global Stellar Network ; September 2015` |
| Testnet | `stellar:testnet` | `stellar-testnet` | `Test SDF Network ; September 2015` |
| Futurenet | `stellar:futurenet` | `stellar-futurenet` | `Test SDF Future Network ; October 2022` |

### CLI Usage

```bash
# Create wallet (derives G-address alongside all chains)
ows wallet create --name my-wallet

# Sign a message (SEP-53)
ows sign message --chain stellar --wallet my-wallet --message "hello"

# Sign and broadcast a transaction
ows sign send-tx --chain stellar-testnet --wallet my-wallet --tx <hex-xdr>

# x402 payment on Stellar
ows pay request --wallet my-wallet --network stellar:pubnet https://api.example.com/data

# Agent access
OWS_PASSPHRASE=ows_key_xxx ows pay request --wallet agent-wallet https://api.example.com
```

### How Soroban Auth Signing Works

When `sign send-tx` receives a transaction containing `InvokeHostFunction`:

1. Detects Soroban auth entries inside the envelope
2. For each `SorobanAuthorizationEntry` with `Address` credentials matching the wallet's pubkey and unsigned (`Void`) signature:
   - Builds `HashIdPreimage::SorobanAuthorization` (network ID, nonce, expiration, invocation)
   - SHA-256 hashes the preimage XDR, Ed25519 signs the hash
   - Formats signature as `ScVal::Vec([ScVal::Map({public_key, signature})])` (standard `__check_auth` format)
3. Skips entries for other signers, already-signed entries, contract addresses, and `SourceAccount` credentials
4. Signs the outer transaction envelope normally

This is transparent — no Soroban-specific CLI flags needed. The caller builds and simulates the transaction externally, passes the envelope to OWS.

### x402 Payment Flow on Stellar

`ows pay request` handles Stellar x402 payments end-to-end:

1. Sends HTTP request, gets 402 with Stellar payment requirements
2. Builds Soroban `InvokeHostFunction` tx calling `transfer(from, to, amount)` on the USDC contract
3. Simulates via Soroban RPC (twice — once to get auth entries, once with signed auth for accurate fees)
4. Signs auth entries with Ed25519 (keys never leave Rust)
5. Retries request with signed payment payload

### Architecture

| Crate | Stellar additions |
|-------|-------------------|
| `ows-core` | Network passphrases, chain IDs, RPC defaults |
| `ows-signer` | `StellarSigner`, `soroban_auth` helpers, `sign_inner_authorizations` |
| `ows-lib` | `sign_and_send` pipeline, `sign_stellar_auth_entry`, policy enforcement |
| `ows-pay` | Soroban tx building, simulation, x402 auth signing via `WalletAccess` |

### Design Decisions

- **`sign_inner_authorizations` is a trait method with default no-op** — only Stellar overrides it; all other chains are unaffected
- **Shared helpers live in `ows-signer/soroban_auth`** — used by `sign_inner_authorizations`; x402 keeps its own inline copy to avoid adding `ows-signer` as a dependency of `ows-pay`
- **G-addresses only** — smart wallet (C-address) support deferred until demand materializes; infrastructure is in place for later
- **MoonPay pre-wired** — `ows fund deposit --chain stellar` returns MoonPay's 400 today but will work with zero changes when they add Stellar to the Agents API

## Test plan

- [x] `cargo check` passes cleanly
- [x] `cargo test -p ows-signer` — 291 passed, 0 failed (13 new `sign_inner_authorizations` tests + 2 `soroban_auth` tests + fixed pre-existing `test_sign_soroban_auth_equivalence`)
- [x] `cargo test -p ows-lib` — 148 passed, 0 failed
- [x] Non-Soroban transactions pass through `sign_inner_authorizations` unchanged
- [x] Auth entries for non-matching keys are never signed
- [x] Already-signed entries are preserved (idempotent)
- [x] Different networks produce different signatures (replay protection)
- [x] Signature cryptographically verifies against the correct preimage
- [ ] Manual test: `ows sign send-tx --chain stellar-testnet` with a real Soroban envelope
- [ ] Manual test: `ows pay request` against an x402 endpoint accepting Stellar USDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk: introduces a new chain family (Stellar) and modifies core signing/broadcast and payment flows, including inner-authorization signing and new network/RPC handling.
> 
> **Overview**
> **Stellar is now a supported chain family** across the CLI, core registry, and docs (CAIP-2 `stellar:*`, BIP-44 coin type `148`, derivation path `m/44'/148'/0'`, and default RPC endpoints for testnet/futurenet).
> 
> **Core signing flow is extended** to support chain-specific *inner authorization signing* via `ChainSigner::sign_inner_authorizations` (default no-op), and the main sign→encode→broadcast pipeline now invokes this hook before signing the outer transaction; Stellar broadcasting is added using Soroban RPC JSON-RPC `sendTransaction` with base64-encoded XDR plus improved error enrichment.
> 
> **x402 payments gain Stellar support**: `ows-pay` can now build/simulate Soroban USDC `transfer` transactions, sign Soroban auth preimages via a new `WalletAccess::sign_stellar_auth` hook, re-simulate for accurate fees, and forward `extensions` in x402 v2 payloads; the CLI adds a `--network` override for payment requests and MoonPay funding adds `stellar` as a target chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b143241bf397344e3796b4ab3a995c1e4c30811a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->