### PR TITLE
feat: implement Nano (XNO) off-chain message signing (ORIS-001)

### DIFF
--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -222,6 +222,7 @@ pub fn build_state_block(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// NOMS (Nano Off-chain Message Standard) magic header.
+/// See: https://github.com/OpenRai/Standards/blob/main/rfcs/ORIS-001.md
 const NOMS_MAGIC_HEADER: &[u8; 25] = b"\x18Nano Off-chain Message:\n";
 
 /// Nano chain signer (Ed25519 with blake2b-512).
@@ -291,6 +292,8 @@ impl ChainSigner for NanoSigner {
         self.sign(private_key, &block_hash)
     }
 
+    // Implements Nano Off-chain Message Signing (NOMS).
+    // See: https://github.com/OpenRai/Standards/blob/main/rfcs/ORIS-001.md
     fn sign_message(
         &self,
         private_key: &[u8],

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -528,15 +528,34 @@ mod tests {
     #[test]
     fn test_sign_message_noms_known_vector() {
         let signer = NanoSigner;
+        
+        // Note: This is the final 32-byte Ed25519-blake2b private key.
+        // It is NOT a Nano Wallet "Seed". 
+        // Implementations treating this input as a Seed may erroneously perform a 
+        // derivation hash (e.g. `blake2b_256(seed || index)`) before expansion, 
+        // producing an entirely different keypair (like the 'nano_3iq5r...' address).
         let private_key = hex::decode("681FD5ED71A9F81E9D29E3450F6CD8AACB87346FD21A26003389290B9D0CB173").unwrap();
+        
+        // The exact corresponding 32-byte public key.
         let expected_pubkey = hex::decode("D2B3C9D00FFB55E84E7979D67308A515FB07CA79E40A77EB1AAFE62881781783").unwrap();
-        let message = b"Hej!";
-        let expected_signature = hex::decode("e347e2d2bc3fba0932bcf533997bdd4c4c6a217e5f5ee128470e0ced8a2450c182189322fd2eeeb354da50f14d2010e8bc9814824c490145013754cdff944806").unwrap();
+        
+        // The UTF-8 string with an emoji which gets domain-separated and hashed via NOMS before being signed.
+        let message = "Hej Nano! 🥦".as_bytes();
+        
+        // Expected ED25519-blake2b signature over the Blake2b-256 NOMS payload digest.
+        let expected_signature = hex::decode("be9e691f3bab829b440126c3492eee518c47a6555de4c00f1017874e7324bdfc1a2451cef59c8a011e03215df92fbc12b9d25c15d2808ca4665616a8c5350506").unwrap();
 
+        // The sign_message call expands the 32-byte key via Blake2b-512 and signs the hashed payload.
         let result = signer.sign_message(&private_key, message).unwrap();
 
+        // Verify the directly extracted public key matches our expected bytes.
         assert_eq!(result.public_key.unwrap(), expected_pubkey);
+        
+        // Verify the signature bytes match exactly.
         assert_eq!(result.signature, expected_signature);
+        
+        // Verify that encoding the 'nano_' address directly from this raw private key 
+        // correctly resolves to the expected address ('nano_3noms...').
         assert_eq!(signer.derive_address(&private_key).unwrap(), "nano_3noms9a1zytox399kygpge6cc7hu1z79ms1cgzojodz8741qi7w5u3nzb8mn");
     }
 

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -526,6 +526,20 @@ mod tests {
     }
 
     #[test]
+    fn test_sign_message_noms_known_vector() {
+        let signer = NanoSigner;
+        let private_key = hex::decode("681FD5ED71A9F81E9D29E3450F6CD8AACB87346FD21A26003389290B9D0CB173").unwrap();
+        let expected_pubkey = hex::decode("D2B3C9D00FFB55E84E7979D67308A515FB07CA79E40A77EB1AAFE62881781783").unwrap();
+        let message = b"Hej!";
+        let expected_signature = hex::decode("e347e2d2bc3fba0932bcf533997bdd4c4c6a217e5f5ee128470e0ced8a2450c182189322fd2eeeb354da50f14d2010e8bc9814824c490145013754cdff944806").unwrap();
+
+        let result = signer.sign_message(&private_key, message).unwrap();
+
+        assert_eq!(result.public_key.unwrap(), expected_pubkey);
+        assert_eq!(result.signature, expected_signature);
+    }
+
+    #[test]
     fn test_public_key_in_sign_output() {
         let key = derive_key(MNEMONIC_24, PASSPHRASE_24, "m/44'/165'/0'");
         let signer = NanoSigner;

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -570,6 +570,21 @@ mod tests {
     }
 
     #[test]
+    fn test_sign_message_noms_empty_string() {
+        let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
+        let signer = NanoSigner;
+
+        // Empty string should not panic on `u32::try_from` or `payload` construction.
+        let message = b"";
+        let result = signer.sign_message(&key, message);
+        assert!(result.is_ok());
+
+        // Validate signature output length manually
+        let sig_output = result.unwrap();
+        assert_eq!(sig_output.signature.len(), 64);
+    }
+
+    #[test]
     fn test_public_key_in_sign_output() {
         let key = derive_key(MNEMONIC_24, PASSPHRASE_24, "m/44'/165'/0'");
         let signer = NanoSigner;

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -512,8 +512,8 @@ mod tests {
 
         // Verify that the signed hash matches NOMS spec manually
         let mut expected_payload = Vec::new();
-        expected_payload.extend_from_slice(b"\x18Nano Off-chain Message:\n");
-        expected_payload.extend_from_slice(&(message.len() as u32).to_be_bytes());
+        expected_payload.extend_from_slice(super::NOMS_MAGIC_HEADER);
+        expected_payload.extend_from_slice(&(u32::try_from(message.len()).unwrap()).to_be_bytes());
         expected_payload.extend_from_slice(message);
 
         let mut hasher = Blake2b::<U32>::new();

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -540,10 +540,10 @@ mod tests {
         let expected_pubkey = hex::decode("D2B3C9D00FFB55E84E7979D67308A515FB07CA79E40A77EB1AAFE62881781783").unwrap();
         
         // The UTF-8 string with an emoji which gets domain-separated and hashed via NOMS before being signed.
-        let message = "Hej Nano! 🥦".as_bytes();
+        let message = "Hej Nano!🥦".as_bytes();
         
         // Expected ED25519-blake2b signature over the Blake2b-256 NOMS payload digest.
-        let expected_signature = hex::decode("be9e691f3bab829b440126c3492eee518c47a6555de4c00f1017874e7324bdfc1a2451cef59c8a011e03215df92fbc12b9d25c15d2808ca4665616a8c5350506").unwrap();
+        let expected_signature = hex::decode("535c745819d0f40056f3c46402b4fae4356b3a8897bde99c955d411920e740d781e6dddcbde228e8b86c4383a1003f9f315519ff73bd356f561d19865dc90f09").unwrap();
 
         // The sign_message call expands the 32-byte key via Blake2b-512 and signs the hashed payload.
         let result = signer.sign_message(&private_key, message).unwrap();

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -221,6 +221,9 @@ pub fn build_state_block(
 // NanoSigner
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// NOMS (Nano Off-chain Message Standard) magic header.
+const NOMS_MAGIC_HEADER: &[u8; 25] = b"\x18Nano Off-chain Message:\n";
+
 /// Nano chain signer (Ed25519 with blake2b-512).
 pub struct NanoSigner;
 
@@ -290,14 +293,23 @@ impl ChainSigner for NanoSigner {
 
     fn sign_message(
         &self,
-        _private_key: &[u8],
-        _message: &[u8],
+        private_key: &[u8],
+        message: &[u8],
     ) -> Result<SignOutput, SignerError> {
-        Err(SignerError::SigningFailed(
-            "Nano off-chain message signing is not supported: no canonical standard exists. \
-             Define an ecosystem convention before enabling this."
-                .into(),
-        ))
+        let msg_len = u32::try_from(message.len())
+            .map_err(|_| SignerError::InvalidMessage("message too large for NOMS".into()))?;
+
+        let mut payload = Vec::with_capacity(NOMS_MAGIC_HEADER.len() + 4 + message.len());
+        payload.extend_from_slice(NOMS_MAGIC_HEADER);
+        payload.extend_from_slice(&msg_len.to_be_bytes());
+        payload.extend_from_slice(message);
+
+        let mut hasher = Blake2b::<U32>::new();
+        hasher.update(&payload);
+        let mut message_hash = [0u8; 32];
+        message_hash.copy_from_slice(&hasher.finalize());
+
+        self.sign(private_key, &message_hash)
     }
 
     fn encode_signed_transaction(
@@ -485,16 +497,32 @@ mod tests {
     }
 
     #[test]
-    fn test_sign_message_unsupported() {
+    fn test_sign_message_noms() {
         let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
         let signer = NanoSigner;
         let message = b"hello nano";
-        let result = signer.sign_message(&key, message);
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Nano off-chain message signing is not supported"));
+        let result = signer.sign_message(&key, message).unwrap();
+
+        // Assert output format
+        assert_eq!(result.signature.len(), 64);
+        assert!(result.recovery_id.is_none());
+        assert!(result.public_key.is_some());
+
+        let vk = NanoSigner::verifying_key(&key).unwrap();
+
+        // Verify that the signed hash matches NOMS spec manually
+        let mut expected_payload = Vec::new();
+        expected_payload.extend_from_slice(b"\x18Nano Off-chain Message:\n");
+        expected_payload.extend_from_slice(&(message.len() as u32).to_be_bytes());
+        expected_payload.extend_from_slice(message);
+
+        let mut hasher = Blake2b::<U32>::new();
+        hasher.update(&expected_payload);
+        let mut expected_hash = [0u8; 32];
+        expected_hash.copy_from_slice(&hasher.finalize());
+
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        raw_verify::<Blake2b512>(&vk, &expected_hash, &sig).expect("should verify against NOMS payload hash");
     }
 
     #[test]

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -537,6 +537,7 @@ mod tests {
 
         assert_eq!(result.public_key.unwrap(), expected_pubkey);
         assert_eq!(result.signature, expected_signature);
+        assert_eq!(signer.derive_address(&private_key).unwrap(), "nano_3noms9a1zytox399kygpge6cc7hu1z79ms1cgzojodz8741qi7w5u3nzb8mn");
     }
 
     #[test]

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -312,6 +312,13 @@ impl ChainSigner for NanoSigner {
         let mut message_hash = [0u8; 32];
         message_hash.copy_from_slice(&hasher.finalize());
 
+        // Note on double-hashing:
+        // The NOMS spec dictates creating a 32-byte Blake2b-256 digest of the payload.
+        // We then pass this 32-byte digest to `self.sign()`, which internally applies
+        // Nano's Ed25519-blake2b signature scheme. That scheme computes a Blake2b-512
+        // hash over the scalar and the message (which in this case is the 32-byte digest).
+        // This effective `Blake2b-512(scalar || Blake2b-256(payload))` double-hash is
+        // intentional and precisely matches the ORIS-001 specification.
         self.sign(private_key, &message_hash)
     }
 


### PR DESCRIPTION
## Summary
Implement **Nano Off-chain Message Standard** to support the `sign_message` interface for the Nano (XNO) chain. 
Example CLI output:
  ```bash
  % cargo run -p ows-cli -- sign message --wallet test --message 'I am me.' --chain nano
  3de8620fb30967916d3dc36cd09eba9a633d1678b986fbc31b70ae2834db25a898085bbce32b744aef42ed56b5c001ffebd5516e78c9f22c678dde2d8bdc150a
```

### Implementation note
_Raw byte signing_ is deliberately unsupported for Nano off-chain messages in order to prevent protocol confusion between _block_ signatures and _general_ signatures; the "NOMS" specification implemented by the PR is designed precisely to _safely wrap_ off-chain text.

### What this means for OWS
The standard OWS `sign_message` & CLI behaves identically to other chains for the end-user while securely conforming to the domain-separated Nano standard internally!

## Technical notes
- Adheres strictly to the format set forward by [ORIS-001](https://github.com/OpenRai/Standards/blob/main/rfcs/ORIS-001.md), which serendipitously happens to comply with the guidelines proposed in PR #185 ...
- **No** new cryptographic dependencies — reuses `blake2` and `ed25519-dalek` (hazmat) from the original implementation.
- Handles padding boundaries, ensuring the maximum message length complies with the `uint32` specification before yielding a `SignerError` (a potential source of bugs otherwise).

## Testing
- Replaces the "unsupported" error-test with `test_sign_message_noms` 
- All workspace tests pass (`cargo test --workspace` 268 total tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cryptographic signing behavior for Nano CLI/API users; correctness depends on strict ORIS-001 compliance, mitigated by known test vectors.
> 
> **Overview**
> **Nano `sign_message` is implemented** using the ORIS-001 NOMS format instead of returning an unsupported error. Payloads are built from the fixed magic header, a big-endian `u32` length, and the message bytes; that blob is Blake2b-256 hashed, then signed with the existing Nano Ed25519-blake2b path (documented as intentional double-hash per the spec). Messages longer than `u32::MAX` fail with `InvalidMessage`.
> 
> Tests replace the old unsupported-error case with NOMS coverage: manual verify against the payload hash, a known vector (emoji message, pubkey, signature, address), and an empty message path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c2fa80b2c591ed8fa057960685deb58e0deeaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->