### PR TITLE
fix(cli): incorrect/unnecessary passphrase assumptions

### DIFF
--- a/ows/crates/ows-cli/src/commands/mod.rs
+++ b/ows/crates/ows-cli/src/commands/mod.rs
@@ -106,23 +106,13 @@ pub fn peek_passphrase() -> Option<String> {
 
 /// Resolve a wallet into the private key bytes for a specific chain.
 ///
-/// Tries an empty passphrase first; if that fails, prompts the user.
-/// Delegates to `ows_lib::decrypt_signing_key` for the actual decryption
-/// and key derivation so the signing path is never duplicated.
+/// Reads the passphrase once, then delegates to `ows_lib::decrypt_signing_key`
+/// for the actual decryption and key derivation so the signing path is never duplicated.
 pub fn resolve_signing_key(
     wallet_name: &str,
     chain_type: ows_core::ChainType,
     index: u32,
 ) -> Result<SecretBytes, CliError> {
-    // Try empty passphrase first.
-    match ows_lib::decrypt_signing_key(wallet_name, chain_type, "", Some(index), None) {
-        Ok(key) => return Ok(key),
-        Err(ows_lib::OwsLibError::Crypto(_)) => {
-            // Empty passphrase didn't work — prompt the user.
-        }
-        Err(e) => return Err(e.into()),
-    }
-
     let passphrase = read_passphrase();
     Ok(ows_lib::decrypt_signing_key(
         wallet_name,

--- a/ows/crates/ows-cli/src/commands/wallet.rs
+++ b/ows/crates/ows-cli/src/commands/wallet.rs
@@ -7,7 +7,9 @@ use zeroize::Zeroize;
 pub fn create(name: &str, words: u32, show_mnemonic: bool) -> Result<(), CliError> {
     // Generate mnemonic, then import it to create the wallet
     let mut mnemonic_phrase = ows_lib::generate_mnemonic(words)?;
-    let info = ows_lib::import_wallet_mnemonic(name, &mnemonic_phrase, None, Some(0), None)?;
+    let passphrase = super::read_passphrase();
+    let info =
+        ows_lib::import_wallet_mnemonic(name, &mnemonic_phrase, Some(&passphrase), Some(0), None)?;
 
     audit::log_wallet_created(&info);
 
@@ -66,9 +68,11 @@ pub fn import(
         ));
     }
 
+    let passphrase = super::read_passphrase();
+
     let info = if use_mnemonic {
         let phrase = super::read_mnemonic()?;
-        ows_lib::import_wallet_mnemonic(name, &phrase, None, Some(index), None)?
+        ows_lib::import_wallet_mnemonic(name, &phrase, Some(&passphrase), Some(index), None)?
     } else {
         // Read from env/stdin only when both curve keys are not already provided
         let private_key_hex = if both_curve_keys {
@@ -80,7 +84,7 @@ pub fn import(
             name,
             &private_key_hex,
             chain,
-            None,
+            Some(&passphrase),
             None,
             secp256k1_key,
             ed25519_key,
@@ -109,14 +113,8 @@ pub fn export(wallet_name: &str) -> Result<(), CliError> {
         ));
     }
 
-    // Try empty passphrase first, then prompt if it fails
-    let mut exported = match ows_lib::export_wallet(wallet_name, None, None) {
-        Ok(s) => s,
-        Err(_) => {
-            let passphrase = super::read_passphrase();
-            ows_lib::export_wallet(wallet_name, Some(&passphrase), None)?
-        }
-    };
+    let passphrase = super::read_passphrase();
+    let mut exported = ows_lib::export_wallet(wallet_name, Some(&passphrase), None)?;
 
     let is_key_pair = exported.starts_with('{');
     eprintln!();


### PR DESCRIPTION
## What

Don't make empty passphrase assumptions in wallet create/import/export/decrypt.

## Why

`read_passphrase` currently:
1. tries to read passphrase from env vars `OWS_PASSPHRASE`, `LWS_PASSPRASE`.
2. checks if it is an interactive terminal, if it is, it prompts the user for passphrase
3. if it is not an interactive terminal, it assumes passphrase to be `""`.

Given this, there is no need for us to assume:
1. Empty passphrases for `ows wallet import`, `ows wallet create`. This assumption creates poor security for human users.
2. Empty passphrase while decrypting the signing key, this assumption causes 2x the time for all wallets encrypted without `""`, even in cases when `OWS_PASSPHRASE` was explicitly set.

Closes #

## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `npm test` passes (if Node bindings changed)
- [x] Tested manually with `ows` CLI

## Notes

Anything reviewers should know.
