### PR TITLE
feat: add solana kit adapter

### DIFF
--- a/bindings/node-adapters/README.md
+++ b/bindings/node-adapters/README.md
@@ -1,6 +1,6 @@
 # @open-wallet-standard/adapters
 
-Framework adapters for the Open Wallet Standard — drop an OWS wallet into viem, Solana web3.js, or the Tether WDK without surfacing private keys.
+Framework adapters for the Open Wallet Standard — drop an OWS wallet into viem, Solana Kit, Solana web3.js, or the Tether WDK without surfacing private keys.
 
 [![npm](https://img.shields.io/npm/v/@open-wallet-standard/adapters)](https://www.npmjs.com/package/@open-wallet-standard/adapters)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/open-wallet-standard/core/blob/main/LICENSE)
@@ -15,6 +15,7 @@ Then install whichever framework you use alongside it:
 
 ```bash
 npm install viem                    # for the viem adapter
+npm install @solana/kit             # for the Solana Kit adapter
 npm install @solana/web3.js         # for the Solana adapter
 npm install @tetherto/wdk-wallet    # for the WDK adapter
 ```
@@ -27,9 +28,10 @@ Framework SDKs are declared as optional peer dependencies — install only what 
 |---------|-------------|---------|
 | viem | `@open-wallet-standard/adapters/viem` | `viem` `Account` that signs via OWS |
 | Solana | `@open-wallet-standard/adapters/solana` | `@solana/web3.js` `Keypair` |
+| Solana Kit | `@open-wallet-standard/adapters/solana-kit` | `@solana/kit` `KeyPairSigner` |
 | WDK | `@open-wallet-standard/adapters/wdk` | WDK `IWalletAccount`-compatible object |
 
-All three delegate signing to `@open-wallet-standard/core`, so keys remain encrypted in the OWS vault.
+All four delegate signing to `@open-wallet-standard/core`, so keys remain encrypted in the OWS vault.
 
 ## viem
 
@@ -64,6 +66,20 @@ tx.sign(keypair);
 Options: `passphrase`, `vaultPath`.
 
 The Solana adapter requires a wallet imported from a raw ed25519 private key. Mnemonic-derived wallets cannot be unwrapped into a `Keypair` — use `signMessage` / `signTransaction` from `@open-wallet-standard/core` directly.
+
+## Solana Kit
+
+```javascript
+import { owsToSolanaKeyPairSigner } from "@open-wallet-standard/adapters/solana-kit";
+
+const signer = await owsToSolanaKeyPairSigner("agent-treasury");
+
+console.log(signer.address);
+```
+
+Options: `passphrase`, `vaultPath`.
+
+The Solana Kit adapter requires a wallet imported from a raw ed25519 private key. Mnemonic-derived wallets cannot be unwrapped into a `KeyPairSigner` — use `signMessage` / `signTransaction` from `@open-wallet-standard/core` directly.
 
 ## WDK (Tether Wallet Development Kit)
 

--- a/bindings/node-adapters/__test__/solana-kit.spec.mjs
+++ b/bindings/node-adapters/__test__/solana-kit.spec.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { ed25519 } from "@noble/curves/ed25519";
+import {
+  createWallet,
+  getWallet,
+  importWalletPrivateKey,
+} from "@open-wallet-standard/core";
+import {
+  createKeyPairSignerFromBytes,
+  createKeyPairSignerFromPrivateKeyBytes,
+} from "@solana/kit";
+import { owsToSolanaKeyPairSigner } from "../src/solana-kit.js";
+
+const require = createRequire(import.meta.url);
+const core = require("@open-wallet-standard/core");
+
+describe("@open-wallet-standard/adapters — solana-kit", () => {
+  let vaultDir;
+  const walletName = "solana-kit-test";
+  const testEd25519Key = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+
+  before(() => {
+    vaultDir = mkdtempSync(join(tmpdir(), "ows-solana-kit-test-"));
+    importWalletPrivateKey(walletName, testEd25519Key, undefined, vaultDir, "solana");
+  });
+
+  after(() => {
+    rmSync(vaultDir, { force: true, recursive: true });
+  });
+
+  it("creates a signer with the correct address", async () => {
+    const wallet = getWallet(walletName, vaultDir);
+    const solAccount = wallet.accounts.find((account) => account.chainId.startsWith("solana:"));
+    const signer = await owsToSolanaKeyPairSigner(walletName, { vaultPath: vaultDir });
+
+    assert.equal(signer.address, solAccount.address);
+  });
+
+  it("same wallet produces the same signer address", async () => {
+    const signerA = await owsToSolanaKeyPairSigner(walletName, { vaultPath: vaultDir });
+    const signerB = await owsToSolanaKeyPairSigner(walletName, { vaultPath: vaultDir });
+
+    assert.equal(signerA.address, signerB.address);
+  });
+
+  it("throws for nonexistent wallets", async () => {
+    await assert.rejects(
+      () => owsToSolanaKeyPairSigner("nonexistent", { vaultPath: vaultDir }),
+    );
+  });
+
+  it("throws for mnemonic wallets", async () => {
+    createWallet("mnemonic-test", undefined, 12, vaultDir);
+
+    await assert.rejects(
+      () => owsToSolanaKeyPairSigner("mnemonic-test", { vaultPath: vaultDir }),
+      /Mnemonic wallets/,
+    );
+  });
+
+  it("accepts both 32-byte and 64-byte ed25519 exports", async () => {
+    const originalExportWallet = core.exportWallet;
+    const privateKeyBytes = Uint8Array.from(Buffer.from(testEd25519Key, "hex"));
+    const fullKeyBytes = new Uint8Array(64);
+    const publicKeyBytes = ed25519.getPublicKey(privateKeyBytes);
+
+    fullKeyBytes.set(privateKeyBytes, 0);
+    fullKeyBytes.set(publicKeyBytes, 32);
+
+    try {
+      core.exportWallet = () => JSON.stringify({ ed25519: Buffer.from(privateKeyBytes).toString("hex") });
+      const signerFromPrivateKey = await owsToSolanaKeyPairSigner(walletName, { vaultPath: vaultDir });
+      const expectedSignerFromPrivateKey = await createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes);
+
+      assert.equal(signerFromPrivateKey.address, expectedSignerFromPrivateKey.address);
+
+      core.exportWallet = () => JSON.stringify({ ed25519: Buffer.from(fullKeyBytes).toString("hex") });
+      const signerFromKeypair = await owsToSolanaKeyPairSigner(walletName, { vaultPath: vaultDir });
+      const expectedSignerFromKeypair = await createKeyPairSignerFromBytes(fullKeyBytes);
+
+      assert.equal(signerFromKeypair.address, expectedSignerFromKeypair.address);
+    } finally {
+      core.exportWallet = originalExportWallet;
+    }
+  });
+});

--- a/bindings/node-adapters/package-lock.json
+++ b/bindings/node-adapters/package-lock.json
@@ -13,15 +13,20 @@
         "@open-wallet-standard/core": "^1.0.0"
       },
       "devDependencies": {
+        "@solana/kit": "^6.0.0",
         "@solana/web3.js": "^1.95.0",
         "viem": "^2.0.0"
       },
       "peerDependencies": {
+        "@solana/kit": ">=3.0.0",
         "@solana/web3.js": ">=1.0.0",
         "@tetherto/wdk-wallet": ">=1.0.0-beta.0",
         "viem": ">=2.0.0"
       },
       "peerDependenciesMeta": {
+        "@solana/kit": {
+          "optional": true
+        },
         "@solana/web3.js": {
           "optional": true
         },
@@ -91,24 +96,24 @@
       }
     },
     "node_modules/@open-wallet-standard/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-6YBlPJK0TLYivSD4etD9NzZGc1qtTa4D3mAeQ+DE0wz0gkeQFTrysiRiSVK5jIel2V2HazHto1qizYTTcVVrWg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core/-/core-1.3.2.tgz",
