### PR TITLE
feat: add EVM testnet chains (sepolia, base-sepolia, arbitrum-sepolia, optimism-sepolia, polygon-amoy)

### DIFF
--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -59,6 +59,11 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | Etherlink | `eip155:42793` |
 | Tempo | `eip155:4217` |
 | Hyperliquid | `eip155:999` |
+| Sepolia | `eip155:11155111` |
+| Base Sepolia | `eip155:84532` |
+| Arbitrum Sepolia | `eip155:421614` |
+| Optimism Sepolia | `eip155:11155420` |
+| Polygon Amoy | `eip155:80002` |
 
 ### Non-EVM Networks
 
@@ -91,7 +96,12 @@ bsc       → eip155:56
 avalanche → eip155:43114
 etherlink → eip155:42793
 tempo       → eip155:4217
-hyperliquid → eip155:999
+hyperliquid       → eip155:999
+sepolia           → eip155:11155111
+base-sepolia      → eip155:84532
+arbitrum-sepolia  → eip155:421614
+optimism-sepolia  → eip155:11155420
+polygon-amoy      → eip155:80002
 solana    → solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp
 bitcoin   → bip122:000000000019d6689c085ae165831e93
 cosmos    → cosmos:cosmoshub-4

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -190,6 +190,32 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_type: ChainType::Evm,
         chain_id: "eip155:999",
     },
+    // EVM testnets
+    Chain {
+        name: "sepolia",
+        chain_type: ChainType::Evm,
+        chain_id: "eip155:11155111",
+    },
+    Chain {
+        name: "base-sepolia",
+        chain_type: ChainType::Evm,
+        chain_id: "eip155:84532",
+    },
+    Chain {
+        name: "arbitrum-sepolia",
+        chain_type: ChainType::Evm,
+        chain_id: "eip155:421614",
+    },
+    Chain {
+        name: "optimism-sepolia",
+        chain_type: ChainType::Evm,
+        chain_id: "eip155:11155420",
+    },
+    Chain {
+        name: "polygon-amoy",
+        chain_type: ChainType::Evm,
+        chain_id: "eip155:80002",
+    },
 ];
 
 /// Parse a chain string into a `Chain`. Accepts:
@@ -628,4 +654,51 @@ mod tests {
         assert_eq!(chain.name, "ethereum");
         assert_eq!(chain.chain_id, "eip155:1");
     }
+    #[test]
+    fn parse_base_sepolia_by_name() {
+        let chain = parse_chain("base-sepolia").unwrap();
+        assert_eq!(chain.chain_id, "eip155:84532");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+    }
+
+    #[test]
+    fn parse_sepolia_by_name() {
+        let chain = parse_chain("sepolia").unwrap();
+        assert_eq!(chain.chain_id, "eip155:11155111");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+    }
+
+    #[test]
+    fn parse_arbitrum_sepolia_by_name() {
+        let chain = parse_chain("arbitrum-sepolia").unwrap();
+        assert_eq!(chain.chain_id, "eip155:421614");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+    }
+
+    #[test]
+    fn parse_optimism_sepolia_by_name() {
+        let chain = parse_chain("optimism-sepolia").unwrap();
+        assert_eq!(chain.chain_id, "eip155:11155420");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+    }
+
+    #[test]
+    fn parse_polygon_amoy_by_name() {
+        let chain = parse_chain("polygon-amoy").unwrap();
+        assert_eq!(chain.chain_id, "eip155:80002");
+        assert_eq!(chain.chain_type, ChainType::Evm);
+    }
+
+    #[test]
+    fn parse_base_sepolia_by_caip2() {
+        let chain = parse_chain("eip155:84532").unwrap();
+        assert_eq!(chain.chain_id, "eip155:84532");
+    }
+
+    #[test]
+    fn parse_base_sepolia_by_chain_id() {
+        let chain = parse_chain("84532").unwrap();
+        assert_eq!(chain.chain_id, "eip155:84532");
+    }
+
 }

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -700,5 +700,4 @@ mod tests {
         let chain = parse_chain("84532").unwrap();
         assert_eq!(chain.chain_id, "eip155:84532");
     }
-
 }


### PR DESCRIPTION
Closes #189

## Summary

Adds named testnet chain entries to the KNOWN_CHAINS registry.

## Chains added

| Name | Chain ID |
|---|---|
| sepolia | eip155:11155111 |
| base-sepolia | eip155:84532 |
| arbitrum-sepolia | eip155:421614 |
| optimism-sepolia | eip155:11155420 |
| polygon-amoy | eip155:80002 |

## Notes

These chains were already usable via CAIP-2 ID (e.g. `eip155:84532`) or bare chain ID (`84532`) due to the generic EVM namespace fallback in `parse_chain`. This PR adds friendly names so users can write `base-sepolia` directly in CLI commands and SDK calls.

## Tests

Adds 7 unit tests covering name lookup, CAIP-2 lookup, and bare chain ID lookup. All 90 existing tests continue to pass.