### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/bindings/node-adapters/package-lock.json
+++ b/bindings/node-adapters/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-wallet-standard/adapters",
-  "version": "1.0.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-wallet-standard/adapters",
-      "version": "1.0.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.0.0",

--- a/bindings/node-adapters/package.json
+++ b/bindings/node-adapters/package.json
@@ -1,21 +1,33 @@
 {
   "name": "@open-wallet-standard/adapters",
-  "version": "1.0.0",
+  "version": "1.3.1",
   "description": "Framework adapters for the Open Wallet Standard — viem, Solana, and more",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "exports": {
-    ".": { "types": "./src/index.d.ts", "default": "./src/index.js" },
-    "./viem": { "types": "./src/viem.d.ts", "default": "./src/viem.js" },
-    "./solana": { "types": "./src/solana.d.ts", "default": "./src/solana.js" },
-    "./wdk": { "types": "./src/wdk.d.ts", "default": "./src/wdk.js" }
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./viem": {
+      "types": "./src/viem.d.ts",
+      "default": "./src/viem.js"
+    },
+    "./solana": {
+      "types": "./src/solana.d.ts",
+      "default": "./src/solana.js"
+    },
+    "./wdk": {
+      "types": "./src/wdk.d.ts",
+      "default": "./src/wdk.js"
+    }
   },
   "scripts": {
     "test": "node --test __test__/viem.spec.mjs __test__/solana.spec.mjs __test__/wdk.spec.mjs",
     "prepublishOnly": "npm test"
   },
   "dependencies": {
-    "@open-wallet-standard/core": "^1.0.0",
+    "@open-wallet-standard/core": "^1.3.1",
     "@noble/curves": "^1.0.0"
   },
   "peerDependencies": {
@@ -24,14 +36,22 @@
     "@tetherto/wdk-wallet": ">=1.0.0-beta.0"
   },
   "peerDependenciesMeta": {
-    "viem": { "optional": true },
-    "@solana/web3.js": { "optional": true },
-    "@tetherto/wdk-wallet": { "optional": true }
+    "viem": {
+      "optional": true
+    },
+    "@solana/web3.js": {
+      "optional": true
+    },
+    "@tetherto/wdk-wallet": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "viem": "^2.0.0",
     "@solana/web3.js": "^1.95.0"
   },
   "license": "MIT",
-  "files": ["src"]
+  "files": [
+    "src"
+  ]
 }

--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -1445,7 +1445,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "ows-node"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-node"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "Node.js native bindings for the Open Wallet Standard"
 

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-darwin-arm64",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "os": [
     "darwin"
   ],

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-darwin-x64",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "os": [
     "darwin"
   ],

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-linux-arm64-gnu",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "os": [
     "linux"
   ],

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-linux-x64-gnu",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "os": [
     "linux"
   ],

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-wallet-standard/core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-wallet-standard/core",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "bin": {
         "ows": "bin/ows"