+      "integrity": "sha512-Dk8bB9G5PjJfNzAqJd9WT9OfqrrSXRc3gA9+BCaY2qirlNrCkIAZCHaDIE0LnGOAaoSZizR6qnOFbukj+DTzJg==",
       "license": "MIT",
       "bin": {
         "ows": "bin/ows"
       },
       "optionalDependencies": {
-        "@open-wallet-standard/core-darwin-arm64": "1.2.0",
-        "@open-wallet-standard/core-darwin-x64": "1.2.0",
-        "@open-wallet-standard/core-linux-arm64-gnu": "1.2.0",
-        "@open-wallet-standard/core-linux-x64-gnu": "1.2.0"
+        "@open-wallet-standard/core-darwin-arm64": "1.3.2",
+        "@open-wallet-standard/core-darwin-x64": "1.3.2",
+        "@open-wallet-standard/core-linux-arm64-gnu": "1.3.2",
+        "@open-wallet-standard/core-linux-x64-gnu": "1.3.2"
       }
     },
     "node_modules/@open-wallet-standard/core-darwin-arm64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-darwin-arm64/-/core-darwin-arm64-1.2.0.tgz",
-      "integrity": "sha512-2TivIvNgm3+/+A7DpAHhgyH+Nefgm0JlHUaGoiazmKEVuUSNN9AhVArSMIVFXD0mN8Wz2cmequ+mFF3Mzhz6jw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-darwin-arm64/-/core-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-rvUsGU8eZtIMYFJ047nFKS79ajJeYCydvvh2B6bX0UUGf2NJZ4wUnxGqijxPiflz2xqzvbHXYZNzy3MIO4+fDQ==",
       "cpu": [
         "arm64"
       ],
