### PR TITLE
feat: native wdk integration with ows

### DIFF
--- a/bindings/node-adapters/__test__/wdk.spec.mjs
+++ b/bindings/node-adapters/__test__/wdk.spec.mjs
@@ -1,0 +1,88 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createWallet, getWallet, signMessage as owsSignMessage } from '@open-wallet-standard/core';
+import { owsToWdkAccount } from '../src/wdk.js';
+
+describe('@open-wallet-standard/adapters — wdk', () => {
+  let vaultDir;
+  const walletName = 'wdk-test';
+  before(() => { vaultDir = mkdtempSync(join(tmpdir(), 'ows-wdk-test-')); createWallet(walletName, undefined, 12, vaultDir); });
+  after(() => { rmSync(vaultDir, { recursive: true, force: true }); });
+
+  it('creates account with correct EVM address', () => {
+    const wallet = getWallet(walletName, vaultDir);
+    const evmAccount = wallet.accounts.find(a => a.chainId.startsWith('eip155:'));
+    const account = owsToWdkAccount(walletName, 'evm', { vaultPath: vaultDir });
+    const address = evmAccount.address;
+    assert.ok(account);
+    assert.equal(account.index, 0);
+    assert.ok(account.path);
+  });
+  it('getAddress returns chain address', async () => {
+    const wallet = getWallet(walletName, vaultDir);
+    const evmAccount = wallet.accounts.find(a => a.chainId.startsWith('eip155:'));
+    const account = owsToWdkAccount(walletName, 'evm', { vaultPath: vaultDir });
+    const address = await account.getAddress();
+    assert.equal(address, evmAccount.address);
+    assert.match(address, /^0x[0-9a-fA-F]{40}$/);
+  });
+  it('resolves Solana chain name', async () => {
+    const wallet = getWallet(walletName, vaultDir);
+    const solAccount = wallet.accounts.find(a => a.chainId.startsWith('solana:'));
+    const account = owsToWdkAccount(walletName, 'solana', { vaultPath: vaultDir });
+    const address = await account.getAddress();
+    assert.equal(address, solAccount.address);
+  });
+  it('resolves Bitcoin chain name', async () => {
+    const wallet = getWallet(walletName, vaultDir);
+    const btcAccount = wallet.accounts.find(a => a.chainId.startsWith('bip122:'));
+    const account = owsToWdkAccount(walletName, 'btc', { vaultPath: vaultDir });
+    const address = await account.getAddress();
+    assert.equal(address, btcAccount.address);
+  });
+  it('accepts CAIP-2 chain IDs directly', async () => {
+    const wallet = getWallet(walletName, vaultDir);
+    const evmAccount = wallet.accounts.find(a => a.chainId.startsWith('eip155:'));
+    const account = owsToWdkAccount(walletName, 'eip155:1', { vaultPath: vaultDir });
+    const address = await account.getAddress();
+    assert.equal(address, evmAccount.address);
+  });
+  it('sign returns Uint8Array signature', async () => {
+    const account = owsToWdkAccount(walletName, 'evm', { vaultPath: vaultDir });
+    const sig = await account.sign(Buffer.from('hello'));
+    assert.ok(sig instanceof Uint8Array);
+    assert.ok(sig.length > 0);
+  });
+  it('sign is deterministic', async () => {
+    const account = owsToWdkAccount(walletName, 'evm', { vaultPath: vaultDir });
+    const sig1 = await account.sign(Buffer.from('deterministic'));
+    const sig2 = await account.sign(Buffer.from('deterministic'));
+    assert.deepEqual(sig1, sig2);
+  });
+  it('sign matches OWS SDK direct call', async () => {
+    const account = owsToWdkAccount(walletName, 'evm', { vaultPath: vaultDir });
+    const msg = Buffer.from('parity-check');
+    const adapterSig = await account.sign(msg);
+    const directResult = owsSignMessage(walletName, 'eip155:1', msg.toString('hex'), undefined, 'hex', undefined, vaultDir);
+    const directSig = Uint8Array.from(Buffer.from(directResult.signature, 'hex'));
+    assert.deepEqual(adapterSig, directSig);
+  });
+  it('keyPair does not expose private key', () => {
+    const account = owsToWdkAccount(walletName, 'evm', { vaultPath: vaultDir });
+    assert.equal(account.keyPair.privateKey, null);
+    assert.equal(account.keyPair.publicKey, null);
+  });
+  it('dispose is a no-op', () => {
+    const account = owsToWdkAccount(walletName, 'evm', { vaultPath: vaultDir });
+    assert.doesNotThrow(() => account.dispose());
+  });
+  it('throws for nonexistent wallet', () => {
+    assert.throws(() => owsToWdkAccount('nonexistent', 'evm', { vaultPath: vaultDir }));
+  });
+  it('throws for unsupported chain', () => {
+    assert.throws(() => owsToWdkAccount(walletName, 'unsupported-chain', { vaultPath: vaultDir }), /No unsupported-chain account/);
+  });
+});

