### PR TITLE
feat: publish npm adaptors package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,36 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --ignore-scripts
 
+  publish-npm-adapters:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    environment: release
+
+    defaults:
+      run:
+        working-directory: bindings/node-adapters
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set version from tag
+        run: |
+          V="${GITHUB_REF_NAME#v}"
+          "$GITHUB_WORKSPACE/scripts/set-version.sh" "$V" --node
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Publish adapters package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --ignore-scripts
+
   publish-crates:
     runs-on: ubuntu-latest
     environment: release

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -46,6 +46,11 @@ set_node_version() {
   npm install
 
   cargo update --workspace
+
+  cd "$REPO_ROOT/bindings/node-adapters"
+  npm version "$VERSION" --no-git-tag-version --allow-same-version
+  jq --arg v "^$VERSION" '.dependencies["@open-wallet-standard/core"] = $v' \
+    package.json > tmp.json && mv tmp.json package.json
 }
 
 set_rust_version() {


### PR DESCRIPTION
## What

Brief description of the change.

## Why

Why is this change needed? Link to related issue(s) if applicable.

Closes #

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` is clean
- [ ] `npm test` passes (if Node bindings changed)
- [ ] Tested manually with `ows` CLI

## Notes

Anything reviewers should know.