@@ -119,9 +124,9 @@
       ]
     },
     "node_modules/@open-wallet-standard/core-darwin-x64": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-darwin-x64/-/core-darwin-x64-1.2.0.tgz",
-      "integrity": "sha512-Kqx4ovI/b0Xs2QRnsY9n7TFzVIszjrNCbOLIUUgFBiNn75jhxTbbcNwMEBkaAu6hy5Y5qnaLdDUjpeqbqgSDfA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-darwin-x64/-/core-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-a6u3CvWZY8sC1S92AMGnO1WFlMW3m38+3/IoKzhxcFvD8rVY0OA0ebH6qzYLT96/TaouXDwmMQV6yQmb1IjfzQ==",
       "cpu": [
         "x64"
       ],
@@ -132,9 +137,9 @@
       ]
     },
     "node_modules/@open-wallet-standard/core-linux-arm64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.0.tgz",
-      "integrity": "sha512-JDrx3D1f7o7WJM6q/LE3xnYQJdz28KLWDHqyhdsBAmYxNaOYC/X48YD5dOhmD3PKR6DOqcgAMyoE58zIDU2kQA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.2.tgz",
+      "integrity": "sha512-wzyd7euZ5qvDr8dHf3eG2XP7iFgMmBUo35U7cWMLs6Yqjqz103SEjtMfNJEedZRb62f8P3Xhp9jdRLzaJvjk5g==",
       "cpu": [
         "arm64"
       ],
@@ -145,9 +150,9 @@
       ]
     },
     "node_modules/@open-wallet-standard/core-linux-x64-gnu": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.0.tgz",
-      "integrity": "sha512-zPOAly+rEhCvTQ4/aBBfBVqeg+NIpCKU6aI/Jtj73gFfnVsunJzRdWyjcSP8rYGMxN2cJi18jdqO7xTPLEW+fw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.2.tgz",
+      "integrity": "sha512-pVtyEP8EqR3rjqdBDCRuB9Rd4xs8+11gRVtWidwPeFz5QPq3c9VGZjGQtTZoiZBHCxKaq5pTQjC78J5lVuA0hg==",
       "cpu": [
         "x64"
       ],
