### PR TITLE
feat: add NEAR Protocol chain support (Ed25519 + Borsh + NEP-413)

### DIFF
--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -10,7 +10,7 @@ Local, policy-gated signing and wallet management for every chain.
 ## Why OWS
 
 - **Local key custody.** Private keys stay encrypted at rest and are decrypted only inside the OWS signing path after the relevant checks pass. Current implementations harden in-process memory handling and wipe key material after use.
-- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
+- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, NEAR — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
 - **Policy before signing.** A pre-signing policy engine gates agent (API key) operations before decryption — chain allowlists, expiry, and optional custom executables.
 - **Built for agents.** Native SDK and CLI today. A wallet created by one tool works in every other.
 
@@ -31,7 +31,7 @@ Using viem, `@solana/web3.js`, or the Tether WDK? Install [`@open-wallet-standar
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("agent-treasury");
-// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 const sig = signMessage("agent-treasury", "evm", "hello");
 console.log(sig.signature);
@@ -64,6 +64,7 @@ ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
 | XRPL | secp256k1 | Base58Check (`r...`) | `m/44'/144'/0'/0/0` |
 | Spark (Bitcoin L2) | secp256k1 | spark: prefixed | `m/84'/0'/0'/0/0` |
 | Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
+| NEAR | Ed25519 | implicit hex (64 chars) | `m/44'/397'/0'` |
 
 ## CLI Reference
 

--- a/bindings/node/__test__/index.spec.mjs
+++ b/bindings/node/__test__/index.spec.mjs
@@ -54,7 +54,7 @@ describe('@open-wallet-standard/core', () => {
 
   it('derives addresses for all chains', () => {
     const phrase = generateMnemonic(12);
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano']) {
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano', 'near']) {
       const addr = deriveAddress(phrase, chain);
       assert.ok(addr.length > 0, `address should be non-empty for ${chain}`);
     }
@@ -62,10 +62,10 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Universal wallet lifecycle ----
 
-  it('creates a universal wallet with 10 accounts', () => {
+  it('creates a universal wallet with 12 accounts', () => {
     const wallet = createWallet('lifecycle-test', undefined, 12, vaultDir);
     assert.equal(wallet.name, 'lifecycle-test');
-    assert.equal(wallet.accounts.length, 10);
+    assert.equal(wallet.accounts.length, 12);
 
     const chainIds = wallet.accounts.map((a) => a.chainId);
     assert.ok(chainIds.some((c) => c.startsWith('eip155:')));
@@ -75,9 +75,11 @@ describe('@open-wallet-standard/core', () => {
     assert.ok(chainIds.some((c) => c.startsWith('cosmos:')));
     assert.ok(chainIds.some((c) => c.startsWith('tron:')));
     assert.ok(chainIds.some((c) => c.startsWith('ton:')));
+    assert.ok(chainIds.some((c) => c.startsWith('spark:')));
     assert.ok(chainIds.some((c) => c.startsWith('fil:')));
     assert.ok(chainIds.some((c) => c.startsWith('xrpl:')));
     assert.ok(chainIds.some((c) => c.startsWith('nano:')));
+    assert.ok(chainIds.some((c) => c.startsWith('near:')));
 
     // List
     const wallets = listWallets(vaultDir);
@@ -111,7 +113,7 @@ describe('@open-wallet-standard/core', () => {
 
     const wallet = importWalletMnemonic('mn-import', phrase, undefined, undefined, vaultDir);
     assert.equal(wallet.name, 'mn-import');
-    assert.equal(wallet.accounts.length, 10);
+    assert.equal(wallet.accounts.length, 12);
 
     const evmAcct = wallet.accounts.find((a) => a.chainId.startsWith('eip155:'));
     assert.equal(evmAcct.address, expectedEvm);
@@ -124,12 +126,12 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Private key import (secp256k1) ----
 
-  it('imports a secp256k1 private key with all 10 accounts', () => {
+  it('imports a secp256k1 private key with all 12 accounts', () => {
     const privkey = '4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318';
     const wallet = importWalletPrivateKey('pk-secp', privkey, undefined, vaultDir, 'evm');
 
     assert.equal(wallet.name, 'pk-secp');
-    assert.equal(wallet.accounts.length, 10, 'should have all 10 chain accounts');
+    assert.equal(wallet.accounts.length, 12, 'should have all 12 chain accounts');
 
     // Sign on EVM (provided key's curve)
     const evmSig = signMessage('pk-secp', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
@@ -149,11 +151,11 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Private key import (ed25519) ----
 
-  it('imports an ed25519 private key with all 10 accounts', () => {
+  it('imports an ed25519 private key with all 12 accounts', () => {
     const privkey = '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60';
     const wallet = importWalletPrivateKey('pk-ed', privkey, undefined, vaultDir, 'solana');
 
-    assert.equal(wallet.accounts.length, 10);
+    assert.equal(wallet.accounts.length, 12);
 
     // Sign on Solana (provided key)
     const solSig = signMessage('pk-ed', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
@@ -181,7 +183,7 @@ describe('@open-wallet-standard/core', () => {
     );
 
     assert.equal(wallet.name, 'pk-both');
-    assert.equal(wallet.accounts.length, 10, 'should have all 10 chain accounts');
+    assert.equal(wallet.accounts.length, 12, 'should have all 12 chain accounts');
 
     // Sign on EVM (secp256k1 key)
     const evmSig = signMessage('pk-both', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
@@ -206,7 +208,8 @@ describe('@open-wallet-standard/core', () => {
 
     // XRPL and Nano are excluded here because their signers explicitly do not
     // support generic off-chain message signing without a defined convention.
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin']) {
+    // NEAR's V1 sign_message is raw ed25519 over the bytes (NEP-413 is a follow-up).
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'near']) {
       const result = signMessage('all-chain-signer', chain, 'test', undefined, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);
     }
@@ -232,12 +235,17 @@ describe('@open-wallet-standard/core', () => {
       '00000000033b2e3c9fd0803ce8000000' +
       `${'03'.repeat(32)}`;
 
+    // NEAR transactions have no envelope; signer hashes via sha256 then ed25519
+    // signs the digest. Any non-empty bytes verify the signing pipeline.
+    const nearTxHex = '42'.repeat(80);
+
     const txHexByChain = {
       solana: solTxHex,
       nano: nanoTxHex,
+      near: nearTxHex,
     };
 
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano']) {
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano', 'near']) {
       const hex = txHexByChain[chain] ?? txHex;
       const result = signTransaction('tx-signer', chain, hex, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -10,7 +10,7 @@ Local, policy-gated signing and wallet management for every chain.
 ## Why OWS
 
 - **Local key custody.** Private keys stay encrypted at rest and are decrypted only inside the OWS signing path after the relevant checks pass. Current implementations harden in-process memory handling and wipe key material after use.
-- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
+- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, NEAR — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
 - **Policy before signing.** A pre-signing policy engine gates agent (API key) operations before decryption — chain allowlists, expiry, and optional custom executables.
 - **Built for agents.** Native SDK and CLI today. A wallet created by one tool works in every other.
 
@@ -28,7 +28,7 @@ The package is **fully self-contained** — it embeds the Rust core via native F
 from ows import create_wallet, sign_message
 
 wallet = create_wallet("agent-treasury")
-# => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+# => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 sig = sign_message("agent-treasury", "evm", "hello")
 print(sig["signature"])
@@ -76,6 +76,7 @@ print(sig["signature"])
 | XRPL | secp256k1 | Base58Check (`r...`) | `m/44'/144'/0'/0/0` |
 | Spark (Bitcoin L2) | secp256k1 | spark: prefixed | `m/84'/0'/0'/0/0` |
 | Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
+| NEAR | Ed25519 | implicit hex (64 chars) | `m/44'/397'/0'` |
 
 ## Architecture
 

--- a/bindings/python/tests/test_bindings.py
+++ b/bindings/python/tests/test_bindings.py
@@ -40,7 +40,7 @@ def test_derive_address_ethereum():
 
 def test_derive_address_all_supported_chains():
     phrase = ows.generate_mnemonic(12)
-    for chain in ["evm", "solana", "sui", "bitcoin", "cosmos", "tron", "ton", "filecoin", "nano"]:
+    for chain in ["evm", "solana", "sui", "bitcoin", "cosmos", "tron", "ton", "filecoin", "xrpl", "nano", "near"]:
         address = ows.derive_address(phrase, chain)
         assert len(address) > 0
 
@@ -49,7 +49,7 @@ def test_create_and_list_wallets(vault_dir):
     wallet = ows.create_wallet("test-wallet", vault_path_opt=vault_dir)
     assert wallet["name"] == "test-wallet"
     assert isinstance(wallet["accounts"], list)
-    assert len(wallet["accounts"]) == 10
+    assert len(wallet["accounts"]) == 12
 
     # Verify each chain family is present
     chain_ids = [a["chain_id"] for a in wallet["accounts"]]
@@ -60,9 +60,11 @@ def test_create_and_list_wallets(vault_dir):
     assert any(c.startswith("cosmos:") for c in chain_ids)
     assert any(c.startswith("tron:") for c in chain_ids)
     assert any(c.startswith("ton:") for c in chain_ids)
+    assert any(c.startswith("spark:") for c in chain_ids)
     assert any(c.startswith("fil:") for c in chain_ids)
     assert any(c.startswith("xrpl:") for c in chain_ids)
     assert any(c.startswith("nano:") for c in chain_ids)
+    assert any(c.startswith("near:") for c in chain_ids)
 
     wallets = ows.list_wallets(vault_path_opt=vault_dir)
     assert len(wallets) == 1
@@ -109,7 +111,7 @@ def test_import_wallet_mnemonic(vault_dir):
         "imported", phrase, vault_path_opt=vault_dir
     )
     assert wallet["name"] == "imported"
-    assert len(wallet["accounts"]) == 10
+    assert len(wallet["accounts"]) == 12
 
     # EVM account should match derived address
     evm_account = next(a for a in wallet["accounts"] if a["chain_id"].startswith("eip155:"))

--- a/docs/02-signing-interface.md
+++ b/docs/02-signing-interface.md
@@ -80,6 +80,7 @@ Message signing follows chain-specific conventions:
 - **Sui**: Intent-prefixed (scope=3) BLAKE2b-256 digest, Ed25519 signature
 - **Cosmos**: ADR-036 off-chain signing
 - **Filecoin**: Blake2b-256 hash then secp256k1 signing
+- **NEAR**: V1 Ed25519 signature over the raw message bytes (parity with Solana). [NEP-413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md) prefixed message signing — `tag 2147484061 || borsh({message, nonce, recipient, callbackUrl?})` — is tracked as a follow-up so callers can opt in via a structured payload. Transaction signing is `Ed25519(SHA-256(borsh(Transaction)))`; `encode_signed_transaction` returns `borsh(Transaction) || 0x00 || sig64` (the canonical `borsh(SignedTransaction)`).
 
 ### `signTypedData(request: SignTypedDataRequest): Promise<SignMessageResult>`
 

--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -39,6 +39,7 @@ OWS groups chains into families that share a cryptographic curve and address der
 | XRPL | secp256k1 | 144 | `m/44'/144'/0'/0/{index}` | Base58Check (`r...`) | `xrpl` |
 | Spark | secp256k1 | 8797555 | `m/84'/0'/0'/0/{index}` | `spark:` + compressed pubkey hex | `spark` |
 | Filecoin | secp256k1 | 461 | `m/44'/461'/0'/0/{index}` | `f1` + base32(blake2b-160) | `fil` |
+| NEAR | ed25519 | 397 | `m/44'/397'/{index}'` | 64-char lowercase hex of pubkey (implicit account) | `near` |
 
 ## Known Networks
 
@@ -73,6 +74,8 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | XRPL | `xrpl:mainnet` |
 | Spark | `spark:mainnet` |
 | Filecoin | `fil:mainnet` |
+| NEAR | `near:mainnet` |
+| NEAR (testnet) | `near:testnet` |
 
 Implementations MAY ship convenience endpoint defaults, but those defaults are deployment choices rather than OWS interoperability requirements.
 
@@ -104,6 +107,8 @@ xrpl-testnet  → xrpl:testnet
 xrpl-devnet   → xrpl:devnet
 spark     → spark:mainnet
 filecoin  → fil:mainnet
+near          → near:mainnet
+near-testnet  → near:testnet
 ```
 
 Aliases MUST be resolved to full CAIP-2 identifiers before any processing. They MUST NOT appear in wallet files, policy files, or audit logs.
@@ -127,7 +132,8 @@ Master Seed (512 bits via PBKDF2)
     ├── m/44'/784'/0'/0'/0' → Sui Account 0
     ├── m/44'/144'/0'/0/0   → XRPL Account 0
     ├── m/84'/0'/0'/0/0     → Spark Account 0
-    └── m/44'/461'/0'/0/0   → Filecoin Account 0
+    ├── m/44'/461'/0'/0/0   → Filecoin Account 0
+    └── m/44'/397'/0'       → NEAR Account 0
 ```
 
 For mnemonic-based wallets, a single mnemonic derives accounts across all supported chains. Those wallet files store the encrypted mnemonic, and the signer derives the appropriate private key using each chain's coin type and derivation path. Wallets imported from raw private keys instead store encrypted curve-key material directly.

--- a/ows/README.md
+++ b/ows/README.md
@@ -57,7 +57,7 @@ The bindings are **standalone** — they embed the Rust core via native FFI. No 
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("my-wallet");
-console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 const sig = signMessage("my-wallet", "evm", "hello");
 console.log(sig.signature);
@@ -68,7 +68,7 @@ console.log(sig.signature);
 | Crate | Description |
 |-------|-------------|
 | `ows-core` | Types, CAIP-2/10 parsing, errors, config. Zero crypto dependencies. |
-| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin. |
+| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, and NEAR. |
 | `ows-lib` | Library interface used by language bindings and the CLI. |
 | `ows-pay` | x402 payment flows, service discovery, and funding helpers. |
 | `ows-cli` | The `ows` command-line tool. |
@@ -85,6 +85,7 @@ console.log(sig.signature);
 - **Spark** (Bitcoin L2) — secp256k1, spark: prefixed addresses
 - **XRPL** — secp256k1, Base58Check r-addresses
 - **Filecoin** — secp256k1, f1 base32 addresses
+- **NEAR** — Ed25519, implicit hex (64 chars), Borsh-serialized transactions
 
 ## License
 

--- a/ows/crates/ows-cli/README.md
+++ b/ows/crates/ows-cli/README.md
@@ -57,7 +57,7 @@ The bindings are **standalone** — they embed the Rust core via native FFI. No 
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("my-wallet");
-console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 const sig = signMessage("my-wallet", "evm", "hello");
 console.log(sig.signature);
@@ -68,7 +68,7 @@ console.log(sig.signature);
 | Crate | Description |
 |-------|-------------|
 | `ows-core` | Types, CAIP-2/10 parsing, errors, config. Zero crypto dependencies. |
-| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin. |
+| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, and NEAR. |
 | `ows-lib` | Library interface used by language bindings and the CLI. |
 | `ows-pay` | x402 payment flows, service discovery, and funding helpers. |
 | `ows-cli` | The `ows` command-line tool. |
@@ -85,6 +85,7 @@ console.log(sig.signature);
 - **Spark** (Bitcoin L2) — secp256k1, spark: prefixed addresses
 - **XRPL** — secp256k1, Base58Check r-addresses
 - **Filecoin** — secp256k1, f1 base32 addresses
+- **NEAR** — Ed25519, implicit hex (64 chars), Borsh-serialized transactions
 
 ## License
 

--- a/ows/crates/ows-core/README.md
+++ b/ows/crates/ows-core/README.md
@@ -57,7 +57,7 @@ The bindings are **standalone** — they embed the Rust core via native FFI. No 
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("my-wallet");
-console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 const sig = signMessage("my-wallet", "evm", "hello");
 console.log(sig.signature);
@@ -68,7 +68,7 @@ console.log(sig.signature);
 | Crate | Description |
 |-------|-------------|
 | `ows-core` | Types, CAIP-2/10 parsing, errors, config. Zero crypto dependencies. |
-| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin. |
+| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, and NEAR. |
 | `ows-lib` | Library interface used by language bindings and the CLI. |
 | `ows-pay` | x402 payment flows, service discovery, and funding helpers. |
 | `ows-cli` | The `ows` command-line tool. |
@@ -85,6 +85,7 @@ console.log(sig.signature);
 - **Spark** (Bitcoin L2) — secp256k1, spark: prefixed addresses
 - **XRPL** — secp256k1, Base58Check r-addresses
 - **Filecoin** — secp256k1, f1 base32 addresses
+- **NEAR** — Ed25519, implicit hex (64 chars), Borsh-serialized transactions
 
 ## License
 

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -17,20 +17,23 @@ pub enum ChainType {
     Sui,
     Xrpl,
     Nano,
+    Near,
 }
 
 /// All supported chain families, used for universal wallet derivation.
-pub const ALL_CHAIN_TYPES: [ChainType; 10] = [
+pub const ALL_CHAIN_TYPES: [ChainType; 12] = [
     ChainType::Evm,
     ChainType::Solana,
     ChainType::Bitcoin,
     ChainType::Cosmos,
     ChainType::Tron,
     ChainType::Ton,
+    ChainType::Spark,
     ChainType::Filecoin,
     ChainType::Sui,
     ChainType::Xrpl,
     ChainType::Nano,
+    ChainType::Near,
 ];
 
 /// A specific chain (e.g. "ethereum", "arbitrum") with its family type and CAIP-2 ID.
@@ -181,6 +184,16 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_id: "nano:mainnet",
     },
     Chain {
+        name: "near",
+        chain_type: ChainType::Near,
+        chain_id: "near:mainnet",
+    },
+    Chain {
+        name: "near-testnet",
+        chain_type: ChainType::Near,
+        chain_id: "near:testnet",
+    },
+    Chain {
         name: "tempo",
         chain_type: ChainType::Evm,
         chain_id: "eip155:4217",
@@ -254,7 +267,7 @@ pub fn parse_chain(s: &str) -> Result<Chain, String> {
            EVM:     ethereum, base, arbitrum, optimism, polygon, bsc, avalanche, plasma, etherlink\n  \
            Solana:  solana\n  \
            Bitcoin: bitcoin\n  \
-           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl, nano\n\n\
+           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl, nano, near\n\n\
          Or use a CAIP-2 ID (eip155:8453) or bare EVM chain ID (8453)"
     ))
 }
@@ -279,6 +292,7 @@ impl ChainType {
             ChainType::Sui => "sui",
             ChainType::Xrpl => "xrpl",
             ChainType::Nano => "nano",
+            ChainType::Near => "near",
         }
     }
 
@@ -296,6 +310,7 @@ impl ChainType {
             ChainType::Sui => 784,
             ChainType::Xrpl => 144,
             ChainType::Nano => 165,
+            ChainType::Near => 397,
         }
     }
 
@@ -313,6 +328,7 @@ impl ChainType {
             "sui" => Some(ChainType::Sui),
             "xrpl" => Some(ChainType::Xrpl),
             "nano" => Some(ChainType::Nano),
+            "near" => Some(ChainType::Near),
             _ => None,
         }
     }
@@ -332,6 +348,7 @@ impl fmt::Display for ChainType {
             ChainType::Sui => "sui",
             ChainType::Xrpl => "xrpl",
             ChainType::Nano => "nano",
+            ChainType::Near => "near",
         };
         write!(f, "{}", s)
     }
@@ -353,6 +370,7 @@ impl FromStr for ChainType {
             "sui" => Ok(ChainType::Sui),
             "xrpl" => Ok(ChainType::Xrpl),
             "nano" => Ok(ChainType::Nano),
+            "near" => Ok(ChainType::Near),
             _ => Err(format!("unknown chain type: {}", s)),
         }
     }
@@ -385,6 +403,7 @@ mod tests {
             (ChainType::Sui, "\"sui\""),
             (ChainType::Xrpl, "\"xrpl\""),
             (ChainType::Nano, "\"nano\""),
+            (ChainType::Near, "\"near\""),
         ] {
             let json = serde_json::to_string(&chain).unwrap();
             assert_eq!(json, expected);
@@ -406,6 +425,7 @@ mod tests {
         assert_eq!(ChainType::Sui.namespace(), "sui");
         assert_eq!(ChainType::Xrpl.namespace(), "xrpl");
         assert_eq!(ChainType::Nano.namespace(), "nano");
+        assert_eq!(ChainType::Near.namespace(), "near");
     }
 
     #[test]
@@ -421,6 +441,7 @@ mod tests {
         assert_eq!(ChainType::Sui.default_coin_type(), 784);
         assert_eq!(ChainType::Xrpl.default_coin_type(), 144);
         assert_eq!(ChainType::Nano.default_coin_type(), 165);
+        assert_eq!(ChainType::Near.default_coin_type(), 397);
     }
 
     #[test]
@@ -439,6 +460,7 @@ mod tests {
         assert_eq!(ChainType::from_namespace("sui"), Some(ChainType::Sui));
         assert_eq!(ChainType::from_namespace("xrpl"), Some(ChainType::Xrpl));
         assert_eq!(ChainType::from_namespace("nano"), Some(ChainType::Nano));
+        assert_eq!(ChainType::from_namespace("near"), Some(ChainType::Near));
         assert_eq!(ChainType::from_namespace("unknown"), None);
     }
 
@@ -619,7 +641,24 @@ mod tests {
 
     #[test]
     fn test_all_chain_types() {
-        assert_eq!(ALL_CHAIN_TYPES.len(), 10);
+        assert_eq!(ALL_CHAIN_TYPES.len(), 12);
+    }
+
+    #[test]
+    fn test_parse_chain_near() {
+        let chain = parse_chain("near").unwrap();
+        assert_eq!(chain.name, "near");
+        assert_eq!(chain.chain_type, ChainType::Near);
+        assert_eq!(chain.chain_id, "near:mainnet");
+
+        let testnet = parse_chain("near-testnet").unwrap();
+        assert_eq!(testnet.chain_type, ChainType::Near);
+        assert_eq!(testnet.chain_id, "near:testnet");
+
+        // CAIP-2 IDs accepted directly
+        let via_caip2 = parse_chain("near:testnet").unwrap();
+        assert_eq!(via_caip2.chain_type, ChainType::Near);
+        assert_eq!(via_caip2.chain_id, "near:testnet");
     }
 
     #[test]

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -74,6 +74,8 @@ impl Config {
             "https://s.devnet.rippletest.net:51234".into(),
         );
         rpc.insert("nano:mainnet".into(), "https://rpc.nano.to".into());
+        rpc.insert("near:mainnet".into(), "https://rpc.mainnet.near.org".into());
+        rpc.insert("near:testnet".into(), "https://rpc.testnet.near.org".into());
         rpc.insert("eip155:4217".into(), "https://rpc.tempo.xyz".into());
         rpc.insert(
             "eip155:999".into(),
@@ -264,8 +266,16 @@ mod tests {
     fn test_load_or_default_nonexistent() {
         let config = Config::load_or_default_from(std::path::Path::new("/nonexistent/config.json"));
         // Should have all default RPCs
-        assert_eq!(config.rpc.len(), 21);
+        assert_eq!(config.rpc.len(), 23);
         assert_eq!(config.rpc_url("eip155:1"), Some("https://eth.llamarpc.com"));
+        assert_eq!(
+            config.rpc_url("near:mainnet"),
+            Some("https://rpc.mainnet.near.org")
+        );
+        assert_eq!(
+            config.rpc_url("near:testnet"),
+            Some("https://rpc.testnet.near.org")
+        );
     }
 
     #[test]

--- a/ows/crates/ows-lib/README.md
+++ b/ows/crates/ows-lib/README.md
@@ -57,7 +57,7 @@ The bindings are **standalone** — they embed the Rust core via native FFI. No 
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("my-wallet");
-console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 const sig = signMessage("my-wallet", "evm", "hello");
 console.log(sig.signature);
@@ -68,7 +68,7 @@ console.log(sig.signature);
 | Crate | Description |
 |-------|-------------|
 | `ows-core` | Types, CAIP-2/10 parsing, errors, config. Zero crypto dependencies. |
-| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin. |
+| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, and NEAR. |
 | `ows-lib` | Library interface used by language bindings and the CLI. |
 | `ows-pay` | x402 payment flows, service discovery, and funding helpers. |
 | `ows-cli` | The `ows` command-line tool. |
@@ -85,6 +85,7 @@ console.log(sig.signature);
 - **Spark** (Bitcoin L2) — secp256k1, spark: prefixed addresses
 - **XRPL** — secp256k1, Base58Check r-addresses
 - **Filecoin** — secp256k1, f1 base32 addresses
+- **NEAR** — Ed25519, implicit hex (64 chars), Borsh-serialized transactions
 
 ## License
 

--- a/ows/crates/ows-lib/src/lib.rs
+++ b/ows/crates/ows-lib/src/lib.rs
@@ -3,6 +3,7 @@ pub mod key_ops;
 pub mod key_store;
 pub mod migrate;
 pub mod nano_rpc;
+pub mod near_rpc;
 pub mod ops;
 pub mod policy_engine;
 pub mod policy_store;

--- a/ows/crates/ows-lib/src/near_rpc.rs
+++ b/ows/crates/ows-lib/src/near_rpc.rs
@@ -1,0 +1,111 @@
+//! NEAR Protocol RPC helpers (`broadcast_tx_commit`).
+//!
+//! Uses `curl` for HTTP, consistent with the rest of ows-lib (no added HTTP deps).
+//!
+//! See <https://docs.near.org/api/rpc/transactions> for the full RPC surface.
+
+use crate::error::OwsLibError;
+use base64::Engine;
+use std::process::Command;
+
+/// Call a NEAR JSON-RPC method via curl and return the parsed JSON response.
+fn near_rpc_call(
+    rpc_url: &str,
+    body: &serde_json::Value,
+) -> Result<serde_json::Value, OwsLibError> {
+    let body_str = body.to_string();
+    let output = Command::new("curl")
+        .args([
+            "-fsSL",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            &body_str,
+            rpc_url,
+        ])
+        .output()
+        .map_err(|e| OwsLibError::BroadcastFailed(format!("failed to run curl: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(OwsLibError::BroadcastFailed(format!(
+            "NEAR RPC call failed: {stderr}"
+        )));
+    }
+
+    let resp_str = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&resp_str)?;
+
+    // JSON-RPC error envelope.
+    if let Some(error) = parsed.get("error") {
+        let msg = error
+            .get("data")
+            .and_then(|d| d.as_str())
+            .or_else(|| error.get("message").and_then(|m| m.as_str()))
+            .or_else(|| error.as_str())
+            .unwrap_or("unknown error");
+        return Err(OwsLibError::BroadcastFailed(format!(
+            "NEAR RPC error: {msg}"
+        )));
+    }
+
+    Ok(parsed)
+}
+
+/// Broadcast a signed NEAR transaction via `broadcast_tx_commit` and return the
+/// transaction hash on success.
+///
+/// `signed_bytes` MUST be the canonical Borsh-encoded `SignedTransaction` —
+/// i.e. the output of `NearSigner::encode_signed_transaction`.
+///
+/// `broadcast_tx_commit` waits for the transaction to be included on-chain and
+/// returns the resulting `transaction.hash`. For fire-and-forget semantics,
+/// callers can switch to `broadcast_tx_async` (not exposed here).
+pub fn broadcast_tx_commit(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibError> {
+    let signed_b64 = base64::engine::general_purpose::STANDARD.encode(signed_bytes);
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "ows",
+        "method": "broadcast_tx_commit",
+        "params": [signed_b64]
+    });
+
+    let resp = near_rpc_call(rpc_url, &body)?;
+
+    // Do NOT embed the raw `resp` JSON in the error message: it contains
+    // operational data (transaction details, account identifiers) that
+    // shouldn't leak through the error's `Display` output to logs/UI.
+    let hash = resp
+        .pointer("/result/transaction/hash")
+        .and_then(|h| h.as_str())
+        .or_else(|| {
+            resp.pointer("/result/transaction_outcome/id")
+                .and_then(|h| h.as_str())
+        })
+        .ok_or_else(|| {
+            OwsLibError::BroadcastFailed(
+                "broadcast_tx_commit response missing transaction hash".into(),
+            )
+        })?
+        .to_string();
+
+    Ok(hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_broadcast_body_shape() {
+        // Sanity check the JSON-RPC envelope shape we send. We do not actually
+        // hit the network here; we only verify base64 encoding is applied
+        // correctly to known bytes.
+        let signed = b"\x00\x01\x02\x03";
+        let b64 = base64::engine::general_purpose::STANDARD.encode(signed);
+        assert_eq!(b64, "AAECAw==");
+    }
+}

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -819,6 +819,7 @@ fn broadcast(chain: ChainType, rpc_url: &str, signed_bytes: &[u8]) -> Result<Str
         ChainType::Sui => broadcast_sui(rpc_url, signed_bytes),
         ChainType::Xrpl => broadcast_xrpl(rpc_url, signed_bytes),
         ChainType::Nano => broadcast_nano(rpc_url, signed_bytes),
+        ChainType::Near => crate::near_rpc::broadcast_tx_commit(rpc_url, signed_bytes),
     }
 }
 
@@ -1181,7 +1182,7 @@ mod tests {
     fn derive_address_all_chains() {
         let phrase = generate_mnemonic(12).unwrap();
         let chains = [
-            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "sui", "xrpl",
+            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "sui", "xrpl", "nano", "near",
         ];
         for chain in &chains {
             let addr = derive_address(&phrase, chain, None).unwrap();
@@ -1262,8 +1263,11 @@ mod tests {
         let vault = dir.path();
         create_wallet("multi-sign", None, None, Some(vault)).unwrap();
 
+        // XRPL and Nano are excluded because their signers explicitly do not
+        // support generic off-chain message signing without a defined convention.
+        // NEAR's V1 sign_message is raw ed25519 (NEP-413 follow-up tracked).
         let chains = [
-            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui",
+            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "near",
         ];
         for chain in &chains {
             let result = sign_message(
@@ -1302,12 +1306,19 @@ mod tests {
         solana_tx.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]); // message payload
         let solana_tx_hex = hex::encode(&solana_tx);
 
+        // NEAR transactions have no envelope; the borsh-encoded Transaction
+        // bytes ARE the signable payload. Any non-empty bytes exercise the
+        // sha256 -> ed25519 pipeline.
+        let near_tx_hex = "42".repeat(80);
+
         let chains = [
-            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "xrpl",
+            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "xrpl", "near",
         ];
         for chain in &chains {
             let tx = if *chain == "solana" {
                 &solana_tx_hex
+            } else if *chain == "near" {
+                &near_tx_hex
             } else {
                 generic_tx_hex
             };

--- a/ows/crates/ows-pay/src/discovery.rs
+++ b/ows/crates/ows-pay/src/discovery.rs
@@ -206,6 +206,7 @@ pub(crate) fn format_price(amount_str: &str, network: &str) -> String {
     let chain_type = crate::chains::resolve_chain_type(network);
     match chain_type {
         Some(ows_core::ChainType::Nano) => format_nano(amount_str),
+        Some(ows_core::ChainType::Near) => format_near(amount_str),
         _ => format_usdc(amount_str),
     }
 }
@@ -231,6 +232,21 @@ pub(crate) fn format_nano(amount_str: &str) -> String {
         let frac_str = format!("{frac:030}");
         let trimmed = frac_str.trim_end_matches('0');
         format!("{whole}.{trimmed} XNO")
+    }
+}
+
+/// Format a NEAR amount expressed in yoctoNEAR (10^24 yoctoNEAR per NEAR).
+pub(crate) fn format_near(amount_str: &str) -> String {
+    let amount: u128 = amount_str.parse().unwrap_or(0);
+    let divisor = 1_000_000_000_000_000_000_000_000u128; // 10^24
+    let whole = amount / divisor;
+    let frac = amount % divisor;
+    if frac == 0 {
+        format!("{whole} NEAR")
+    } else {
+        let frac_str = format!("{frac:024}");
+        let trimmed = frac_str.trim_end_matches('0');
+        format!("{whole}.{trimmed} NEAR")
     }
 }
 
@@ -325,6 +341,48 @@ mod tests {
             format_price("1000000000000000000000000000000", "nano:mainnet"),
             "1 XNO"
         );
+        assert_eq!(
+            format_price("1000000000000000000000000", "near:mainnet"),
+            "1 NEAR"
+        );
+        assert_eq!(format_price("1000000000000000000000000", "near"), "1 NEAR");
+    }
+
+    // -----------------------------------------------------------------------
+    // format_near
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_near_whole() {
+        // 1 NEAR = 10^24 yoctoNEAR
+        assert_eq!(format_near("1000000000000000000000000"), "1 NEAR");
+    }
+
+    #[test]
+    fn format_near_fractional() {
+        assert_eq!(format_near("1500000000000000000000000"), "1.5 NEAR");
+    }
+
+    #[test]
+    fn format_near_zero() {
+        assert_eq!(format_near("0"), "0 NEAR");
+    }
+
+    #[test]
+    fn format_near_one_yocto() {
+        // Smallest unit: 1 yoctoNEAR (10^-24 NEAR).
+        assert_eq!(format_near("1"), "0.000000000000000000000001 NEAR");
+    }
+
+    #[test]
+    fn format_near_storage_deposit() {
+        // 0.00125 NEAR (typical NEP-141 storage deposit).
+        assert_eq!(format_near("1250000000000000000000"), "0.00125 NEAR");
+    }
+
+    #[test]
+    fn format_near_non_numeric() {
+        assert_eq!(format_near("abc"), "0 NEAR");
     }
 
     // -----------------------------------------------------------------------

--- a/ows/crates/ows-signer/README.md
+++ b/ows/crates/ows-signer/README.md
@@ -57,7 +57,7 @@ The bindings are **standalone** — they embed the Rust core via native FFI. No 
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("my-wallet");
-console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 const sig = signMessage("my-wallet", "evm", "hello");
 console.log(sig.signature);
@@ -68,7 +68,7 @@ console.log(sig.signature);
 | Crate | Description |
 |-------|-------------|
 | `ows-core` | Types, CAIP-2/10 parsing, errors, config. Zero crypto dependencies. |
-| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin. |
+| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, and NEAR. |
 | `ows-lib` | Library interface used by language bindings and the CLI. |
 | `ows-pay` | x402 payment flows, service discovery, and funding helpers. |
 | `ows-cli` | The `ows` command-line tool. |
@@ -85,6 +85,7 @@ console.log(sig.signature);
 - **Spark** (Bitcoin L2) — secp256k1, spark: prefixed addresses
 - **XRPL** — secp256k1, Base58Check r-addresses
 - **Filecoin** — secp256k1, f1 base32 addresses
+- **NEAR** — Ed25519, implicit hex (64 chars), Borsh-serialized transactions
 
 ## License
 

--- a/ows/crates/ows-signer/src/chains/mod.rs
+++ b/ows/crates/ows-signer/src/chains/mod.rs
@@ -3,6 +3,7 @@ pub mod cosmos;
 pub mod evm;
 pub mod filecoin;
 pub mod nano;
+pub mod near;
 pub mod solana;
 pub mod spark;
 pub mod sui;
@@ -15,6 +16,7 @@ pub use self::cosmos::CosmosSigner;
 pub use self::evm::EvmSigner;
 pub use self::filecoin::FilecoinSigner;
 pub use self::nano::NanoSigner;
+pub use self::near::NearSigner;
 pub use self::solana::SolanaSigner;
 pub use self::spark::SparkSigner;
 pub use self::sui::SuiSigner;
@@ -39,5 +41,6 @@ pub fn signer_for_chain(chain: ChainType) -> Box<dyn ChainSigner> {
         ChainType::Sui => Box::new(SuiSigner),
         ChainType::Xrpl => Box::new(XrplSigner),
         ChainType::Nano => Box::new(NanoSigner),
+        ChainType::Near => Box::new(NearSigner),
     }
 }

--- a/ows/crates/ows-signer/src/chains/near.rs
+++ b/ows/crates/ows-signer/src/chains/near.rs
@@ -1,0 +1,383 @@
+use crate::curve::Curve;
+use crate::traits::{ChainSigner, SignOutput, SignerError};
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use ows_core::ChainType;
+use sha2::{Digest, Sha256};
+
+/// NEAR Protocol chain signer (Ed25519 over Borsh-serialized transactions).
+///
+/// # Wire format
+///
+/// NEAR uses [Borsh](https://borsh.io/) for canonical, deterministic transaction
+/// serialization. The signature is computed over `sha256(borsh(Transaction))`
+/// and the final `SignedTransaction` is `borsh(Transaction) || borsh(Signature)`,
+/// where `Signature` is an enum with discriminant `0x00` (ED25519) followed by
+/// the 64-byte signature.
+///
+/// # Address format
+///
+/// `derive_address` returns the NEAR **implicit account ID**: the lowercase hex
+/// encoding of the 32-byte ed25519 public key (64 chars, no `0x` prefix).
+/// Named accounts (e.g. `alice.near`) require on-chain registration and are out
+/// of scope for a stateless signer.
+///
+/// # Network binding
+///
+/// The signer is genesis-agnostic. Network binding is carried inside the
+/// `Transaction.block_hash` field, which callers populate from the target chain
+/// via JSON-RPC `block` query.
+pub struct NearSigner;
+
+/// Borsh enum discriminant for ED25519 signatures (and public keys) in NEAR.
+const KEY_TYPE_ED25519: u8 = 0x00;
+
+impl NearSigner {
+    fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
+        let key_bytes: [u8; 32] = private_key.try_into().map_err(|_| {
+            SignerError::InvalidPrivateKey(format!("expected 32 bytes, got {}", private_key.len()))
+        })?;
+        Ok(SigningKey::from_bytes(&key_bytes))
+    }
+}
+
+impl ChainSigner for NearSigner {
+    fn chain_type(&self) -> ChainType {
+        ChainType::Near
+    }
+
+    fn curve(&self) -> Curve {
+        Curve::Ed25519
+    }
+
+    fn coin_type(&self) -> u32 {
+        397
+    }
+
+    fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key: VerifyingKey = signing_key.verifying_key();
+        Ok(hex::encode(verifying_key.as_bytes()))
+    }
+
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let signature = signing_key.sign(message);
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: Some(signing_key.verifying_key().as_bytes().to_vec()),
+        })
+    }
+
+    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        // V1: raw ed25519 over message bytes (parity with Solana).
+        // NEP-413 message signing (`tag 2147484061 || borsh(payload)`) is a
+        // structurally distinct flow with required fields (recipient, nonce);
+        // tracked as a follow-up so callers can opt in.
+        self.sign(private_key, message)
+    }
+
+    fn sign_transaction(
+        &self,
+        private_key: &[u8],
+        tx_bytes: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        // tx_bytes = borsh-serialized NEAR `Transaction`.
+        // Signing input is sha256(tx_bytes); ed25519 signs that 32-byte digest.
+        if tx_bytes.is_empty() {
+            return Err(SignerError::InvalidTransaction("empty transaction".into()));
+        }
+        let digest = Sha256::digest(tx_bytes);
+        self.sign(private_key, &digest)
+    }
+
+    fn encode_signed_transaction(
+        &self,
+        tx_bytes: &[u8],
+        signature: &SignOutput,
+    ) -> Result<Vec<u8>, SignerError> {
+        // borsh(SignedTransaction) = borsh(Transaction) || borsh(Signature)
+        // borsh(Signature::ED25519(sig)) = 0x00 (enum tag) || sig (64 bytes)
+        if signature.signature.len() != 64 {
+            return Err(SignerError::InvalidTransaction(
+                "expected 64-byte Ed25519 signature".into(),
+            ));
+        }
+        if tx_bytes.is_empty() {
+            return Err(SignerError::InvalidTransaction("empty transaction".into()));
+        }
+        let mut signed = Vec::with_capacity(tx_bytes.len() + 1 + 64);
+        signed.extend_from_slice(tx_bytes);
+        signed.push(KEY_TYPE_ED25519);
+        signed.extend_from_slice(&signature.signature);
+        Ok(signed)
+    }
+
+    fn extract_signable_bytes<'a>(&self, tx_bytes: &'a [u8]) -> Result<&'a [u8], SignerError> {
+        // NEAR transactions have no envelope; the borsh-serialized Transaction
+        // *is* the signable payload. sign_transaction handles the sha256 hashing.
+        if tx_bytes.is_empty() {
+            return Err(SignerError::InvalidTransaction("empty transaction".into()));
+        }
+        Ok(tx_bytes)
+    }
+
+    fn default_derivation_path(&self, index: u32) -> String {
+        // NEAR Foundation / Sender Wallet convention: single hardened account index.
+        // SLIP-44 coin type 397. Multi-account variation uses different index values.
+        format!("m/44'/397'/{}'", index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Verifier;
+
+    /// RFC 8032 test vector 1 — used as a stable seed across the suite.
+    const RFC_8032_SEED_HEX: &str =
+        "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+    const RFC_8032_PUBKEY_HEX: &str =
+        "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a";
+
+    fn rfc_seed() -> Vec<u8> {
+        hex::decode(RFC_8032_SEED_HEX).unwrap()
+    }
+
+    #[test]
+    fn test_chain_properties() {
+        let signer = NearSigner;
+        assert_eq!(signer.chain_type(), ChainType::Near);
+        assert_eq!(signer.curve(), Curve::Ed25519);
+        assert_eq!(signer.coin_type(), 397);
+    }
+
+    #[test]
+    fn test_derivation_path() {
+        let signer = NearSigner;
+        assert_eq!(signer.default_derivation_path(0), "m/44'/397'/0'");
+        assert_eq!(signer.default_derivation_path(1), "m/44'/397'/1'");
+    }
+
+    #[test]
+    fn test_implicit_address_is_lowercase_hex_pubkey() {
+        // For RFC 8032 vector 1, the 32-byte pubkey hex IS the implicit
+        // NEAR account ID. This is the canonical NEAR rule and the same
+        // result `hex(borsh(public_key.data))` produces in near-api-js.
+        let signer = NearSigner;
+        let address = signer.derive_address(&rfc_seed()).unwrap();
+        assert_eq!(address, RFC_8032_PUBKEY_HEX);
+        assert_eq!(address.len(), 64);
+        assert!(address
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
+    }
+
+    #[test]
+    fn test_sign_verify_roundtrip() {
+        let signer = NearSigner;
+        let message = b"test message for near";
+        let result = signer.sign(&rfc_seed(), message).unwrap();
+        assert_eq!(result.signature.len(), 64);
+        assert!(result.recovery_id.is_none());
+        assert_eq!(result.public_key.as_ref().map(|p| p.len()), Some(32));
+
+        let signing_key = SigningKey::from_bytes(&rfc_seed().try_into().unwrap());
+        let verifying_key = signing_key.verifying_key();
+        let sig = ed25519_dalek::Signature::from_bytes(&result.signature.try_into().unwrap());
+        verifying_key.verify(message, &sig).expect("should verify");
+    }
+
+    #[test]
+    fn test_deterministic_signature() {
+        let signer = NearSigner;
+        let sig1 = signer.sign(&rfc_seed(), b"hello").unwrap();
+        let sig2 = signer.sign(&rfc_seed(), b"hello").unwrap();
+        assert_eq!(sig1.signature, sig2.signature);
+    }
+
+    #[test]
+    fn test_sign_message_matches_sign() {
+        let signer = NearSigner;
+        let msg = b"hello near";
+        let s1 = signer.sign(&rfc_seed(), msg).unwrap();
+        let s2 = signer.sign_message(&rfc_seed(), msg).unwrap();
+        assert_eq!(s1.signature, s2.signature);
+    }
+
+    #[test]
+    fn test_invalid_key_length() {
+        let signer = NearSigner;
+        assert!(signer.derive_address(&[0u8; 16]).is_err());
+        assert!(signer.sign(&[0u8; 33], b"x").is_err());
+    }
+
+    #[test]
+    fn test_sign_transaction_hashes_with_sha256() {
+        // sign_transaction must produce a signature over sha256(tx_bytes),
+        // NOT a signature over tx_bytes directly. This is the NEAR convention.
+        let signer = NearSigner;
+        let tx_bytes = b"borsh-serialized-transaction-placeholder-bytes";
+
+        let signed_tx_output = signer.sign_transaction(&rfc_seed(), tx_bytes).unwrap();
+        let signed_raw_output = signer.sign(&rfc_seed(), tx_bytes).unwrap();
+
+        // The two must differ because sign_transaction hashes first.
+        assert_ne!(
+            signed_tx_output.signature, signed_raw_output.signature,
+            "sign_transaction must hash with sha256 before ed25519, not pass-through"
+        );
+
+        // Verify the sign_transaction output against sha256(tx_bytes).
+        let digest = Sha256::digest(tx_bytes);
+        let signing_key = SigningKey::from_bytes(&rfc_seed().try_into().unwrap());
+        let verifying_key = signing_key.verifying_key();
+        let sig =
+            ed25519_dalek::Signature::from_bytes(&signed_tx_output.signature.try_into().unwrap());
+        verifying_key
+            .verify(&digest, &sig)
+            .expect("sign_transaction output must verify against sha256(tx_bytes)");
+    }
+
+    #[test]
+    fn test_sign_transaction_empty_errors() {
+        let signer = NearSigner;
+        assert!(signer.sign_transaction(&rfc_seed(), &[]).is_err());
+    }
+
+    #[test]
+    fn test_extract_signable_bytes_passthrough() {
+        let signer = NearSigner;
+        let tx_bytes = b"any-borsh-serialized-bytes";
+        let extracted = signer.extract_signable_bytes(tx_bytes).unwrap();
+        assert_eq!(extracted, tx_bytes);
+    }
+
+    #[test]
+    fn test_extract_signable_bytes_empty_errors() {
+        let signer = NearSigner;
+        assert!(signer.extract_signable_bytes(&[]).is_err());
+    }
+
+    #[test]
+    fn test_encode_signed_transaction_layout() {
+        // borsh(SignedTransaction) = tx_bytes || 0x00 (ED25519 tag) || 64-byte sig.
+        let signer = NearSigner;
+        let tx_bytes = b"FAKE_TX_BORSH";
+        let sig = SignOutput {
+            signature: vec![0xAB; 64],
+            recovery_id: None,
+            public_key: None,
+        };
+
+        let encoded = signer.encode_signed_transaction(tx_bytes, &sig).unwrap();
+        assert_eq!(encoded.len(), tx_bytes.len() + 1 + 64);
+        assert_eq!(&encoded[..tx_bytes.len()], tx_bytes);
+        assert_eq!(encoded[tx_bytes.len()], KEY_TYPE_ED25519);
+        assert_eq!(&encoded[tx_bytes.len() + 1..], &[0xAB; 64]);
+    }
+
+    #[test]
+    fn test_encode_signed_transaction_rejects_wrong_sig_len() {
+        let signer = NearSigner;
+        let bad = SignOutput {
+            signature: vec![0xAB; 32],
+            recovery_id: None,
+            public_key: None,
+        };
+        assert!(signer.encode_signed_transaction(b"tx", &bad).is_err());
+    }
+
+    #[test]
+    fn test_encode_signed_transaction_rejects_empty_tx() {
+        let signer = NearSigner;
+        let sig = SignOutput {
+            signature: vec![0xAB; 64],
+            recovery_id: None,
+            public_key: None,
+        };
+        assert!(signer.encode_signed_transaction(&[], &sig).is_err());
+    }
+
+    /// Byte-parity test against the canonical `near-api-js` reference vector.
+    ///
+    /// Source: `near/near-api-js`, `test/unit/transactions/data/transaction1.json`.
+    /// This is a transfer of 1 yoctoNEAR from `test.near` to `whatever.near`
+    /// (nonce=1) signed by ed25519 pubkey
+    /// `Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC` over block_hash
+    /// `244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM`.
+    ///
+    /// Verifies:
+    /// 1. `extract_signable_bytes` is a no-op on canonical NEAR borsh tx bytes.
+    /// 2. `encode_signed_transaction` emits exactly
+    ///    `tx_bytes || 0x00 || sig` (the canonical Borsh layout for
+    ///    `SignedTransaction { transaction, signature: Signature::ED25519(_) }`).
+    ///
+    /// The signature segment itself cannot be byte-matched without the original
+    /// private key (which is not part of the public near-api-js fixture); we
+    /// verify the wrapping layout instead. Round-trip signing of this exact
+    /// `tx_bytes` with our own deterministic ed25519 key is covered by
+    /// `test_full_pipeline_extract_sign_encode_roundtrip` below.
+    #[test]
+    fn test_borsh_byte_parity_with_near_api_js_transaction1() {
+        let tx_hex = "09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68\
+                      d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00\
+                      00007768617465766572\
+                      2e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224\
+                      b6986910e630c2fef6010000000301000000000000000000000000\
+                      000000";
+        let tx_bytes = hex::decode(tx_hex).unwrap();
+
+        let signer = NearSigner;
+
+        // (1) extract_signable_bytes is identity for NEAR.
+        let signable = signer.extract_signable_bytes(&tx_bytes).unwrap();
+        assert_eq!(signable, tx_bytes.as_slice());
+
+        // (2) encode_signed_transaction layout matches near-api-js:
+        //     borsh(SignedTransaction) = borsh(Transaction) || 0x00 || sig64
+        let dummy_sig = SignOutput {
+            signature: vec![0xAB; 64],
+            recovery_id: None,
+            public_key: None,
+        };
+        let signed = signer
+            .encode_signed_transaction(&tx_bytes, &dummy_sig)
+            .unwrap();
+        assert_eq!(signed.len(), tx_bytes.len() + 1 + 64);
+        assert_eq!(&signed[..tx_bytes.len()], tx_bytes.as_slice());
+        assert_eq!(signed[tx_bytes.len()], 0x00, "ED25519 enum discriminant");
+        assert_eq!(&signed[tx_bytes.len() + 1..], &[0xAB; 64]);
+    }
+
+    #[test]
+    fn test_full_pipeline_extract_sign_encode_roundtrip() {
+        let signer = NearSigner;
+        let tx_bytes = b"a-realistic-looking-borsh-transaction-payload";
+
+        // Pipeline mirrors how ops.rs invokes the signer:
+        //   extract -> sign_transaction -> encode_signed_transaction
+        let signable = signer.extract_signable_bytes(tx_bytes).unwrap();
+        assert_eq!(signable, tx_bytes);
+
+        let output = signer.sign_transaction(&rfc_seed(), signable).unwrap();
+        let encoded = signer.encode_signed_transaction(tx_bytes, &output).unwrap();
+
+        // The encoded SignedTransaction must contain the original tx unchanged.
+        assert_eq!(&encoded[..tx_bytes.len()], tx_bytes);
+        // Followed by the ED25519 tag.
+        assert_eq!(encoded[tx_bytes.len()], KEY_TYPE_ED25519);
+        // Followed by the 64-byte signature.
+        assert_eq!(&encoded[tx_bytes.len() + 1..], output.signature.as_slice());
+
+        // And the signature must verify against sha256(tx_bytes).
+        let digest = Sha256::digest(tx_bytes);
+        let signing_key = SigningKey::from_bytes(&rfc_seed().try_into().unwrap());
+        let verifying_key = signing_key.verifying_key();
+        let sig =
+            ed25519_dalek::Signature::from_bytes(&output.signature.clone().try_into().unwrap());
+        verifying_key
+            .verify(&digest, &sig)
+            .expect("signature must verify against sha256(tx_bytes)");
+    }
+}

--- a/readme/partials/supported-chains.md
+++ b/readme/partials/supported-chains.md
@@ -12,3 +12,4 @@
 | XRPL | secp256k1 | Base58Check (`r...`) | `m/44'/144'/0'/0/0` |
 | Spark (Bitcoin L2) | secp256k1 | spark: prefixed | `m/84'/0'/0'/0/0` |
 | Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
+| NEAR | Ed25519 | implicit hex (64 chars) | `m/44'/397'/0'` |

--- a/readme/partials/why-ows.md
+++ b/readme/partials/why-ows.md
@@ -1,6 +1,6 @@
 ## Why OWS
 
 - **Local key custody.** Private keys stay encrypted at rest and are decrypted only inside the OWS signing path after the relevant checks pass. Current implementations harden in-process memory handling and wipe key material after use.
-- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
+- **Every chain, one interface.** EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, NEAR — all first-class. CAIP-2/CAIP-10 addressing abstracts away chain-specific details.
 - **Policy before signing.** A pre-signing policy engine gates agent (API key) operations before decryption — chain allowlists, expiry, and optional custom executables.
 - **Built for agents.** Native SDK and CLI today. A wallet created by one tool works in every other.

--- a/readme/templates/node.md
+++ b/readme/templates/node.md
@@ -26,7 +26,7 @@ Using viem, `@solana/web3.js`, or the Tether WDK? Install [`@open-wallet-standar
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("agent-treasury");
-// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 const sig = signMessage("agent-treasury", "evm", "hello");
 console.log(sig.signature);

--- a/readme/templates/ows.md
+++ b/readme/templates/ows.md
@@ -36,7 +36,7 @@ The bindings are **standalone** — they embed the Rust core via native FFI. No 
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("my-wallet");
-console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+console.log(wallet.accounts); // addresses for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 const sig = signMessage("my-wallet", "evm", "hello");
 console.log(sig.signature);
@@ -47,7 +47,7 @@ console.log(sig.signature);
 | Crate | Description |
 |-------|-------------|
 | `ows-core` | Types, CAIP-2/10 parsing, errors, config. Zero crypto dependencies. |
-| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin. |
+| `ows-signer` | ChainSigner trait, HD derivation, address derivation for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, and NEAR. |
 | `ows-lib` | Library interface used by language bindings and the CLI. |
 | `ows-pay` | x402 payment flows, service discovery, and funding helpers. |
 | `ows-cli` | The `ows` command-line tool. |
@@ -64,6 +64,7 @@ console.log(sig.signature);
 - **Spark** (Bitcoin L2) — secp256k1, spark: prefixed addresses
 - **XRPL** — secp256k1, Base58Check r-addresses
 - **Filecoin** — secp256k1, f1 base32 addresses
+- **NEAR** — Ed25519, implicit hex (64 chars), Borsh-serialized transactions
 
 ## License
 

--- a/readme/templates/python.md
+++ b/readme/templates/python.md
@@ -23,7 +23,7 @@ The package is **fully self-contained** — it embeds the Rust core via native F
 from ows import create_wallet, sign_message
 
 wallet = create_wallet("agent-treasury")
-# => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Filecoin, Sui, and XRPL
+# => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
 
 sig = sign_message("agent-treasury", "evm", "hello")
 print(sig["signature"])

--- a/skills/ows/SKILL.md
+++ b/skills/ows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ows
-description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, and Filecoin via CLI, Node.js, or Python.
+description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, and NEAR via CLI, Node.js, or Python.
 version: 1.3.2
 metadata:
   openclaw:
@@ -33,7 +33,7 @@ Use this skill when the user asks to:
 
 - Create, import, list, delete, or manage crypto wallets
 - Derive blockchain addresses from a mnemonic
-- Sign messages or transactions for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, or Filecoin
+- Sign messages or transactions for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, or NEAR
 - Broadcast signed transactions to a chain
 - Generate BIP-39 mnemonic phrases
 - Fund a wallet with USDC (MoonPay) or check token balances
@@ -56,6 +56,7 @@ Use this skill when the user asks to:
 | Spark (Bitcoin L2) | `spark` | secp256k1 | spark: prefixed |
 | XRPL | `xrpl` | secp256k1 | Base58Check (`r...`) |
 | Filecoin | `filecoin` | secp256k1 | f1 secp256k1 |
+| NEAR | `near`, `near-testnet` | Ed25519 | implicit hex (64 chars) |
 
 ## Installation
 

--- a/website-docs/md/02-signing-interface.md
+++ b/website-docs/md/02-signing-interface.md
@@ -80,6 +80,7 @@ Message signing follows chain-specific conventions:
 - **Sui**: Intent-prefixed (scope=3) BLAKE2b-256 digest, Ed25519 signature
 - **Cosmos**: ADR-036 off-chain signing
 - **Filecoin**: Blake2b-256 hash then secp256k1 signing
+- **NEAR**: V1 Ed25519 signature over the raw message bytes (parity with Solana). [NEP-413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md) prefixed message signing — `tag 2147484061 || borsh({message, nonce, recipient, callbackUrl?})` — is tracked as a follow-up so callers can opt in via a structured payload. Transaction signing is `Ed25519(SHA-256(borsh(Transaction)))`; `encode_signed_transaction` returns `borsh(Transaction) || 0x00 || sig64` (the canonical `borsh(SignedTransaction)`).
 
 ### `signTypedData(request: SignTypedDataRequest): Promise<SignMessageResult>`
 

--- a/website-docs/md/07-supported-chains.md
+++ b/website-docs/md/07-supported-chains.md
@@ -38,6 +38,7 @@ OWS groups chains into families that share a cryptographic curve and address der
 | Sui | ed25519 | 784 | `m/44'/784'/{index}'/0'/0'` | `0x` + BLAKE2b-256 hex (32 bytes) | `sui` |
 | Spark | secp256k1 | 8797555 | `m/84'/0'/0'/0/{index}` | `spark:` + compressed pubkey hex | `spark` |
 | Filecoin | secp256k1 | 461 | `m/44'/461'/0'/0/{index}` | `f1` + base32(blake2b-160) | `fil` |
+| NEAR | ed25519 | 397 | `m/44'/397'/{index}'` | 64-char lowercase hex of pubkey (implicit account) | `near` |
 
 ## Known Networks
 
@@ -67,6 +68,8 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | Sui | `sui:mainnet` |
 | Spark | `spark:mainnet` |
 | Filecoin | `fil:mainnet` |
+| NEAR | `near:mainnet` |
+| NEAR (testnet) | `near:testnet` |
 
 Implementations MAY ship convenience endpoint defaults, but those defaults are deployment choices rather than OWS interoperability requirements.
 
@@ -90,6 +93,8 @@ ton       → ton:mainnet
 sui       → sui:mainnet
 spark     → spark:mainnet
 filecoin  → fil:mainnet
+near          → near:mainnet
+near-testnet  → near:testnet
 ```
 
 Aliases MUST be resolved to full CAIP-2 identifiers before any processing. They MUST NOT appear in wallet files, policy files, or audit logs.
@@ -112,7 +117,8 @@ Master Seed (512 bits via PBKDF2)
     ├── m/44'/607'/0'       → TON Account 0
     ├── m/44'/784'/0'/0'/0' → Sui Account 0
     ├── m/84'/0'/0'/0/0     → Spark Account 0
-    └── m/44'/461'/0'/0/0   → Filecoin Account 0
+    ├── m/44'/461'/0'/0/0   → Filecoin Account 0
+    └── m/44'/397'/0'       → NEAR Account 0
 ```
 
 A single mnemonic derives accounts across all supported chains. The wallet file stores the encrypted mnemonic; the signer derives the appropriate private key using each chain's coin type and derivation path.


### PR DESCRIPTION
Closes #219

## Summary

Adds **NEAR Protocol** as a supported chain in OWS, following the canonical pattern from merged Nano PR #109 and in-flight Algorand PR #124. NEAR uses **Ed25519** (no new curve) over **Borsh-serialized** transactions, with **SHA-256 pre-hash** before signing. The signer is genesis-agnostic — network binding lives inside `Transaction.block_hash`, the same model Algorand uses for `gh`.

## Chain Specification

| Property | Value |
|---|---|
| `ChainType` | `Near` |
| CAIP-2 | `near:mainnet`, `near:testnet` |
| BIP-44 coin type | 397 ([SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)) |
| Curve | Ed25519 (existing `Curve::Ed25519`) |
| Default derivation path | `m/44'/397'/{index}'` (NEAR Foundation / Sender Wallet, fully hardened) |
| Address (implicit) | 64-char lowercase hex of the ed25519 pubkey |
| TX serialization | Borsh (deterministic, NEAR-canonical) |
| TX signing preimage | `Ed25519(SHA-256(borsh(Transaction)))` |
| `encode_signed_transaction` layout | `borsh(Transaction) ‖ 0x00 ‖ sig64` |
| Network binding | `block_hash` field within Transaction (genesis-agnostic signer) |
| `signMessage` (V1) | Raw ed25519 over message bytes (parity with Solana). [NEP-413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md) tracked as follow-up. |
| Default RPC | `https://rpc.mainnet.near.org`, `https://rpc.testnet.near.org` |

## Files Changed (31 files, +696 / -49)

### Core implementation
- `ows/crates/ows-signer/src/chains/near.rs` (new) — `NearSigner`, 15 inline tests
- `ows/crates/ows-signer/src/chains/mod.rs` — module + factory registration
- `ows/crates/ows-core/src/chain.rs` — `ChainType::Near` variant + KNOWN_CHAINS rows + namespace + coin_type + serde + parse_chain test
- `ows/crates/ows-core/src/config.rs` — default RPC URLs
- `ows/crates/ows-lib/src/near_rpc.rs` (new) — `broadcast_tx_commit` JSON-RPC helper
- `ows/crates/ows-lib/src/lib.rs`, `ops.rs` — module export + broadcast dispatch + 3 integration-test loops include `near`
- `ows/crates/ows-pay/src/discovery.rs` — `format_near()` with yoctoNEAR divisor (10^24), wired into `format_price()`, 6 unit tests

### Bindings tests
- `bindings/node/__test__/index.spec.mjs` — `near` added to chain coverage loops; account count 10 → 12 (also fixed pre-existing Spark omission); `spark:` startswith assertion added
- `bindings/python/tests/test_bindings.py` — same pattern; also fixed pre-existing missing `xrpl` in derive-all loop

### Documentation
- `docs/07-supported-chains.md` + `website-docs/md/07-supported-chains.md` — chain families table, non-EVM networks, shorthand aliases, HD derivation tree
- `docs/02-signing-interface.md` + `website-docs/md/02-signing-interface.md` — chain-specific signMessage / signTransaction semantics for NEAR

### README normalization (drive-by — fixed pre-existing gaps too)
- `ows/README.md`, `bindings/{node,python}/README.md`, `readme/templates/{ows,node,python}.md`, `readme/partials/{supported-chains,why-ows}.md`, `skills/ows/SKILL.md` — chain enumerations now consistently include Spark, Nano, NEAR

### Pre-existing fix (drive-by, single-line)
- `ows-core/src/chain.rs`: `ALL_CHAIN_TYPES: [ChainType; 10]` → `[ChainType; 12]` — Spark was already a `ChainType` variant with a registered signer but missing from the universal-wallet derivation list. Fixed alongside NEAR addition since adding NEAR exposed the count mismatch in bindings tests. Easy to revert if maintainers prefer this in a separate PR.

## Why these design choices

- **No new dependencies.** `ed25519-dalek`, `sha2`, `hex`, `bs58`, `base64` are all already in the workspace. We do not pull `near-primitives` (heavy: tokio + dozens of transitive crates the wallet doesn't need). The minimal NearSigner is ~330 LoC.
- **Implicit account, not named.** `derive_address` returns the implicit account ID (`hex(pubkey)`). Named accounts (`alice.near`) require on-chain registration and are out of scope for a stateless signer primitive.
- **HD derivation reuses existing SLIP-10.** NEAR's hardened-only path `m/44'/397'/{index}'` works through the existing ed25519 SLIP-10 implementation in `hd.rs`. No new HD machinery (in contrast to Algorand PR #124 which needed BIP32-Ed25519 with Peikert).
- **Stateless signing.** `block_hash` inside the Transaction binds it to a network, so the signer doesn't need a `network` parameter at signing time. Same model Algorand PR #124 uses.

## Production Reference

A production x402 facilitator with full NEAR support runs at [`facilitator.ultravioletadao.xyz`](https://facilitator.ultravioletadao.xyz), source at [`UltravioletaDAO/x402-rs`](https://github.com/UltravioletaDAO/x402-rs). It uses NEP-366 SignedDelegateAction for gasless meta-transactions on the facilitator side; this PR provides the underlying signer primitives so OWS wallets can produce the bytes that facilitator settles. Meta-tx wrapping belongs in `ows-pay` as a follow-up.

## Test Strategy

### Unit tests (15 inline in `chains/near.rs`)

- Trait properties (chain_type, curve, coin_type, derivation path)
- Implicit-address derivation against RFC 8032 vector 1 (verifies our `hex(pubkey)` lowercase produces the canonical 64-char NEAR implicit account ID)
- ed25519 sign/verify roundtrip with `ed25519-dalek::Verifier`
- Deterministic signing (RFC 8032 ed25519 is deterministic)
- `sign_message` parity with `sign` (V1)
- Invalid private key length rejection
- `sign_transaction` MUST sha256 the input first (verified by signing both ways and asserting the signatures differ; then verifying the `sign_transaction` output matches `Ed25519(SHA-256(tx_bytes))`)
- Empty input rejection
- `encode_signed_transaction` byte layout (1-byte ED25519 enum tag + 64-byte sig)
- Wrong sig length rejection
- Full pipeline `extract → sign → encode` with signature verifiable against `sha256(tx_bytes)`

### Byte-parity test against `near-api-js`

`test_borsh_byte_parity_with_near_api_js_transaction1` hard-codes the canonical `Transaction` borsh hex from [`near/near-api-js test/unit/transactions/data/transaction1.json`](https://github.com/near/near-api-js) (transfer of 1 yoctoNEAR `test.near` → `whatever.near`, nonce=1). Verifies that `extract_signable_bytes` is identity AND that `encode_signed_transaction` emits exactly `tx_bytes ‖ 0x00 ‖ sig64` matching `near-api-js`'s `borsh(SignedTransaction)` layout.

### Integration tests in `ops.rs`

NEAR added to all 3 cross-chain loops:
- `derive_address_all_chains`
- `mnemonic_wallet_sign_message_all_chains`
- `mnemonic_wallet_sign_tx_all_chains`

### `format_near` unit tests (6)

Whole NEAR / fractional / zero / one yoctoNEAR / typical NEP-141 storage deposit / non-numeric input rejection.

### CI gates (verified locally)

```
cargo fmt --all --check                                  clean
cargo clippy --workspace --all-targets -- -D warnings    clean
cargo test --workspace                                   604 passed, 0 failed
.githooks/pre-commit                                     pass
```

## Out of scope (tracked as follow-ups)

- **NEP-413 prefixed message signing** (`tag 2147484061 ‖ borsh({message, nonce, recipient, callbackUrl?})`) — the V1 `sign_message` here is raw ed25519 over message bytes for parity with Solana. NEP-413 is a structurally distinct flow with required fields; better as an opt-in API in a follow-up.
- **NEP-366 SignedDelegateAction** (gasless meta-transactions) — belongs in `ows-pay`, not the signer crate.
- **Named-account resolution** (`alice.near` → AccountId) — requires RPC, not a pure stateless signer concern.
- **Live testnet broadcast smoke test** — Nano #109 didn't include one either; can be added behind `#[ignore]` later.

## References

- [near-api-js](https://github.com/near/near-api-js) — reference TypeScript SDK
- [NEP-413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md) — Off-chain message signing
- [NEP-366](https://github.com/near/NEPs/blob/master/neps/nep-0366.md) — Meta-transactions
- [SLIP-44 coin type 397](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- Nano PR #109 (merged) — closest structural template
- Algorand PR #124 (open) — sibling ed25519 chain addition

cc @njdawn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new chain implementation and RPC broadcasting path, which touches signing/encoding and expands universal wallet derivation; mistakes could cause invalid signatures/tx bytes or mis-broadcasts for NEAR.
> 
> **Overview**
> Adds **NEAR Protocol support end-to-end**: introduces `ChainType::Near` with `near:mainnet`/`near:testnet`, default coin type/derivation path, and a new `NearSigner` that signs transactions as `Ed25519(SHA-256(borsh(Transaction)))` and encodes signed tx bytes as `borsh(Transaction) || 0x00 || sig64`.
> 
> Wires NEAR into runtime flows by adding default NEAR RPC URLs, adding a `curl`-based `broadcast_tx_commit` implementation for `signAndSend`/broadcast dispatch, and updating `ows-pay` price formatting to render yoctoNEAR amounts.
> 
> Updates Node/Python bindings tests and universal-wallet expectations (account count `10 → 12`, adds `near` coverage and a `spark:` assertion), and refreshes specs/READMEs to list NEAR and document its message/transaction signing conventions and aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16c6caf041add3061579ac55b29e0c5bb2d76531. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->