### PR TITLE
style: run cargo fmt on node and python SDK bindings

### DIFF
--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -285,9 +285,8 @@ pub fn create_policy(policy_json: String, vault_path_opt: Option<String>) -> Res
 /// List all registered policies.
 #[napi]
 pub fn list_policies(vault_path_opt: Option<String>) -> Result<Vec<serde_json::Value>> {
-    let policies =
-        ows_lib::policy_store::list_policies(vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let policies = ows_lib::policy_store::list_policies(vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     policies
         .iter()
         .map(|p| serde_json::to_value(p).map_err(|e| napi::Error::from_reason(e.to_string())))
@@ -297,9 +296,8 @@ pub fn list_policies(vault_path_opt: Option<String>) -> Result<Vec<serde_json::V
 /// Get a single policy by ID.
 #[napi]
 pub fn get_policy(id: String, vault_path_opt: Option<String>) -> Result<serde_json::Value> {
-    let policy =
-        ows_lib::policy_store::load_policy(&id, vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let policy = ows_lib::policy_store::load_policy(&id, vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     serde_json::to_value(&policy).map_err(|e| napi::Error::from_reason(e.to_string()))
 }
 
@@ -355,14 +353,13 @@ pub fn create_api_key(
 /// List all API keys (tokens are never returned).
 #[napi]
 pub fn list_api_keys(vault_path_opt: Option<String>) -> Result<Vec<serde_json::Value>> {
-    let keys =
-        ows_lib::key_store::list_api_keys(vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let keys = ows_lib::key_store::list_api_keys(vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     keys.iter()
         .map(|k| {
             // Strip wallet_secrets from the output — never expose encrypted material
-            let mut v = serde_json::to_value(k)
-                .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+            let mut v =
+                serde_json::to_value(k).map_err(|e| napi::Error::from_reason(e.to_string()))?;
             v.as_object_mut().map(|m| m.remove("wallet_secrets"));
             Ok(v)
         })
@@ -372,8 +369,7 @@ pub fn list_api_keys(vault_path_opt: Option<String>) -> Result<Vec<serde_json::V
 /// Revoke (delete) an API key by ID.
 #[napi]
 pub fn revoke_api_key(id: String, vault_path_opt: Option<String>) -> Result<()> {
-    ows_lib::key_store::delete_api_key(&id, vault_path(vault_path_opt).as_deref())
-        .map_err(map_err)
+    ows_lib::key_store::delete_api_key(&id, vault_path(vault_path_opt).as_deref()).map_err(map_err)
 }
 
 /// Sign and broadcast a transaction. Returns the transaction hash.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -272,8 +272,8 @@ fn sign_and_send(
 #[pyfunction]
 #[pyo3(signature = (policy_json, vault_path_opt=None))]
 fn create_policy(policy_json: &str, vault_path_opt: Option<String>) -> PyResult<()> {
-    let policy: ows_core::Policy =
-        serde_json::from_str(policy_json).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    let policy: ows_core::Policy = serde_json::from_str(policy_json)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
     ows_lib::policy_store::save_policy(&policy, vault_path(vault_path_opt).as_deref())
         .map_err(map_err)
 }
@@ -282,14 +282,15 @@ fn create_policy(policy_json: &str, vault_path_opt: Option<String>) -> PyResult<
 #[pyfunction]
 #[pyo3(signature = (vault_path_opt=None))]
 fn list_policies(vault_path_opt: Option<String>) -> PyResult<PyObject> {
-    let policies =
-        ows_lib::policy_store::list_policies(vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let policies = ows_lib::policy_store::list_policies(vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     let json_str =
         serde_json::to_string(&policies).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     Python::with_gil(|py| {
         let json_mod = py.import("json")?;
-        json_mod.call_method1("loads", (json_str,)).map(|o| o.unbind())
+        json_mod
+            .call_method1("loads", (json_str,))
+            .map(|o| o.unbind())
     })
 }
 
@@ -297,14 +298,15 @@ fn list_policies(vault_path_opt: Option<String>) -> PyResult<PyObject> {
 #[pyfunction]
 #[pyo3(signature = (id, vault_path_opt=None))]
 fn get_policy(id: &str, vault_path_opt: Option<String>) -> PyResult<PyObject> {
-    let policy =
-        ows_lib::policy_store::load_policy(id, vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let policy = ows_lib::policy_store::load_policy(id, vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     let json_str =
         serde_json::to_string(&policy).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     Python::with_gil(|py| {
         let json_mod = py.import("json")?;
-        json_mod.call_method1("loads", (json_str,)).map(|o| o.unbind())
+        json_mod
+            .call_method1("loads", (json_str,))
+            .map(|o| o.unbind())
     })
 }
 
@@ -312,8 +314,7 @@ fn get_policy(id: &str, vault_path_opt: Option<String>) -> PyResult<PyObject> {
 #[pyfunction]
 #[pyo3(signature = (id, vault_path_opt=None))]
 fn delete_policy(id: &str, vault_path_opt: Option<String>) -> PyResult<()> {
-    ows_lib::policy_store::delete_policy(id, vault_path(vault_path_opt).as_deref())
-        .map_err(map_err)
+    ows_lib::policy_store::delete_policy(id, vault_path(vault_path_opt).as_deref()).map_err(map_err)
 }
 
 // ---------------------------------------------------------------------------
@@ -355,9 +356,8 @@ fn create_api_key(
 #[pyfunction]
 #[pyo3(signature = (vault_path_opt=None))]
 fn list_api_keys(vault_path_opt: Option<String>) -> PyResult<PyObject> {
-    let keys =
-        ows_lib::key_store::list_api_keys(vault_path(vault_path_opt).as_deref())
-            .map_err(map_err)?;
+    let keys = ows_lib::key_store::list_api_keys(vault_path(vault_path_opt).as_deref())
+        .map_err(map_err)?;
     // Strip wallet_secrets from output
     let sanitized: Vec<serde_json::Value> = keys
         .iter()
@@ -367,11 +367,13 @@ fn list_api_keys(vault_path_opt: Option<String>) -> PyResult<PyObject> {
             v
         })
         .collect();
-    let json_str = serde_json::to_string(&sanitized)
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    let json_str =
+        serde_json::to_string(&sanitized).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     Python::with_gil(|py| {
         let json_mod = py.import("json")?;
-        json_mod.call_method1("loads", (json_str,)).map(|o| o.unbind())
+        json_mod
+            .call_method1("loads", (json_str,))
+            .map(|o| o.unbind())
     })
 }
 
@@ -379,8 +381,7 @@ fn list_api_keys(vault_path_opt: Option<String>) -> PyResult<PyObject> {
 #[pyfunction]
 #[pyo3(signature = (id, vault_path_opt=None))]
 fn revoke_api_key(id: &str, vault_path_opt: Option<String>) -> PyResult<()> {
-    ows_lib::key_store::delete_api_key(id, vault_path(vault_path_opt).as_deref())
-        .map_err(map_err)
+    ows_lib::key_store::delete_api_key(id, vault_path(vault_path_opt).as_deref()).map_err(map_err)
 }
 
 fn wallet_info_to_dict(py: Python<'_>, info: &ows_lib::WalletInfo) -> PyResult<PyObject> {


### PR DESCRIPTION
## Summary

Applies `rustfmt` to the Node and Python SDK binding source files. No behavioral changes.

- `bindings/node/src/lib.rs`
- `bindings/python/src/lib.rs`

These were flagged by `cargo fmt -- --check` on current main.