--- a/bindings/node-adapters/package-lock.json
+++ b/bindings/node-adapters/package-lock.json
@@ -18,10 +18,14 @@
       },
       "peerDependencies": {
         "@solana/web3.js": ">=1.0.0",
+        "@tetherto/wdk-wallet": ">=1.0.0-beta.0",
         "viem": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "@solana/web3.js": {
+          "optional": true
+        },
+        "@tetherto/wdk-wallet": {
           "optional": true
         },
         "viem": {
@@ -454,7 +458,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -773,7 +776,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -900,22 +902,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -1019,7 +1005,6 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/bindings/node-adapters/package.json
+++ b/bindings/node-adapters/package.json
@@ -7,10 +7,11 @@
   "exports": {
     ".": { "types": "./src/index.d.ts", "default": "./src/index.js" },
     "./viem": { "types": "./src/viem.d.ts", "default": "./src/viem.js" },
-    "./solana": { "types": "./src/solana.d.ts", "default": "./src/solana.js" }
+    "./solana": { "types": "./src/solana.d.ts", "default": "./src/solana.js" },
+    "./wdk": { "types": "./src/wdk.d.ts", "default": "./src/wdk.js" }
   },
   "scripts": {
-    "test": "node --test __test__/viem.spec.mjs __test__/solana.spec.mjs",
+    "test": "node --test __test__/viem.spec.mjs __test__/solana.spec.mjs __test__/wdk.spec.mjs",
     "prepublishOnly": "npm test"
   },
   "dependencies": {
@@ -19,11 +20,13 @@
   },
   "peerDependencies": {
     "viem": ">=2.0.0",
-    "@solana/web3.js": ">=1.0.0"
+    "@solana/web3.js": ">=1.0.0",
+    "@tetherto/wdk-wallet": ">=1.0.0-beta.0"
   },
   "peerDependenciesMeta": {
     "viem": { "optional": true },
-    "@solana/web3.js": { "optional": true }
+    "@solana/web3.js": { "optional": true },
+    "@tetherto/wdk-wallet": { "optional": true }
   },
   "devDependencies": {
     "viem": "^2.0.0",

--- a/bindings/node-adapters/src/index.d.ts
+++ b/bindings/node-adapters/src/index.d.ts
@@ -1,2 +1,3 @@
 export { owsToViemAccount, OwsViemAccountOptions } from "./viem";
 export { owsToSolanaKeypair, OwsSolanaOptions } from "./solana";
+export { owsToWdkAccount, OwsWdkAccountOptions, WdkCompatibleAccount } from "./wdk";

--- a/bindings/node-adapters/src/index.js
+++ b/bindings/node-adapters/src/index.js
@@ -7,3 +7,8 @@ Object.defineProperty(exports, "owsToSolanaKeypair", {
   enumerable: true,
   get() { return require("./solana").owsToSolanaKeypair; },
 });
+
+Object.defineProperty(exports, "owsToWdkAccount", {
+  enumerable: true,
+  get() { return require("./wdk").owsToWdkAccount; },
+});

--- a/bindings/node-adapters/src/wdk.d.ts
+++ b/bindings/node-adapters/src/wdk.d.ts
@@ -1,0 +1,25 @@
+export interface OwsWdkAccountOptions {
+  passphrase?: string;
+  index?: number;
+  rpcUrl?: string;
+  vaultPath?: string;
+}
+
+export interface WdkCompatibleAccount {
+  index: number;
+  path: string;
+  keyPair: { publicKey: null; privateKey: null };
+  getAddress(): Promise<string>;
+  sign(message: Uint8Array | Buffer | string): Promise<Uint8Array>;
+  signTransaction(txData: Uint8Array | Buffer | string): Promise<Uint8Array>;
+  sendTransaction(txData: Uint8Array | Buffer | string): Promise<string>;
+  dispose(): void;
+}
+
+export declare const CHAIN_MAP: Record<string, string>;
+
+export declare function owsToWdkAccount(
+  walletNameOrId: string,
+  chain: string,
+  options?: OwsWdkAccountOptions,
+): WdkCompatibleAccount;

--- a/bindings/node-adapters/src/wdk.js
+++ b/bindings/node-adapters/src/wdk.js
@@ -1,0 +1,96 @@
+const { getWallet, signMessage, signTransaction, signAndSend } = require("@open-wallet-standard/core");
+
+/**
+ * Map WDK blockchain names to OWS CAIP-2 chain identifiers.
+ * WDK uses plain names ("evm", "solana", "btc"); OWS uses CAIP-2.
+ */
+const CHAIN_MAP = {
+  evm: "eip155:1",
+  solana: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  btc: "bip122:000000000019d6689c085ae165831e93",
+  bitcoin: "bip122:000000000019d6689c085ae165831e93",
+  ton: "ton:mainnet",
+  tron: "tron:mainnet",
+  cosmos: "cosmos:cosmoshub-4",
+  sui: "sui:mainnet",
+  xrpl: "xrpl:mainnet",
+  filecoin: "fil:mainnet",
+  spark: "spark:mainnet",
+};
+
+function resolveChain(chain) {
+  return CHAIN_MAP[chain] ?? chain;
+}
+
+/**
+ * Wrap an OWS wallet as a WDK-compatible account object.
+ *
+ * Returns an object conforming to WDK's IWalletAccount interface for signing
+ * operations. Signing is delegated to OWS core — keys never leave the vault.
+ *
+ * @param {string} walletNameOrId  OWS wallet name or UUID
+ * @param {string} chain           WDK chain name ("evm", "solana", "btc", …) or CAIP-2 ID
+ * @param {object} [options]
+ * @param {string} [options.passphrase]  Vault passphrase (owner mode)
+ * @param {number} [options.index]       Account derivation index (default: 0)
+ * @param {string} [options.rpcUrl]      RPC endpoint for sendTransaction
+ * @param {string} [options.vaultPath]   Custom vault directory
+ */
+function owsToWdkAccount(walletNameOrId, chain, options = {}) {
+  const caipChain = resolveChain(chain);
+  const namespace = caipChain.split(":")[0];
+  const wallet = getWallet(walletNameOrId, options.vaultPath);
+  const account =
+    wallet.accounts.find((a) => a.chainId === caipChain) ??
+    wallet.accounts.find((a) => a.chainId.startsWith(namespace + ":"));
+  if (!account) {
+    throw new Error(`No ${chain} account found in wallet "${walletNameOrId}".`);
+  }
+
+  const idx = options.index ?? 0;
+
+  return {
+    index: idx,
+    path: account.derivationPath,
+
+    keyPair: {
+      publicKey: null,
+      privateKey: null,
+    },
+
+    async getAddress() {
+      return account.address;
+    },
+
+    async sign(message) {
+      const msg = Buffer.isBuffer(message) || message instanceof Uint8Array
+        ? Buffer.from(message).toString("hex")
+        : message;
+      const encoding = Buffer.isBuffer(message) || message instanceof Uint8Array ? "hex" : "utf8";
+      const result = signMessage(walletNameOrId, caipChain, msg, options.passphrase, encoding, idx, options.vaultPath);
+      return Uint8Array.from(Buffer.from(result.signature, "hex"));
+    },
+
+    async signTransaction(txData) {
+      const txHex = Buffer.isBuffer(txData) || txData instanceof Uint8Array
+        ? Buffer.from(txData).toString("hex")
+        : typeof txData === "string" && txData.startsWith("0x") ? txData.slice(2)
+        : txData;
+      const result = signTransaction(walletNameOrId, caipChain, txHex, options.passphrase, idx, options.vaultPath);
+      return Uint8Array.from(Buffer.from(result.signature, "hex"));
+    },
+
+    async sendTransaction(txData) {
+      const txHex = Buffer.isBuffer(txData) || txData instanceof Uint8Array
+        ? Buffer.from(txData).toString("hex")
+        : typeof txData === "string" && txData.startsWith("0x") ? txData.slice(2)
+        : txData;
+      const result = signAndSend(walletNameOrId, caipChain, txHex, options.passphrase, idx, options.rpcUrl, options.vaultPath);
+      return result.txHash;
+    },
+
+    dispose() { /* OWS manages key lifecycle internally */ },
+  };
+}
+
+module.exports = { owsToWdkAccount, CHAIN_MAP };


### PR DESCRIPTION
## Summary

Adds a [WDK (Wallet Development Kit)](https://github.com/tetherto/wdk) adapter to `@open-wallet-standard/adapters`, following the same pattern as the existing viem and Solana adapters.

- `owsToWdkAccount(walletNameOrId, chain, options)` wraps an OWS wallet as a WDK-compatible `IWalletAccount` object
- Maps WDK chain names (`"evm"`, `"solana"`, `"btc"`, `"ton"`, `"tron"`, `"cosmos"`, `"sui"`, `"xrpl"`, `"filecoin"`, `"spark"`) to OWS CAIP-2 identifiers
- Signing delegated to OWS core — keys never leave the vault
- Available via subpath import: `@open-wallet-standard/adapters/wdk`

### Usage

```javascript
import { owsToWdkAccount } from '@open-wallet-standard/adapters/wdk';

const account = owsToWdkAccount('my-wallet', 'evm');

await account.getAddress();                    // "0x..."
await account.sign(Buffer.from('hello'));       // Uint8Array
await account.sendTransaction(txHex);           // tx hash
```

### Files changed

- **`src/wdk.js`** — adapter implementation
- **`src/wdk.d.ts`** — TypeScript declarations (`WdkCompatibleAccount`, `OwsWdkAccountOptions`)
- **`__test__/wdk.spec.mjs`** — 12 tests (chain resolution, signing, OWS SDK parity, error cases)
- **`src/index.js` / `src/index.d.ts`** — re-exports
- **`package.json`** — `./wdk` subpath export, `@tetherto/wdk-wallet` as optional peer dep

## Test plan

- [x] All 12 WDK adapter tests pass
- [x] Existing viem (10) and Solana (6) tests unaffected — full suite 28/28
- [ ] Verify `sign()` output is usable with WDK protocol modules (swap, bridge, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)