@@ -15,10 +15,10 @@
         "@napi-rs/cli": "^2.18.0"
       },
       "optionalDependencies": {
-        "@open-wallet-standard/core-darwin-arm64": "1.3.0",
-        "@open-wallet-standard/core-darwin-x64": "1.3.0",
-        "@open-wallet-standard/core-linux-arm64-gnu": "1.3.0",
-        "@open-wallet-standard/core-linux-x64-gnu": "1.3.0"
+        "@open-wallet-standard/core-darwin-arm64": "1.3.1",
+        "@open-wallet-standard/core-darwin-x64": "1.3.1",
+        "@open-wallet-standard/core-linux-arm64-gnu": "1.3.1",
+        "@open-wallet-standard/core-linux-x64-gnu": "1.3.1"
       }
     },
     "node_modules/@napi-rs/cli": {

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Node.js native bindings for the Open Wallet Standard",
   "main": "index.js",
   "types": "index.d.ts",
@@ -31,10 +31,10 @@
     "@napi-rs/cli": "^2.18.0"
   },
   "optionalDependencies": {
-    "@open-wallet-standard/core-linux-x64-gnu": "1.3.0",
-    "@open-wallet-standard/core-linux-arm64-gnu": "1.3.0",
-    "@open-wallet-standard/core-darwin-x64": "1.3.0",
-    "@open-wallet-standard/core-darwin-arm64": "1.3.0"
+    "@open-wallet-standard/core-linux-x64-gnu": "1.3.1",
+    "@open-wallet-standard/core-linux-arm64-gnu": "1.3.1",
+    "@open-wallet-standard/core-darwin-x64": "1.3.1",
+    "@open-wallet-standard/core-darwin-arm64": "1.3.1"
   },
   "license": "MIT",
   "files": [

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1366,7 +1366,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "ows-python"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "ows-core",
  "ows-lib",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-python"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "Python native bindings for the Open Wallet Standard"
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "open-wallet-standard"
-version = "1.3.0"
+version = "1.3.1"
 description = "Python native bindings for the Open Wallet Standard"
 requires-python = ">=3.8"
 license = { text = "MIT" }

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -1522,7 +1522,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-cli"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "ows-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "ows-pay"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/ows/crates/ows-cli/Cargo.toml
+++ b/ows/crates/ows-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-cli"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 license = "MIT"
 description = "CLI for the Open Wallet Standard"
@@ -12,9 +12,9 @@ name = "ows"
 path = "src/main.rs"
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=1.3.0" }
-ows-signer = { path = "../ows-signer", version = "=1.3.0" }
-ows-lib = { path = "../ows-lib", version = "=1.3.0" }
+ows-core = { path = "../ows-core", version = "=1.3.1" }
+ows-signer = { path = "../ows-signer", version = "=1.3.1" }
+ows-lib = { path = "../ows-lib", version = "=1.3.1" }
 clap = { version = "4", features = ["derive", "env"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -25,8 +25,8 @@ tempfile = "3"
 rpassword = "7"
 serde = { version = "1", features = ["derive"] }
 zeroize = "1"
-ows-pay = { path = "../ows-pay", version = "=1.3.0" }
+ows-pay = { path = "../ows-pay", version = "=1.3.1" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
-ows-signer = { path = "../ows-signer", version = "=1.3.0", features = ["fast-kdf"] }
+ows-signer = { path = "../ows-signer", version = "=1.3.1", features = ["fast-kdf"] }

--- a/ows/crates/ows-core/Cargo.toml
+++ b/ows/crates/ows-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-core"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 license = "MIT"
 description = "Core types and traits for the Open Wallet Standard"

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-lib"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 license = "MIT"
 description = "High-level library API for the Open Wallet Standard"
@@ -12,8 +12,8 @@ default = []
 fast-kdf = ["ows-signer/fast-kdf"]
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=1.3.0" }
-ows-signer = { path = "../ows-signer", version = "=1.3.0" }
+ows-core = { path = "../ows-core", version = "=1.3.1" }
+ows-signer = { path = "../ows-signer", version = "=1.3.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -35,4 +35,4 @@ sha3 = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"] }
 ed25519-dalek = "2"
 bs58 = "0.5"
-ows-signer = { path = "../ows-signer", version = "=1.3.0", features = ["fast-kdf"] }
+ows-signer = { path = "../ows-signer", version = "=1.3.1", features = ["fast-kdf"] }

--- a/ows/crates/ows-pay/Cargo.toml
+++ b/ows/crates/ows-pay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-pay"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 license = "MIT"
 description = "Payment client for the Open Wallet Standard (x402)"
@@ -8,7 +8,7 @@ repository = "https://github.com/open-wallet-standard/core"
 
 [dependencies]
 # Core types (ChainType, parse_chain, etc.)
-ows-core = { path = "../ows-core", version = "=1.3.0" }
+ows-core = { path = "../ows-core", version = "=1.3.1" }
 
 # HTTP
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-signer"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 license = "MIT"
 description = "Cryptographic signing and key management for the Open Wallet Standard"
@@ -12,7 +12,7 @@ default = []
 fast-kdf = []
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=1.3.0" }
+ows-core = { path = "../ows-core", version = "=1.3.1" }
 xrpl-rust = { version = "1.1.0", default-features = false, features = ["core"] }
 k256 = { version = "0.13", features = ["ecdsa", "arithmetic"] }
 ed25519-dalek = { version = "2", features = ["hazmat"] }

--- a/skills/ows/SKILL.md
+++ b/skills/ows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ows
 description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin via CLI, Node.js, or Python.
-version: 1.3.0
+version: 1.3.1
 metadata:
   openclaw:
     requires:

--- a/website-docs/index.html
+++ b/website-docs/index.html
@@ -43,7 +43,7 @@
     </aside>
 
     <main class="docs-content">
-      <h1>Open Wallet Standard v1.3.0</h1>
+      <h1>Open Wallet Standard v1.3.1</h1>
       <p class="subtitle">An open standard for local wallet storage, delegated agent access, and policy-gated signing.</p>
 
       <h2>Abstract</h2>


### PR DESCRIPTION
## Summary

Automated version bump to `1.3.1` triggered by tag [`v1.3.1`](https://github.com/open-wallet-standard/core/releases/tag/v1.3.1).

### Changes
- Rust crate versions (`Cargo.toml`)
- Python binding version (`pyproject.toml`, `Cargo.toml`)
- Node binding version (`package.json`, `Cargo.toml`, platform packages)
- Skill manifest version (`SKILL.md`)
- Docs site version badge and heading (`website-docs/`)
- Regenerated READMEs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This is a coordinated version/lockfile update across multiple packaging surfaces with no functional code changes. Risk is limited to release/packaging consistency (e.g., mismatched versions or dependency pins).
> 
> **Overview**
> Updates the project release to **`v1.3.1`** across the Rust workspace (`ows-*` crates), Node native bindings (including per-platform npm packages), Python bindings, and the `@open-wallet-standard/adapters` package (including updating its `@open-wallet-standard/core` dependency to `^1.3.1`).
> 
> Regenerates associated lockfiles/manifests and updates version references in `skills/ows/SKILL.md` and the docs landing page (`website-docs/index.html`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71a407bc34c85ffeed02e556978baa7501c96cc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->