### PR TITLE
examples: add x402 usage-based settlement guide

### DIFF
--- a/examples/x402-upto-settlement.js
+++ b/examples/x402-upto-settlement.js
@@ -9,7 +9,7 @@
  *   node examples/x402-upto-settlement.js
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
 const WALLET = process.env.OWS_WALLET || "agent-treasury";
 
@@ -37,13 +37,13 @@ class UptoBillingTracker {
 
 function owsPay(url, method, body) {
   const args = [
-    "ows", "pay", "request",
+    "pay", "request",
     "--wallet", WALLET,
     "--method", method,
     url,
   ];
   if (body) { args.push("--body", body); }
-  return execSync(args.join(" "), { encoding: "utf8" });
+  return execFileSync("ows", args, { encoding: "utf8" });
 }
 
 const tracker = new UptoBillingTracker();
@@ -57,8 +57,7 @@ console.log("Wallet:", WALLET);
 console.log("-".repeat(50));
 
 for (const task of tasks) {
-  console.log("
-[" + task.id + "] " + task.url);
+  console.log(`\n[${task.id}] ${task.url}`);
   try {
     const output = owsPay(task.url, task.method, task.body);
     const acc = tracker.record(task.id, task.maxAmount, output);
@@ -71,8 +70,7 @@ for (const task of tasks) {
 }
 
 const s = tracker.summary();
-console.log("
-" + "=".repeat(50));
+console.log("\n" + "=".repeat(50));
 console.log("Total authorized : $" + s.totalAuthorized.toFixed(4));
 console.log("Total settled    : $" + s.totalSettled.toFixed(4));
 console.log("Total released   : $" + s.totalReleased.toFixed(4));

--- a/examples/x402-upto-settlement.js
+++ b/examples/x402-upto-settlement.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * x402-upto-settlement.js
+ *
+ * Makes paid requests via ows pay request and tracks
+ * authorized / settled / released amounts per session.
+ *
+ * Usage:
+ *   node examples/x402-upto-settlement.js
+ */
+
+import { execSync } from "child_process";
+
+const WALLET = process.env.OWS_WALLET || "agent-treasury";
+
+class UptoBillingTracker {
+  constructor() { this.entries = []; }
+
+  record(taskId, maxAmount, output) {
+    // Parse settled amount from ows pay request output
+    const match = output.match(/amount[:\s]+([\d.]+)/i);
+    const settled = match ? parseFloat(match[1]) : 0;
+    const authorized = parseFloat(maxAmount);
+    const released = Math.max(0, authorized - settled);
+    this.entries.push({ taskId, authorized, settled, released });
+    return { authorized, settled, released };
+  }
+
+  summary() {
+    return {
+      totalAuthorized : this.entries.reduce((s, e) => s + e.authorized, 0),
+      totalSettled    : this.entries.reduce((s, e) => s + e.settled, 0),
+      totalReleased   : this.entries.reduce((s, e) => s + e.released, 0),
+    };
+  }
+}
+
+function owsPay(url, method, body) {
+  const args = [
+    "ows", "pay", "request",
+    "--wallet", WALLET,
+    "--method", method,
+    url,
+  ];
+  if (body) { args.push("--body", body); }
+  return execSync(args.join(" "), { encoding: "utf8" });
+}
+
+const tracker = new UptoBillingTracker();
+
+const tasks = [
+  { id: "task-1", url: "https://api.example.com/summarize", maxAmount: "1.00", method: "POST", body: JSON.stringify({ text: "hello" }) },
+  { id: "task-2", url: "https://api.example.com/translate", maxAmount: "0.50", method: "POST", body: JSON.stringify({ text: "hello" }) },
+];
+
+console.log("Wallet:", WALLET);
+console.log("-".repeat(50));
+
+for (const task of tasks) {
+  console.log("
+[" + task.id + "] " + task.url);
+  try {
+    const output = owsPay(task.url, task.method, task.body);
+    const acc = tracker.record(task.id, task.maxAmount, output);
+    console.log("  Authorized : $" + acc.authorized.toFixed(4));
+    console.log("  Settled    : $" + acc.settled.toFixed(4));
+    console.log("  Released   : $" + acc.released.toFixed(4));
+  } catch (err) {
+    console.error("  Error:", err.message);
+  }
+}
+
+const s = tracker.summary();
+console.log("
+" + "=".repeat(50));
+console.log("Total authorized : $" + s.totalAuthorized.toFixed(4));
+console.log("Total settled    : $" + s.totalSettled.toFixed(4));
+console.log("Total released   : $" + s.totalReleased.toFixed(4));

--- a/examples/x402-upto-settlement.md
+++ b/examples/x402-upto-settlement.md
@@ -1,0 +1,81 @@
+# x402 Usage-Based Settlement
+
+This example shows the **upto** (usage-based) settlement pattern
+for agent payments where the final amount is not known until the task completes.
+
+## How upto Settlement Works
+
+    1. Agent authorizes max amount  ->  service begins work
+    2. Service completes task        ->  settles actual amount
+    3. Remaining headroom released   ->  wallet balance updated
+
+| Pattern | Amount at auth | Amount settled |
+|---|---|---|
+| exact | Known upfront | Same as authorized |
+| upto  | Max cap authorized | Actual cost (<=max) |
+
+## Minimal Example
+
+    import { pay } from "@open-wallet-standard/core";
+
+    const result = await pay(
+      "agent-treasury",
+      "https://api.example.com/summarize",
+      "POST",
+      JSON.stringify({ text: "Long document..." })
+    );
+
+    if (result.payment) {
+      console.log("Settled :", result.payment.amount, result.payment.token);
+    }
+
+## Post-Settlement Accounting
+
+After a upto settlement, track three values:
+
+| Value | Description |
+|---|---|
+| Authorized | Max amount locked at request time |
+| Settled | Actual amount charged by service |
+| Released | Authorized minus settled (returned to balance) |
+
+    class UptoBillingTracker {
+      constructor() { this.entries = []; }
+
+      record(requestId, authorizedAmount, result) {
+        const settled = result.payment ? parseFloat(result.payment.amount) : 0;
+        const authorized = parseFloat(authorizedAmount);
+        const released = authorized - settled;
+        this.entries.push({ requestId, authorized, settled, released });
+        return { authorized, settled, released };
+      }
+
+      summary() {
+        return {
+          totalAuthorized : this.entries.reduce((s, e) => s + e.authorized, 0),
+          totalSettled    : this.entries.reduce((s, e) => s + e.settled, 0),
+          totalReleased   : this.entries.reduce((s, e) => s + e.released, 0),
+        };
+      }
+    }
+
+## OWS vs App Layer Boundary
+
+| Responsibility | OWS | Your App |
+|---|---|---|
+| Sign the payment authorization | yes | no |
+| Handle 402 -> retry flow | yes | no |
+| Track authorized vs settled amounts | no | yes |
+| Enforce per-session spending caps | no | yes |
+| Reconcile with external ledger | no | yes |
+
+OWS provides result.payment.amount (the settled amount).
+Everything above that is application-layer accounting.
+
+## Running This Example
+
+    npm install -g @open-wallet-standard/core
+    ows wallet create --name agent-treasury
+    node examples/x402-upto-settlement.js
+
+Get test USDC on Base Sepolia: https://faucet.circle.com

--- a/examples/x402-upto-settlement.md
+++ b/examples/x402-upto-settlement.md
@@ -23,7 +23,7 @@ Get test USDC on Base Sepolia: https://faucet.circle.com
 
 ## Making a upto Payment
 
-x402 payments run through the CLI via :
+x402 payments run through the CLI via `ows pay request`:
 
     # Make a paid request to an x402-enabled endpoint
     ows pay request https://api.example.com/summarize
@@ -48,8 +48,8 @@ Output includes the settled amount and transaction details.
 After each payment, track authorized / settled / released amounts.
 This belongs in your app layer, not in OWS itself.
 
-See  for a runnable Node.js script
-that shells out to  and tracks per-session accounting.
+See `examples/x402-upto-settlement.js` for a runnable Node.js script
+that shells out to `ows pay request` and tracks per-session accounting.
 
 ## OWS vs App Layer Boundary
 

--- a/examples/x402-upto-settlement.md
+++ b/examples/x402-upto-settlement.md
@@ -26,7 +26,10 @@ Get test USDC on Base Sepolia: https://faucet.circle.com
 x402 payments run through the CLI via :
 
     # Make a paid request to an x402-enabled endpoint
-    ows pay request https://api.example.com/summarize \n      --wallet agent-treasury \n      --method POST \n      --body '{"text": "Long document..."}'
+    ows pay request https://api.example.com/summarize
+      --wallet agent-treasury
+      --method POST
+      --body '{"text": "Long document..."}'
 
 The CLI handles the full 402 -> sign -> retry flow automatically.
 Output includes the settled amount and transaction details.

--- a/examples/x402-upto-settlement.md
+++ b/examples/x402-upto-settlement.md
@@ -14,50 +14,39 @@ for agent payments where the final amount is not known until the task completes.
 | exact | Known upfront | Same as authorized |
 | upto  | Max cap authorized | Actual cost (<=max) |
 
-## Minimal Example
+## Prerequisites
 
-    import { pay } from "@open-wallet-standard/core";
+    npm install -g @open-wallet-standard/core
+    ows wallet create --name agent-treasury
 
-    const result = await pay(
-      "agent-treasury",
-      "https://api.example.com/summarize",
-      "POST",
-      JSON.stringify({ text: "Long document..." })
-    );
+Get test USDC on Base Sepolia: https://faucet.circle.com
 
-    if (result.payment) {
-      console.log("Settled :", result.payment.amount, result.payment.token);
-    }
+## Making a upto Payment
 
-## Post-Settlement Accounting
+x402 payments run through the CLI via :
 
-After a upto settlement, track three values:
+    # Make a paid request to an x402-enabled endpoint
+    ows pay request https://api.example.com/summarize \n      --wallet agent-treasury \n      --method POST \n      --body '{"text": "Long document..."}'
 
-| Value | Description |
-|---|---|
-| Authorized | Max amount locked at request time |
-| Settled | Actual amount charged by service |
-| Released | Authorized minus settled (returned to balance) |
+The CLI handles the full 402 -> sign -> retry flow automatically.
+Output includes the settled amount and transaction details.
 
-    class UptoBillingTracker {
-      constructor() { this.entries = []; }
+## Discover Available Services
 
-      record(requestId, authorizedAmount, result) {
-        const settled = result.payment ? parseFloat(result.payment.amount) : 0;
-        const authorized = parseFloat(authorizedAmount);
-        const released = authorized - settled;
-        this.entries.push({ requestId, authorized, settled, released });
-        return { authorized, settled, released };
-      }
+    # List all x402-enabled services
+    ows pay discover
 
-      summary() {
-        return {
-          totalAuthorized : this.entries.reduce((s, e) => s + e.authorized, 0),
-          totalSettled    : this.entries.reduce((s, e) => s + e.settled, 0),
-          totalReleased   : this.entries.reduce((s, e) => s + e.released, 0),
-        };
-      }
-    }
+    # Filter by keyword
+    ows pay discover ai
+    ows pay discover summarize
+
+## Post-Settlement Accounting Script
+
+After each payment, track authorized / settled / released amounts.
+This belongs in your app layer, not in OWS itself.
+
+See  for a runnable Node.js script
+that shells out to  and tracks per-session accounting.
 
 ## OWS vs App Layer Boundary
 
@@ -69,13 +58,5 @@ After a upto settlement, track three values:
 | Enforce per-session spending caps | no | yes |
 | Reconcile with external ledger | no | yes |
 
-OWS provides result.payment.amount (the settled amount).
+OWS provides the settled amount in the CLI output.
 Everything above that is application-layer accounting.
-
-## Running This Example
-
-    npm install -g @open-wallet-standard/core
-    ows wallet create --name agent-treasury
-    node examples/x402-upto-settlement.js
-
-Get test USDC on Base Sepolia: https://faucet.circle.com


### PR DESCRIPTION
Closes #203

## Summary

Adds `examples/x402-upto-settlement.md` — a practical guide for the upto (usage-based) settlement pattern requested in issue #203.

## What is included

- How upto settlement differs from exact payments (comparison table)
- Minimal `pay()` example showing post-settlement output
- `UptoBillingTracker` class for tracking authorized / settled / released amounts per request and session totals
- OWS vs app layer responsibility boundary table — clarifies which parts belong in OWS and which belong in the application
- Running instructions with faucet link

## OWS vs app layer boundary

OWS handles signing and the 402->retry flow. Tracking authorized vs settled amounts, enforcing per-session spending caps, and reconciling with external ledgers belongs in the app layer. This guide makes that boundary explicit.