@@ -196,6 +201,195 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@solana/accounts": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.8.0.tgz",
+      "integrity": "sha512-rXjFYVopaEw1H2PTBQbRjKr+0i4EFuBEhRT5E0dI4cMaabSb4KKypC2gaf47+6cjU3hMlM1AcsyIs72/MqAVBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.8.0.tgz",
+      "integrity": "sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.8.0.tgz",
+      "integrity": "sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
@@ -207,6 +401,31 @@
       },
       "engines": {
         "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.8.0.tgz",
+      "integrity": "sha512-qCSAaw1qszeQflavkIM7c21qJ3BHReP/qgDelZbhsEXpZc852CCZM00FOIWuxePr6X+JjSNqJquxwdDSoZe7Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/options": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-core": {
@@ -225,6 +444,97 @@
         "typescript": ">=5.3.3"
       }
     },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.8.0.tgz",
+      "integrity": "sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@solana/codecs-numbers": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
@@ -240,6 +550,169 @@
       },
       "peerDependencies": {
         "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.8.0.tgz",
+      "integrity": "sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/errors": {
@@ -260,6 +733,1773 @@
       },
       "peerDependencies": {
         "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.8.0.tgz",
+      "integrity": "sha512-lZa3Qnsn+9ew6rHTXkPc+uqSa3i+AWqSBhV6oYxxBc+smvuxovItU4TPIs30cTfA7lAP+j+oYAQtUDu2dLy0hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.8.0.tgz",
+      "integrity": "sha512-oMSAD/8w9ujx7OplvwRWwHHFnaaxi/Xrji1XH3xAB+gzxupUpBbOmgxQ+e84x+9VN8QWk5aU3L7gmCqdTAR6OA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.8.0.tgz",
+      "integrity": "sha512-osAsY8ozqohrcTcHlG1EmO3i9flc0eESMIy9akTHyVvqk915gZgkaTmt4IjcYSwBGt7i+Rh8TmLj27RrTpCKvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/promises": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.8.0.tgz",
+      "integrity": "sha512-dTtykhS9IeN3npCfnd7wSS6KmKAh54+g90JRtLYy5/31L2Zvunf3AJz2QUk58vgsAGZ5fuoiMyhCxRJm4rHUBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.8.0.tgz",
+      "integrity": "sha512-Wo8CnbrVfCP1Jbsb3ElMej/3dmMrl4ArPhI1mDcqIIz/O4j4HmxZYbn2BCWtnV9V/LPM638EMO2r1x6GzDNrPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/promises": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.8.0.tgz",
+      "integrity": "sha512-+McC1aCgcUBdM7Cd7U6k2ZHJ9OKCy5mzpb0XWrhkrgsFxT0QoRr0AcWJc85o6tIDfG6Jz7vVhbS3l8ugYz2Vzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.8.0",
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instruction-plans": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/offchain-messages": "6.8.0",
+        "@solana/plugin-core": "6.8.0",
+        "@solana/plugin-interfaces": "6.8.0",
+        "@solana/program-client-core": "6.8.0",
+        "@solana/programs": "6.8.0",
+        "@solana/rpc": "6.8.0",
+        "@solana/rpc-api": "6.8.0",
+        "@solana/rpc-parsed-types": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/rpc-subscriptions": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/signers": "6.8.0",
+        "@solana/subscribable": "6.8.0",
+        "@solana/sysvars": "6.8.0",
+        "@solana/transaction-confirmation": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.8.0.tgz",
+      "integrity": "sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.8.0.tgz",
+      "integrity": "sha512-HoniTs2uoCHGicD0dTTJ3YBhLZC9URxdXXUf0CHalLFwAidF9iNuB8dsuKk16Euu68L4/ERKKGfyC0QobBvahw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.8.0.tgz",
+      "integrity": "sha512-T5441HHeucFaLtaMAJQJl79T7mX007oAFPunpPebBphRvCXGv+qQwQvqa4HkYct6Jf2O0aKLBL9GSe/kfdCk9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.8.0.tgz",
+      "integrity": "sha512-kdqFIhQvJP2BDUsMOIbor35esj8u78SO33Xv0Wmo+uTRg6yKONKVK53ghw235pWrinOT4f0VnVe6MN6ciYiQVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.8.0.tgz",
+      "integrity": "sha512-4olaMKGUVA7wG6BBWM5A31bQsUWBlfcL1pjhq6ZTqVEJ7vshHXGwHVlWYXYyYn9ixozGDpGSl553yaRY9jQwWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/instruction-plans": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-subscriptions-spec": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/signers": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.8.0.tgz",
+      "integrity": "sha512-eOZtEnwl+vdiy9x/rFF89NDtnvt+Q3H04A/0u4GoHnt+fFkQG3JS+ChWG9c77izmpmRuz5C1GptOPDGNDnIUgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.8.0",
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/instruction-plans": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/plugin-interfaces": "6.8.0",
+        "@solana/rpc-api": "6.8.0",
+        "@solana/signers": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/program-client-core/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.8.0.tgz",
+      "integrity": "sha512-8hSKGfPTLX9Sm7KGV/UtiGCeSzptT/9vcjbodE+ZGHKFefo5vES4UAW+qD01LjL7IumGtMJvnfhCWt81qT/jbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.8.0.tgz",
+      "integrity": "sha512-kIypZG83ZbADbrAq9/LS7LuWlVxlgJSzIpic75+9IuAfC3k5/KSus8LrvggBkCzfAyIslrUh70iz4JcnzUZrOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.8.0.tgz",
+      "integrity": "sha512-+jW4n9TDmBttY3bO3PdUo54GAnwFrd7UJsyfXoMgl/lWGQq5uddYDgnzQLtHOBP5zKslkR8h0RKkic0GZhMZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/fast-stable-stringify": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/rpc-api": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/rpc-transformers": "6.8.0",
+        "@solana/rpc-transport-http": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.8.0.tgz",
+      "integrity": "sha512-v8ZKWgPtKbF6HeJcfC4ciwI8mwDCizBtRLYYjjHOu+9S9IJYyefQzsQxL5P8OjJPpI4gFauT6gsjQLo76BoojA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/rpc-parsed-types": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-transformers": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.8.0.tgz",
+      "integrity": "sha512-jYddZviBSUYbuUKqvNthet7KbJVI7me6xfRH2znv1SjIpmvhSPJcGN5QrlHVOasHdzEWSpvZa5VYDfnqH3aYvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.8.0.tgz",
+      "integrity": "sha512-kE5uOspxCVFJKNUu73hlebGiAFosjfYXbbTXAbGKfksPzy84u1oJFC2IVIobLRnqUCw1x7oJcvfnX00Zs0Itpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.8.0.tgz",
+      "integrity": "sha512-ebCWgiQbIgFOehU7PdRFmYCzda3Azc/qa2Y3P8gexSHSsDAO27VwS4E05XSY+a7cIL5MYmvUa1vpDynl1Rkakw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.8.0.tgz",
+      "integrity": "sha512-9CotreNZmKAP2z07FY1I7TPPvylKLFF5p4mujB5ZFMHQPp5JVQFVCmMIhSj5voZHAeYx7jdwJ2Kf0RDeClqJzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/fast-stable-stringify": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/promises": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/rpc-subscriptions-api": "6.8.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.8.0",
+        "@solana/rpc-subscriptions-spec": "6.8.0",
+        "@solana/rpc-transformers": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/subscribable": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.8.0.tgz",
+      "integrity": "sha512-cPJOsydyoqkztW3msEH09wPDYqxJcMvO6DBlvrboq6wGu1UjeP66w2eApzQ8POoQHxhyw+CfEXl1Gbu6kKwuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/rpc-subscriptions-spec": "6.8.0",
+        "@solana/rpc-transformers": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.8.0.tgz",
+      "integrity": "sha512-c3PpkorYwhAz1iuUfM5sLpZQi8xtZFGbaPbaPRELVeDjFSRzoa12KFnuQs4i9fbVbLy5Cnt1t23tf0bL2snZCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/rpc-subscriptions-spec": "6.8.0",
+        "@solana/subscribable": "6.8.0",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.8.0.tgz",
+      "integrity": "sha512-+t4L5q9qE6IVfunW3n1amA/3EswJr64pVqRF7234vCUuVUz4PgYfbqtEBV3KkA1o0NwEHHM3pXuofT63nBb8Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/promises": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/subscribable": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.8.0.tgz",
+      "integrity": "sha512-GzcFkllym7eXbw7grdE41MCb15CjkibrXtr7EFsf4d6LD9DRvzFj2ZRYywS2FB2ibVP0LUXXGk3vmtkZJjfajA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.8.0.tgz",
+      "integrity": "sha512-jw/L0q2motGcx7yo6KvkKJd2HGVg9gvViXatFloLl1XmHbkwE7+97YYmG17WRuM5xauzI/UGYOXNW7cEB+Uaxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-spec": "6.8.0",
+        "@solana/rpc-spec-types": "6.8.0",
+        "undici-types": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.8.0.tgz",
+      "integrity": "sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/nominal-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-types/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-types/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-types/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.8.0.tgz",
+      "integrity": "sha512-7E1cAXBLOcz9kmHhzWdu5m3UJlJzxfwOl8irOMLJI6NnKB2EmU0B0h4I+Mlfs9w8Bfj0WQpUei21ammbNBq39g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/offchain-messages": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.8.0.tgz",
+      "integrity": "sha512-yj41Q97MiWrOmLj1iRFobvTdtU6H5wz5BlH5FHJg9lyapy1YQyaYF37MZx4LiUj4Ww0V3ReluIZTWWDBOJ53Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.8.0.tgz",
+      "integrity": "sha512-pwfMpMNL6MSmm07eHQYdTdRdzmPOd+EuVCCaNLSYdWGpYcocVJiaLiNWRV3cXA5wPj/ZFkoUGtc1bo0v7H50lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.8.0.tgz",
+      "integrity": "sha512-R6rj8y/+kZqYJr8FR/fWxgi3Pw3eCiacUyjCPTVtdVe6i+hIiBApTGLzXrSRJmAMdpZrjYBZU1cG8C6oAb+B2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/promises": "6.8.0",
+        "@solana/rpc": "6.8.0",
+        "@solana/rpc-subscriptions": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0",
+        "@solana/transactions": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.8.0.tgz",
+      "integrity": "sha512-jsJu9mAcN1x7onKOeC4WEvYP04UVcnkOYu/9bMe+S9jqjL+3DMy9kFZpV5FBl+TPuTNJrtOqc6Gc28hUWyyp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.8.0.tgz",
+      "integrity": "sha512-Q46m+o3C1yL2EIZBAP5B8ou2VZwHN9wTi+muIS6/giCKO3jwUtnTEbWcZEDMj2vxUb7P2WfwTluZb/VAWxlx7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.8.0",
+        "@solana/codecs-core": "6.8.0",
+        "@solana/codecs-data-structures": "6.8.0",
+        "@solana/codecs-numbers": "6.8.0",
+        "@solana/codecs-strings": "6.8.0",
+        "@solana/errors": "6.8.0",
+        "@solana/functional": "6.8.0",
+        "@solana/instructions": "6.8.0",
+        "@solana/keys": "6.8.0",
+        "@solana/nominal-types": "6.8.0",
+        "@solana/rpc-types": "6.8.0",
+        "@solana/transaction-messages": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.8.0.tgz",
+      "integrity": "sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-numbers": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.8.0.tgz",
+      "integrity": "sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.8.0",
+        "@solana/errors": "6.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/errors": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.8.0.tgz",
+      "integrity": "sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/web3.js": {
@@ -901,6 +3141,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.1.0.tgz",
+      "integrity": "sha512-JlLXdMmH4kxyn2JPtGK/cajzKY7F15OKYG8sO5HfkIC1AC09sLUeptGFKjnMWnprDQ2EwzYDO3kgzkK3aaoHCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/bindings/node-adapters/package.json
+++ b/bindings/node-adapters/package.json
@@ -17,13 +17,17 @@
       "types": "./src/solana.d.ts",
       "default": "./src/solana.js"
     },
+    "./solana-kit": {
+      "types": "./src/solana-kit.d.ts",
+      "default": "./src/solana-kit.js"
+    },
     "./wdk": {
       "types": "./src/wdk.d.ts",
       "default": "./src/wdk.js"
     }
   },
   "scripts": {
-    "test": "node --test __test__/viem.spec.mjs __test__/solana.spec.mjs __test__/wdk.spec.mjs",
+    "test": "node --test __test__/viem.spec.mjs __test__/solana.spec.mjs __test__/solana-kit.spec.mjs __test__/wdk.spec.mjs",
     "prepublishOnly": "npm test"
   },
   "dependencies": {
@@ -32,11 +36,15 @@
   },
   "peerDependencies": {
     "viem": ">=2.0.0",
+    "@solana/kit": ">=3.0.0",
     "@solana/web3.js": ">=1.0.0",
     "@tetherto/wdk-wallet": ">=1.0.0-beta.0"
   },
   "peerDependenciesMeta": {
     "viem": {
+      "optional": true
+    },
+    "@solana/kit": {
       "optional": true
     },
     "@solana/web3.js": {
@@ -48,6 +56,7 @@
   },
   "devDependencies": {
     "viem": "^2.0.0",
+    "@solana/kit": "^6.0.0",
     "@solana/web3.js": "^1.95.0"
   },
   "license": "MIT",

--- a/bindings/node-adapters/src/solana-kit.d.ts
+++ b/bindings/node-adapters/src/solana-kit.d.ts
@@ -1,0 +1,11 @@
+import type { KeyPairSigner } from "@solana/kit";
+
+export interface OwsSolanaKitOptions {
+  passphrase?: string;
+  vaultPath?: string;
+}
+
+export declare function owsToSolanaKeyPairSigner(
+  walletNameOrId: string,
+  options?: OwsSolanaKitOptions,
+): Promise<KeyPairSigner>;

--- a/bindings/node-adapters/src/solana-kit.js
+++ b/bindings/node-adapters/src/solana-kit.js
@@ -1,0 +1,34 @@
+const core = require("@open-wallet-standard/core");
+
+function hexToBytes(hex) {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const pairs = clean.match(/.{2}/g) ?? [];
+  return Uint8Array.from(pairs.map((pair) => parseInt(pair, 16)));
+}
+
+async function owsToSolanaKeyPairSigner(walletNameOrId, options = {}) {
+  const {
+    createKeyPairSignerFromBytes,
+    createKeyPairSignerFromPrivateKeyBytes,
+  } = await import("@solana/kit");
+  const exported = core.exportWallet(walletNameOrId, options.passphrase, options.vaultPath);
+  let keys;
+  try { keys = JSON.parse(exported); } catch {
+    throw new Error("Mnemonic wallets: use @open-wallet-standard/core signMessage/signTransaction directly, or import with a private key for Keypair access.");
+  }
+  const hex = keys.ed25519;
+  if (!hex) {
+    throw new Error(`No ed25519 key found in wallet "${walletNameOrId}". Wallet may use a different curve.`);
+  }
+
+  const privateKeyBytes = hexToBytes(hex);
+  if (privateKeyBytes.length === 32) {
+    return createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes);
+  }
+  if (privateKeyBytes.length === 64) {
+    return createKeyPairSignerFromBytes(privateKeyBytes);
+  }
+  throw new Error(`Unexpected key length: ${privateKeyBytes.length} bytes`);
+}
+
+module.exports = { owsToSolanaKeyPairSigner };


### PR DESCRIPTION
## What

Add a new solana-kit subpath export that returns a Kit KeyPairSigner from an exported OWS ed25519 key.

Cover the adapter with dedicated tests and document the new install and usage flow in the adapters README.

## Why

I want to use OWS with a @solana/kit app and it would be great if it's natively supported.

Closes #

## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `npm test` passes (if Node bindings changed)
- [x] Tested manually with `ows` CLI

## Notes

If you'd like to see any changes, please let me know.

I thought for consistency it may be good to rename the existing `solana` option to `solana-web3js` but that would probably be a breaking change and a different PR.  
