### PR TITLE
feat: add Atto support

### DIFF
--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -21,7 +21,7 @@ type AssetId = `${ChainId}:${string}`;
 // e.g. "eip155:8453:native" (ETH on Base)
 ```
 
-The `native` token refers to the chain's native currency (ETH, SOL, SUI, XRP, BTC, ATOM, TRX, TON, etc.).
+The `native` token refers to the chain's native currency (ETH, SOL, SUI, XRP, BTC, ATOM, TRX, TON, ATTO, etc.).
 
 ## Chain Families
 
@@ -40,6 +40,7 @@ OWS groups chains into families that share a cryptographic curve and address der
 | Spark | secp256k1 | 8797555 | `m/84'/0'/0'/0/{index}` | `spark:` + compressed pubkey hex | `spark` |
 | Filecoin | secp256k1 | 461 | `m/44'/461'/0'/0/{index}` | `f1` + base32(blake2b-160) | `fil` |
 | NEAR | ed25519 | 397 | `m/44'/397'/{index}'` | 64-char lowercase hex of pubkey (implicit account) | `near` |
+| Atto | ed25519 | 1869902945 | `m/44'/1869902945'/{index}'` | `atto://` + 61-char lowercase unpadded Base32 | `atto` |
 
 ## Known Networks
 
@@ -76,6 +77,10 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | Filecoin | `fil:mainnet` |
 | NEAR | `near:mainnet` |
 | NEAR (testnet) | `near:testnet` |
+| Atto | `atto:live` |
+| Atto (beta) | `atto:beta` |
+| Atto (dev) | `atto:dev` |
+| Atto (local) | `atto:local` |
 
 Implementations MAY ship convenience endpoint defaults, but those defaults are deployment choices rather than OWS interoperability requirements.
 
@@ -109,6 +114,11 @@ spark     → spark:mainnet
 filecoin  → fil:mainnet
 near          → near:mainnet
 near-testnet  → near:testnet
+atto          → atto:live
+atto-live     → atto:live
+atto-beta     → atto:beta
+atto-dev      → atto:dev
+atto-local    → atto:local
 ```
 
 Aliases MUST be resolved to full CAIP-2 identifiers before any processing. They MUST NOT appear in wallet files, policy files, or audit logs.
@@ -133,7 +143,8 @@ Master Seed (512 bits via PBKDF2)
     ├── m/44'/144'/0'/0/0   → XRPL Account 0
     ├── m/84'/0'/0'/0/0     → Spark Account 0
     ├── m/44'/461'/0'/0/0   → Filecoin Account 0
-    └── m/44'/397'/0'       → NEAR Account 0
+    ├── m/44'/397'/0'       → NEAR Account 0
+    └── m/44'/1869902945'/0' → Atto Account 0
 ```
 
 For mnemonic-based wallets, a single mnemonic derives accounts across all supported chains. Those wallet files store the encrypted mnemonic, and the signer derives the appropriate private key using each chain's coin type and derivation path. Wallets imported from raw private keys instead store encrypted curve-key material directly.

--- a/ows/crates/ows-core/src/caip.rs
+++ b/ows/crates/ows-core/src/caip.rs
@@ -146,6 +146,13 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_atto_chain_id() {
+        let id: ChainId = "atto:live".parse().unwrap();
+        assert_eq!(id.namespace, "atto");
+        assert_eq!(id.reference, "live");
+    }
+
+    #[test]
     fn test_reject_empty_namespace() {
         assert!("".parse::<ChainId>().is_err());
     }

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -18,10 +18,11 @@ pub enum ChainType {
     Xrpl,
     Nano,
     Near,
+    Atto,
 }
 
 /// All supported chain families, used for universal wallet derivation.
-pub const ALL_CHAIN_TYPES: [ChainType; 12] = [
+pub const ALL_CHAIN_TYPES: [ChainType; 13] = [
     ChainType::Evm,
     ChainType::Solana,
     ChainType::Bitcoin,
@@ -34,6 +35,7 @@ pub const ALL_CHAIN_TYPES: [ChainType; 12] = [
     ChainType::Xrpl,
     ChainType::Nano,
     ChainType::Near,
+    ChainType::Atto,
 ];
 
 /// A specific chain (e.g. "ethereum", "arbitrum") with its family type and CAIP-2 ID.
@@ -194,6 +196,31 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_id: "near:testnet",
     },
     Chain {
+        name: "atto",
+        chain_type: ChainType::Atto,
+        chain_id: "atto:live",
+    },
+    Chain {
+        name: "atto-live",
+        chain_type: ChainType::Atto,
+        chain_id: "atto:live",
+    },
+    Chain {
+        name: "atto-beta",
+        chain_type: ChainType::Atto,
+        chain_id: "atto:beta",
+    },
+    Chain {
+        name: "atto-dev",
+        chain_type: ChainType::Atto,
+        chain_id: "atto:dev",
+    },
+    Chain {
+        name: "atto-local",
+        chain_type: ChainType::Atto,
+        chain_id: "atto:local",
+    },
+    Chain {
         name: "tempo",
         chain_type: ChainType::Evm,
         chain_id: "eip155:4217",
@@ -267,7 +294,7 @@ pub fn parse_chain(s: &str) -> Result<Chain, String> {
            EVM:     ethereum, base, arbitrum, optimism, polygon, bsc, avalanche, plasma, etherlink\n  \
            Solana:  solana\n  \
            Bitcoin: bitcoin\n  \
-           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl, nano, near\n\n\
+           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl, nano, near, atto\n\n\
          Or use a CAIP-2 ID (eip155:8453) or bare EVM chain ID (8453)"
     ))
 }
@@ -293,6 +320,7 @@ impl ChainType {
             ChainType::Xrpl => "xrpl",
             ChainType::Nano => "nano",
             ChainType::Near => "near",
+            ChainType::Atto => "atto",
         }
     }
 
@@ -311,6 +339,7 @@ impl ChainType {
             ChainType::Xrpl => 144,
             ChainType::Nano => 165,
             ChainType::Near => 397,
+            ChainType::Atto => 1_869_902_945,
         }
     }
 
@@ -329,6 +358,7 @@ impl ChainType {
             "xrpl" => Some(ChainType::Xrpl),
             "nano" => Some(ChainType::Nano),
             "near" => Some(ChainType::Near),
+            "atto" => Some(ChainType::Atto),
             _ => None,
         }
     }
@@ -349,6 +379,7 @@ impl fmt::Display for ChainType {
             ChainType::Xrpl => "xrpl",
             ChainType::Nano => "nano",
             ChainType::Near => "near",
+            ChainType::Atto => "atto",
         };
         write!(f, "{}", s)
     }
@@ -371,6 +402,7 @@ impl FromStr for ChainType {
             "xrpl" => Ok(ChainType::Xrpl),
             "nano" => Ok(ChainType::Nano),
             "near" => Ok(ChainType::Near),
+            "atto" => Ok(ChainType::Atto),
             _ => Err(format!("unknown chain type: {}", s)),
         }
     }
@@ -404,6 +436,7 @@ mod tests {
             (ChainType::Xrpl, "\"xrpl\""),
             (ChainType::Nano, "\"nano\""),
             (ChainType::Near, "\"near\""),
+            (ChainType::Atto, "\"atto\""),
         ] {
             let json = serde_json::to_string(&chain).unwrap();
             assert_eq!(json, expected);
@@ -426,6 +459,7 @@ mod tests {
         assert_eq!(ChainType::Xrpl.namespace(), "xrpl");
         assert_eq!(ChainType::Nano.namespace(), "nano");
         assert_eq!(ChainType::Near.namespace(), "near");
+        assert_eq!(ChainType::Atto.namespace(), "atto");
     }
 
     #[test]
@@ -442,6 +476,7 @@ mod tests {
         assert_eq!(ChainType::Xrpl.default_coin_type(), 144);
         assert_eq!(ChainType::Nano.default_coin_type(), 165);
         assert_eq!(ChainType::Near.default_coin_type(), 397);
+        assert_eq!(ChainType::Atto.default_coin_type(), 1_869_902_945);
     }
 
     #[test]
@@ -461,6 +496,7 @@ mod tests {
         assert_eq!(ChainType::from_namespace("xrpl"), Some(ChainType::Xrpl));
         assert_eq!(ChainType::from_namespace("nano"), Some(ChainType::Nano));
         assert_eq!(ChainType::from_namespace("near"), Some(ChainType::Near));
+        assert_eq!(ChainType::from_namespace("atto"), Some(ChainType::Atto));
         assert_eq!(ChainType::from_namespace("unknown"), None);
     }
 
@@ -468,6 +504,7 @@ mod tests {
     fn test_from_str() {
         assert_eq!("evm".parse::<ChainType>().unwrap(), ChainType::Evm);
         assert_eq!("Solana".parse::<ChainType>().unwrap(), ChainType::Solana);
+        assert_eq!("Atto".parse::<ChainType>().unwrap(), ChainType::Atto);
         assert!("unknown".parse::<ChainType>().is_err());
     }
 
@@ -475,6 +512,7 @@ mod tests {
     fn test_display() {
         assert_eq!(ChainType::Evm.to_string(), "evm");
         assert_eq!(ChainType::Bitcoin.to_string(), "bitcoin");
+        assert_eq!(ChainType::Atto.to_string(), "atto");
     }
 
     #[test]
@@ -641,7 +679,7 @@ mod tests {
 
     #[test]
     fn test_all_chain_types() {
-        assert_eq!(ALL_CHAIN_TYPES.len(), 12);
+        assert_eq!(ALL_CHAIN_TYPES.len(), 13);
     }
 
     #[test]
@@ -666,5 +704,27 @@ mod tests {
         let chain = default_chain_for_type(ChainType::Evm);
         assert_eq!(chain.name, "ethereum");
         assert_eq!(chain.chain_id, "eip155:1");
+
+        let atto = default_chain_for_type(ChainType::Atto);
+        assert_eq!(atto.name, "atto");
+        assert_eq!(atto.chain_id, "atto:live");
+    }
+
+    #[test]
+    fn test_parse_chain_atto() {
+        let chain = parse_chain("atto").unwrap();
+        assert_eq!(chain.name, "atto");
+        assert_eq!(chain.chain_type, ChainType::Atto);
+        assert_eq!(chain.chain_id, "atto:live");
+
+        let live = parse_chain("atto-live").unwrap();
+        assert_eq!(live.chain_id, "atto:live");
+
+        let beta = parse_chain("atto-beta").unwrap();
+        assert_eq!(beta.chain_id, "atto:beta");
+
+        let via_caip2 = parse_chain("atto:dev").unwrap();
+        assert_eq!(via_caip2.chain_type, ChainType::Atto);
+        assert_eq!(via_caip2.chain_id, "atto:dev");
     }
 }

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -76,6 +76,32 @@ impl Config {
         rpc.insert("nano:mainnet".into(), "https://rpc.nano.to".into());
         rpc.insert("near:mainnet".into(), "https://rpc.mainnet.near.org".into());
         rpc.insert("near:testnet".into(), "https://rpc.testnet.near.org".into());
+        rpc.insert(
+            "atto:live".into(),
+            "https://gatekeeper.live.application.atto.cash".into(),
+        );
+        rpc.insert(
+            "atto:beta".into(),
+            "https://gatekeeper.beta.application.atto.cash".into(),
+        );
+        rpc.insert(
+            "atto:dev".into(),
+            "https://gatekeeper.dev.application.atto.cash".into(),
+        );
+        rpc.insert("atto:local".into(), "".into());
+        rpc.insert(
+            "atto-work:live".into(),
+            "https://gatekeeper.live.application.atto.cash".into(),
+        );
+        rpc.insert(
+            "atto-work:beta".into(),
+            "https://gatekeeper.beta.application.atto.cash".into(),
+        );
+        rpc.insert(
+            "atto-work:dev".into(),
+            "https://gatekeeper.dev.application.atto.cash".into(),
+        );
+        rpc.insert("atto-work:local".into(), "".into());
         rpc.insert("eip155:4217".into(), "https://rpc.tempo.xyz".into());
         rpc.insert(
             "eip155:999".into(),
@@ -224,6 +250,14 @@ mod tests {
             config.rpc_url("eip155:999"),
             Some("https://rpc.hyperliquid.xyz/evm")
         );
+        assert_eq!(
+            config.rpc_url("atto:live"),
+            Some("https://gatekeeper.live.application.atto.cash")
+        );
+        assert_eq!(
+            config.rpc_url("atto-work:live"),
+            Some("https://gatekeeper.live.application.atto.cash")
+        );
     }
 
     #[test]
@@ -266,7 +300,7 @@ mod tests {
     fn test_load_or_default_nonexistent() {
         let config = Config::load_or_default_from(std::path::Path::new("/nonexistent/config.json"));
         // Should have all default RPCs
-        assert_eq!(config.rpc.len(), 23);
+        assert_eq!(config.rpc.len(), 31);
         assert_eq!(config.rpc_url("eip155:1"), Some("https://eth.llamarpc.com"));
         assert_eq!(
             config.rpc_url("near:mainnet"),

--- a/ows/crates/ows-lib/src/atto_rpc.rs
+++ b/ows/crates/ows-lib/src/atto_rpc.rs
@@ -1,0 +1,315 @@
+//! Minimal Atto Node and Work Server REST helpers.
+//!
+//! Uses `curl` for HTTP, consistent with the rest of ows-lib (no added HTTP deps).
+
+use crate::error::OwsLibError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::process::Command;
+
+pub type AttoHash = String;
+pub type AttoInstant = i64;
+pub type AttoTransaction = Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttoWorkRequest {
+    pub network: String,
+    pub timestamp: AttoInstant,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttoWorkResponse {
+    pub work: String,
+}
+
+pub struct AttoNodeClient {
+    base_url: String,
+}
+
+impl AttoNodeClient {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: trim_base_url(base_url.into()),
+        }
+    }
+
+    /// `POST /transactions/stream`, collected until the first streamed
+    /// transaction. Returns the streamed hash when one is present.
+    pub(crate) fn publish_transaction_value_stream(
+        &self,
+        transaction: &AttoTransaction,
+    ) -> Result<Option<AttoHash>, OwsLibError> {
+        let text = http_call(
+            "POST",
+            &self.url("transactions/stream"),
+            Some(transaction),
+            "application/x-ndjson",
+        )?;
+        let streamed = first_ndjson_value(&text)?;
+        Ok(streamed.and_then(|value| {
+            value
+                .get("hash")
+                .and_then(Value::as_str)
+                .or_else(|| value.get("transactionHash").and_then(Value::as_str))
+                .or_else(|| {
+                    value
+                        .get("block")
+                        .and_then(|block| block.get("hash"))
+                        .and_then(Value::as_str)
+                })
+                .map(str::to_string)
+        }))
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}/{}", self.base_url, path.trim_start_matches('/'))
+    }
+}
+
+pub struct AttoWorkServerClient {
+    base_url: String,
+}
+
+impl AttoWorkServerClient {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: trim_base_url(base_url.into()),
+        }
+    }
+
+    /// Atto Commons remote worker contract: `POST /works` with
+    /// `{ network, timestamp, target }` and response `{ work }`.
+    pub fn work(&self, request: &AttoWorkRequest) -> Result<AttoWorkResponse, OwsLibError> {
+        let body = serde_json::to_value(request)?;
+        let text = http_call(
+            "POST",
+            &format!("{}/works", self.base_url),
+            Some(&body),
+            "application/json",
+        )?;
+        Ok(serde_json::from_str(&text)?)
+    }
+}
+
+fn trim_base_url(mut base_url: String) -> String {
+    while base_url.ends_with('/') {
+        base_url.pop();
+    }
+    base_url
+}
+
+fn first_ndjson_value(body: &str) -> Result<Option<Value>, OwsLibError> {
+    body.lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).map_err(OwsLibError::from))
+        .transpose()
+}
+
+fn http_call(
+    method: &str,
+    url: &str,
+    body: Option<&Value>,
+    accept: &str,
+) -> Result<String, OwsLibError> {
+    let is_ndjson_stream = accept == "application/x-ndjson";
+    let mut args = vec![
+        "-sS".to_string(),
+        "-X".to_string(),
+        method.to_string(),
+        "-H".to_string(),
+        "Content-Type: application/json".to_string(),
+        "-H".to_string(),
+        format!("Accept: {accept}"),
+    ];
+
+    if is_ndjson_stream {
+        args.push("-N".to_string());
+        args.push("--max-time".to_string());
+        args.push("15".to_string());
+    }
+
+    let body_string;
+    if let Some(body) = body {
+        body_string = body.to_string();
+        args.push("-d".to_string());
+        args.push(body_string);
+    }
+
+    args.push("-w".to_string());
+    args.push("\n%{http_code}".to_string());
+    args.push(url.to_string());
+
+    let output = Command::new("curl")
+        .args(args)
+        .output()
+        .map_err(|e| OwsLibError::BroadcastFailed(format!("failed to run curl: {e}")))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let (body, status) = stdout.rsplit_once('\n').ok_or_else(|| {
+        OwsLibError::BroadcastFailed(format!(
+            "Atto HTTP response missing status trailer for {method} {url}"
+        ))
+    })?;
+    let status_code = status.trim().parse::<u16>().map_err(|e| {
+        OwsLibError::BroadcastFailed(format!(
+            "Atto HTTP response had invalid status trailer `{}`: {e}",
+            status.trim()
+        ))
+    })?;
+
+    if !output.status.success() {
+        let curl_timed_out = output.status.code() == Some(28);
+        if !(is_ndjson_stream && curl_timed_out && (200..300).contains(&status_code)) {
+            return Err(OwsLibError::BroadcastFailed(format!(
+                "Atto HTTP transport failed for {method} {url}: {stderr}"
+            )));
+        }
+    }
+
+    if !(200..300).contains(&status_code) {
+        let trimmed = body.trim();
+        let detail = if trimmed.is_empty() {
+            stderr.trim()
+        } else {
+            trimmed
+        };
+        return Err(OwsLibError::BroadcastFailed(format!(
+            "Atto HTTP {status_code} for {method} {url}: {detail}"
+        )));
+    }
+
+    Ok(body.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    const ADDRESS: &str = "atto://aaferyy3quqiyugpambc452bu2oqh7hrcazz4vnvem2meaa6thwf4vkiuiwyw";
+    const HASH: &str = "9072A5DB95CF7866F9AF4CC4C12C01F8E1DF903A6A0660EF62986A4B6191BD0C";
+
+    #[test]
+    fn publish_transaction_stream_posts_signed_transaction_and_returns_hash() {
+        let transaction = sample_transaction();
+        let body = format!(
+            "{}\n",
+            serde_json::json!({
+                "type": "SEND",
+                "hash": HASH,
+                "signature": "00".repeat(64),
+                "work": "8E9C4A839AB702AF",
+                "address": ADDRESS
+            })
+        );
+        let (base_url, handle) = serve_once(200, "application/x-ndjson", &body);
+
+        let client = AttoNodeClient::new(base_url);
+        let hash = client
+            .publish_transaction_value_stream(&transaction)
+            .unwrap();
+        let request = handle.join().unwrap();
+
+        assert!(
+            request.starts_with("POST /transactions/stream HTTP/1.1"),
+            "{request}"
+        );
+        assert!(request.contains("\"type\":\"SEND\""), "{request}");
+        assert!(request.contains("\"signature\""), "{request}");
+        assert_eq!(hash.as_deref(), Some(HASH));
+    }
+
+    #[test]
+    fn work_server_posts_works_request() {
+        let response = r#"{"work":"8E9C4A839AB702AF"}"#;
+        let (base_url, handle) = serve_once(200, "application/json", response);
+
+        let client = AttoWorkServerClient::new(base_url);
+        let work = client
+            .work(&AttoWorkRequest {
+                network: "LIVE".to_string(),
+                timestamp: 1_767_390_950_000,
+                target: HASH.to_string(),
+            })
+            .unwrap();
+        let request = handle.join().unwrap();
+
+        assert!(request.starts_with("POST /works HTTP/1.1"), "{request}");
+        assert!(request.contains("\"network\":\"LIVE\""), "{request}");
+        assert_eq!(work.work, "8E9C4A839AB702AF");
+    }
+
+    #[test]
+    fn http_error_maps_to_broadcast_failed_with_status_and_body() {
+        let (base_url, handle) =
+            serve_once(400, "application/json", r#"{"error":"bad transaction"}"#);
+
+        let client = AttoNodeClient::new(base_url);
+        let err = client
+            .publish_transaction_value_stream(&sample_transaction())
+            .unwrap_err();
+        let _ = handle.join().unwrap();
+
+        match err {
+            OwsLibError::BroadcastFailed(msg) => {
+                assert!(msg.contains("HTTP 400"), "{msg}");
+                assert!(msg.contains("bad transaction"), "{msg}");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    fn sample_transaction() -> Value {
+        serde_json::json!({
+            "type": "SEND",
+            "network": "LIVE",
+            "version": 0,
+            "algorithm": "V1",
+            "publicKey": "44C8865188D6FBE1C084436FF2E08D34538BA0FB2FCB1A8FA76F8127CCF6A281",
+            "height": "2",
+            "balance": "999999999999999999",
+            "timestamp": 1767390950976_i64,
+            "address": ADDRESS,
+            "previous": HASH,
+            "receiverAlgorithm": "V1",
+            "receiverPublicKey": "44C8865188D6FBE1C084436FF2E08D34538BA0FB2FCB1A8FA76F8127CCF6A281",
+            "receiverAddress": ADDRESS,
+            "amount": "1",
+            "signature": "00".repeat(64),
+            "work": "8E9C4A839AB702AF"
+        })
+    }
+
+    fn serve_once(
+        status: u16,
+        content_type: &'static str,
+        body: &str,
+    ) -> (String, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let body = body.to_string();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 16 * 1024];
+            let n = stream.read(&mut buf).unwrap();
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            let reason = match status {
+                200 => "OK",
+                400 => "Bad Request",
+                _ => "Status",
+            };
+            let response = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(), body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            request
+        });
+        (format!("http://{addr}"), handle)
+    }
+}

--- a/ows/crates/ows-lib/src/lib.rs
+++ b/ows/crates/ows-lib/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod atto_rpc;
 pub mod error;
 pub mod key_ops;
 pub mod key_store;

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -10,6 +10,7 @@ use ows_signer::{
     MnemonicStrength, SecretBytes,
 };
 
+use crate::atto_rpc::{AttoWorkRequest, AttoWorkServerClient};
 use crate::error::OwsLibError;
 use crate::types::{AccountInfo, SendResult, SignResult, WalletInfo};
 use crate::vault;
@@ -36,6 +37,14 @@ fn parse_chain(s: &str) -> Result<ows_core::Chain, OwsLibError> {
     ows_core::parse_chain(s).map_err(OwsLibError::InvalidInput)
 }
 
+fn wallet_account_id(chain: &ows_core::Chain, address: &str) -> String {
+    let account = match chain.chain_type {
+        ChainType::Atto => address.strip_prefix("atto://").unwrap_or(address),
+        _ => address,
+    };
+    format!("{}:{account}", chain.chain_id)
+}
+
 /// Derive accounts for all chain families from a mnemonic at the given index.
 fn derive_all_accounts(mnemonic: &Mnemonic, index: u32) -> Result<Vec<WalletAccount>, OwsLibError> {
     let mut accounts = Vec::with_capacity(ALL_CHAIN_TYPES.len());
@@ -46,7 +55,7 @@ fn derive_all_accounts(mnemonic: &Mnemonic, index: u32) -> Result<Vec<WalletAcco
         let curve = signer.curve();
         let key = HdDeriver::derive_from_mnemonic(mnemonic, "", &path, curve)?;
         let address = signer.derive_address(key.expose())?;
-        let account_id = format!("{}:{}", chain.chain_id, address);
+        let account_id = wallet_account_id(&chain, &address);
         accounts.push(WalletAccount {
             account_id,
             address,
@@ -119,7 +128,7 @@ fn derive_all_accounts_from_keys(keys: &KeyPair) -> Result<Vec<WalletAccount>, O
         let address = signer.derive_address(key)?;
         let chain = default_chain_for_type(*ct);
         accounts.push(WalletAccount {
-            account_id: format!("{}:{}", chain.chain_id, address),
+            account_id: wallet_account_id(&chain, &address),
             address,
             chain_id: chain.chain_id.to_string(),
             derivation_path: String::new(),
@@ -820,7 +829,172 @@ fn broadcast(chain: ChainType, rpc_url: &str, signed_bytes: &[u8]) -> Result<Str
         ChainType::Xrpl => broadcast_xrpl(rpc_url, signed_bytes),
         ChainType::Nano => broadcast_nano(rpc_url, signed_bytes),
         ChainType::Near => crate::near_rpc::broadcast_tx_commit(rpc_url, signed_bytes),
+        ChainType::Atto => broadcast_atto(rpc_url, signed_bytes),
     }
+}
+
+fn broadcast_atto(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibError> {
+    let mut transaction =
+        ows_signer::chains::atto::atto_signed_transaction_to_api_json_value(signed_bytes)?;
+    let tx_hash = ows_signer::chains::atto::atto_signed_transaction_hash_hex(signed_bytes)?;
+
+    if transaction
+        .get("signature")
+        .and_then(serde_json::Value::as_str)
+        .is_none_or(|sig| sig.trim().is_empty())
+    {
+        return Err(OwsLibError::InvalidInput(
+            "missing Atto signature in signed transaction payload".into(),
+        ));
+    }
+    if transaction
+        .get("address")
+        .and_then(serde_json::Value::as_str)
+        .is_none_or(|address| address.trim().is_empty())
+    {
+        return Err(OwsLibError::InvalidInput(
+            "missing Atto address in signed transaction payload".into(),
+        ));
+    }
+
+    if transaction
+        .get("work")
+        .and_then(serde_json::Value::as_str)
+        .is_none_or(is_missing_atto_work)
+    {
+        let work = generate_atto_work(&transaction)?;
+        transaction
+            .as_object_mut()
+            .ok_or_else(|| {
+                OwsLibError::InvalidInput("Atto transaction payload must be a JSON object".into())
+            })?
+            .insert("work".to_string(), serde_json::Value::String(work));
+    }
+
+    let publish_payload = atto_node_transaction_payload(&transaction)?;
+    let streamed_hash = crate::atto_rpc::AttoNodeClient::new(rpc_url)
+        .publish_transaction_value_stream(&publish_payload)?;
+    Ok(streamed_hash.unwrap_or(tx_hash))
+}
+
+fn atto_node_transaction_payload(
+    transaction: &serde_json::Value,
+) -> Result<serde_json::Value, OwsLibError> {
+    let mut block = transaction.clone();
+    let object = block.as_object_mut().ok_or_else(|| {
+        OwsLibError::InvalidInput("Atto transaction payload must be a JSON object".into())
+    })?;
+    let signature = object
+        .remove("signature")
+        .and_then(|value| value.as_str().map(str::to_string))
+        .ok_or_else(|| {
+            OwsLibError::InvalidInput("missing Atto signature in signed transaction payload".into())
+        })?;
+    let work = object
+        .remove("work")
+        .and_then(|value| value.as_str().map(str::to_string))
+        .ok_or_else(|| {
+            OwsLibError::InvalidInput("missing Atto work in signed transaction payload".into())
+        })?;
+
+    Ok(serde_json::json!({
+        "block": block,
+        "signature": signature,
+        "work": work,
+    }))
+}
+
+fn is_missing_atto_work(work: &str) -> bool {
+    let trimmed = work.trim();
+    trimmed.is_empty() || trimmed == "0000000000000000"
+}
+
+fn generate_atto_work(transaction: &serde_json::Value) -> Result<String, OwsLibError> {
+    let network = atto_transaction_string_field(transaction, "network")?;
+    let timestamp = atto_transaction_i64_field(transaction, "timestamp")?;
+    let target = atto_work_target(transaction)?;
+    let work_url = resolve_atto_work_url(network)?;
+
+    Ok(AttoWorkServerClient::new(work_url)
+        .work(&AttoWorkRequest {
+            network: network.to_string(),
+            timestamp,
+            target,
+        })?
+        .work)
+}
+
+fn atto_work_target(transaction: &serde_json::Value) -> Result<String, OwsLibError> {
+    let block_type = atto_transaction_string_field(transaction, "type")?;
+    let field = if block_type.eq_ignore_ascii_case("OPEN") {
+        "publicKey"
+    } else {
+        "previous"
+    };
+    atto_transaction_string_field(transaction, field).map(str::to_string)
+}
+
+fn atto_transaction_string_field<'a>(
+    transaction: &'a serde_json::Value,
+    field: &str,
+) -> Result<&'a str, OwsLibError> {
+    transaction
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            OwsLibError::InvalidInput(format!(
+                "missing Atto {field} in signed transaction payload"
+            ))
+        })
+}
+
+fn atto_transaction_i64_field(
+    transaction: &serde_json::Value,
+    field: &str,
+) -> Result<i64, OwsLibError> {
+    let value = transaction.get(field).ok_or_else(|| {
+        OwsLibError::InvalidInput(format!(
+            "missing Atto {field} in signed transaction payload"
+        ))
+    })?;
+    value
+        .as_i64()
+        .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+        .ok_or_else(|| {
+            OwsLibError::InvalidInput(format!(
+                "invalid Atto {field} in signed transaction payload"
+            ))
+        })
+}
+
+fn resolve_atto_work_url(network: &str) -> Result<String, OwsLibError> {
+    let network_key = match network.to_ascii_uppercase().as_str() {
+        "LIVE" => "live",
+        "BETA" => "beta",
+        "DEV" => "dev",
+        "LOCAL" => "local",
+        other => {
+            return Err(OwsLibError::InvalidInput(format!(
+                "unsupported Atto network in signed transaction payload: {other}"
+            )));
+        }
+    };
+    let key = format!("atto-work:{network_key}");
+    let config = Config::load_or_default();
+    let defaults = Config::default_rpc();
+    let url = config
+        .rpc
+        .get(&key)
+        .or_else(|| defaults.get(&key))
+        .ok_or_else(|| OwsLibError::InvalidInput(format!("no Atto work URL configured for {key}")))?
+        .clone();
+    if url.trim().is_empty() {
+        return Err(OwsLibError::InvalidInput(format!(
+            "Atto work URL is not configured for {key}"
+        )));
+    }
+    Ok(url)
 }
 
 fn broadcast_xrpl(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibError> {
@@ -1129,6 +1303,32 @@ mod tests {
 
     const TEST_PRIVKEY: &str = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318";
 
+    fn sample_atto_unsigned_payload_with_work() -> Vec<u8> {
+        let block = ows_signer::chains::atto::AttoBlock::Receive(
+            ows_signer::chains::atto::AttoReceiveBlock {
+                network: ows_signer::chains::atto::AttoNetwork::Local,
+                version: 0,
+                public_key: [0x11; 32],
+                height: 2,
+                balance: 42,
+                timestamp_ms: 1_700_000_000_000,
+                previous: [0x22; 32],
+                send_hash: [0x33; 32],
+            },
+        );
+        let mut payload = block.to_buffer();
+        payload.extend_from_slice(&[0x44; 8]);
+        payload
+    }
+
+    fn sample_atto_signed_payload() -> Vec<u8> {
+        let mut payload = sample_atto_unsigned_payload_with_work();
+        let work = payload.split_off(payload.len() - 8);
+        payload.extend_from_slice(&[0xaa; 64]);
+        payload.extend_from_slice(&work);
+        payload
+    }
+
     fn save_allowed_chains_policy(vault: &Path, id: &str, chain_ids: Vec<String>) {
         let policy = ows_core::Policy {
             id: id.to_string(),
@@ -1183,10 +1383,14 @@ mod tests {
         let phrase = generate_mnemonic(12).unwrap();
         let chains = [
             "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "sui", "xrpl", "nano", "near",
+            "atto",
         ];
         for chain in &chains {
             let addr = derive_address(&phrase, chain, None).unwrap();
             assert!(!addr.is_empty(), "address should be non-empty for {chain}");
+            if *chain == "atto" {
+                assert!(addr.starts_with("atto://"));
+            }
         }
     }
 
@@ -1238,6 +1442,30 @@ mod tests {
         let w1 = create_wallet("w1", None, None, Some(v1.path())).unwrap();
         assert!(!w1.accounts.is_empty());
 
+        let atto_account = w1
+            .accounts
+            .iter()
+            .find(|acct| acct.chain_id == "atto:live")
+            .expect("Atto account should be derived for new wallets");
+        assert!(atto_account.address.starts_with("atto://"));
+        assert_eq!(atto_account.derivation_path, "m/44'/1869902945'/0'");
+        let expected_atto_account_id = format!(
+            "atto:live:{}",
+            atto_account.address.strip_prefix("atto://").unwrap()
+        );
+
+        let stored = vault::load_wallet_by_name_or_id("w1", Some(v1.path())).unwrap();
+        let stored_atto = stored
+            .accounts
+            .iter()
+            .find(|acct| acct.chain_id == "atto:live")
+            .expect("Atto account should persist in wallet JSON");
+        assert_eq!(
+            stored_atto.account_id, expected_atto_account_id,
+            "Atto account IDs must persist without duplicating the atto:// address scheme"
+        );
+        assert!(stored_atto.address.starts_with("atto://"));
+
         // Export mnemonic
         let phrase = export_wallet("w1", None, Some(v1.path())).unwrap();
         assert_eq!(phrase.split_whitespace().count(), 12);
@@ -1267,7 +1495,7 @@ mod tests {
         // support generic off-chain message signing without a defined convention.
         // NEAR's V1 sign_message is raw ed25519 (NEP-413 follow-up tracked).
         let chains = [
-            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "near",
+            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "near", "atto",
         ];
         for chain in &chains {
             let result = sign_message(
@@ -1854,6 +2082,39 @@ mod tests {
     }
 
     // ================================================================
+    // 11A. ATTO PAYLOAD
+    // ================================================================
+
+    #[test]
+    fn atto_node_transaction_payload_separates_block_signature_and_work() {
+        let transaction = ows_signer::chains::atto::atto_signed_transaction_to_api_json_value(
+            &sample_atto_signed_payload(),
+        )
+        .unwrap();
+
+        let payload = atto_node_transaction_payload(&transaction).unwrap();
+        let block = payload["block"].as_object().unwrap();
+
+        assert_eq!(payload["block"]["type"], "RECEIVE");
+        assert_eq!(payload["work"], "4444444444444444");
+        assert_eq!(payload["signature"].as_str().unwrap().len(), 128);
+        assert!(!block.contains_key("signature"));
+        assert!(!block.contains_key("work"));
+        assert!(block["address"].as_str().unwrap().starts_with("atto://"));
+    }
+
+    #[test]
+    fn atto_broadcast_rejects_malformed_signed_payloads() {
+        let err = broadcast(ChainType::Atto, "http://127.0.0.1:9", b"not json").unwrap_err();
+
+        assert!(
+            err.to_string().contains("invalid transaction")
+                || err.to_string().contains("unsupported Atto block type"),
+            "{err}"
+        );
+    }
+
+    // ================================================================
     // 11. BUG REGRESSION: CLI send_transaction broadcasts raw signature
     // ================================================================
 
@@ -2275,6 +2536,123 @@ mod tests {
         let sig = sign_transaction("char-pk", "evm", "deadbeef", None, None, Some(vault)).unwrap();
         assert!(!sig.signature.is_empty());
         assert!(sig.recovery_id.is_some());
+    }
+
+    #[test]
+    fn atto_private_key_import_uses_ed25519_without_corrupting_secp256k1() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+        let atto_ed25519_key = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+        let expected_atto = signer_for_chain(ChainType::Atto)
+            .derive_address(&hex::decode(atto_ed25519_key).unwrap())
+            .unwrap();
+
+        let wallet = import_wallet_private_key(
+            "atto-pk",
+            atto_ed25519_key,
+            Some("atto"),
+            Some("pass"),
+            Some(vault),
+            Some(TEST_PRIVKEY),
+            None,
+        )
+        .unwrap();
+
+        let atto_account = wallet
+            .accounts
+            .iter()
+            .find(|acct| acct.chain_id == "atto:live")
+            .expect("Atto account should be present for private-key imports");
+        assert_eq!(atto_account.address, expected_atto);
+        let stored = vault::load_wallet_by_name_or_id("atto-pk", Some(vault)).unwrap();
+        let stored_atto = stored
+            .accounts
+            .iter()
+            .find(|acct| acct.chain_id == "atto:live")
+            .expect("Atto account should persist for private-key imports");
+        assert!(stored_atto.address.starts_with("atto://"));
+        assert_eq!(
+            stored_atto.account_id,
+            format!(
+                "atto:live:{}",
+                expected_atto.strip_prefix("atto://").unwrap()
+            )
+        );
+
+        let atto_sig = sign_message(
+            "atto-pk",
+            "atto",
+            "atto import test",
+            Some("pass"),
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
+        assert!(!atto_sig.signature.is_empty());
+        assert!(atto_sig.recovery_id.is_none());
+
+        let evm_sig = sign_transaction(
+            "atto-pk",
+            "base",
+            "deadbeef",
+            Some("pass"),
+            None,
+            Some(vault),
+        )
+        .unwrap();
+        assert!(!evm_sig.signature.is_empty());
+        assert!(evm_sig.recovery_id.is_some());
+    }
+
+    #[test]
+    fn atto_allowed_chains_policy_allows_and_denies_canonical_chain_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path();
+        let wallet = create_wallet("atto-policy", None, None, Some(vault)).unwrap();
+        save_allowed_chains_policy(vault, "atto-only", vec!["atto:live".to_string()]);
+
+        let (token, _) = crate::key_ops::create_api_key(
+            "atto-policy-key",
+            std::slice::from_ref(&wallet.id),
+            &["atto-only".to_string()],
+            "",
+            None,
+            Some(vault),
+        )
+        .unwrap();
+
+        let allowed = sign_message(
+            &wallet.id,
+            "atto",
+            "policy allows canonical Atto",
+            Some(&token),
+            None,
+            None,
+            Some(vault),
+        );
+        assert!(
+            allowed.is_ok(),
+            "Atto allowlist should pass: {:?}",
+            allowed.err()
+        );
+
+        let denied = sign_message(
+            &wallet.id,
+            "base",
+            "policy denies non-Atto",
+            Some(&token),
+            None,
+            None,
+            Some(vault),
+        );
+        match denied.unwrap_err() {
+            OwsLibError::Core(OwsError::PolicyDenied { reason, .. }) => {
+                assert!(reason.contains("eip155:8453"));
+                assert!(reason.contains("not in allowlist"));
+            }
+            other => panic!("expected PolicyDenied, got: {other}"),
+        }
     }
 
     #[test]

--- a/ows/crates/ows-signer/src/chains/atto.rs
+++ b/ows/crates/ows-signer/src/chains/atto.rs
@@ -1,0 +1,1063 @@
+use crate::curve::Curve;
+use crate::traits::{ChainSigner, SignOutput, SignerError};
+use blake2::digest::{consts::U32, consts::U5, consts::U64, Digest};
+use blake2::Blake2b;
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use ows_core::ChainType;
+use serde_json::{json, Value};
+
+const ATTO_COIN_TYPE: u32 = 1_869_902_945;
+const ATTO_ADDRESS_ALGORITHM_V1: u8 = 0;
+const ATTO_SIGNED_MESSAGE_DOMAIN: &[u8] = b"ATTO Signed Message v1";
+const RFC4648_BASE32_LOWER: &[u8; 32] = b"abcdefghijklmnopqrstuvwxyz234567";
+
+/// Encode bytes using RFC 4648 base32 without padding, lowercased.
+fn encode_base32_lower_no_pad(data: &[u8]) -> String {
+    let mut out = String::with_capacity((data.len() * 8).div_ceil(5));
+    let mut buffer: u16 = 0;
+    let mut bits: u8 = 0;
+
+    for &byte in data {
+        buffer = (buffer << 8) | byte as u16;
+        bits += 8;
+        while bits >= 5 {
+            let shift = bits - 5;
+            let index = ((buffer >> shift) & 0x1f) as usize;
+            out.push(RFC4648_BASE32_LOWER[index] as char);
+            bits -= 5;
+            buffer &= (1 << bits) - 1;
+        }
+    }
+
+    if bits > 0 {
+        let index = ((buffer << (5 - bits)) & 0x1f) as usize;
+        out.push(RFC4648_BASE32_LOWER[index] as char);
+    }
+
+    out
+}
+
+fn decode_base32_lower_no_pad(body: &str) -> Result<Vec<u8>, SignerError> {
+    let mut out = Vec::with_capacity(body.len() * 5 / 8);
+    let mut buffer: u16 = 0;
+    let mut bits: u8 = 0;
+
+    for (idx, byte) in body.bytes().enumerate() {
+        let value = match byte {
+            b'a'..=b'z' => byte - b'a',
+            b'2'..=b'7' => byte - b'2' + 26,
+            b'A'..=b'Z' => {
+                return Err(SignerError::AddressDerivationFailed(format!(
+                    "invalid Atto address alphabet: uppercase character at body index {idx}"
+                )))
+            }
+            _ => {
+                return Err(SignerError::AddressDerivationFailed(format!(
+                    "invalid Atto address alphabet: character {:?} at body index {idx}",
+                    byte as char
+                )))
+            }
+        };
+
+        buffer = (buffer << 5) | value as u16;
+        bits += 5;
+        while bits >= 8 {
+            let shift = bits - 8;
+            out.push(((buffer >> shift) & 0xff) as u8);
+            bits -= 8;
+            buffer &= (1 << bits) - 1;
+        }
+    }
+
+    if bits > 0 && buffer != 0 {
+        return Err(SignerError::AddressDerivationFailed(
+            "invalid Atto address padding bits".into(),
+        ));
+    }
+
+    Ok(out)
+}
+
+fn atto_checksum(payload: &[u8; 33]) -> [u8; 5] {
+    let mut hasher = Blake2b::<U5>::new();
+    hasher.update(payload);
+    hasher.finalize().into()
+}
+
+pub fn atto_address(pubkey: &[u8; 32]) -> String {
+    let mut bytes = [0u8; 38];
+    bytes[0] = ATTO_ADDRESS_ALGORITHM_V1;
+    bytes[1..33].copy_from_slice(pubkey);
+
+    let payload: [u8; 33] = bytes[..33].try_into().expect("payload length is fixed");
+    bytes[33..].copy_from_slice(&atto_checksum(&payload));
+
+    format!("atto://{}", encode_base32_lower_no_pad(&bytes))
+}
+
+fn decode_atto_address_bytes(address: &str) -> Result<[u8; 38], SignerError> {
+    let body = address.strip_prefix("atto://").ok_or_else(|| {
+        SignerError::AddressDerivationFailed("invalid Atto address prefix: expected atto://".into())
+    })?;
+
+    if body.len() != 61 {
+        return Err(SignerError::AddressDerivationFailed(format!(
+            "invalid Atto address length: expected 61 base32 characters, got {}",
+            body.len()
+        )));
+    }
+
+    let decoded = decode_base32_lower_no_pad(body)?;
+    let bytes: [u8; 38] = decoded.try_into().map_err(|decoded: Vec<u8>| {
+        SignerError::AddressDerivationFailed(format!(
+            "invalid Atto address payload length: expected 38 bytes, got {}",
+            decoded.len()
+        ))
+    })?;
+
+    Ok(bytes)
+}
+
+pub fn atto_pubkey_from_address(address: &str) -> Result<[u8; 32], SignerError> {
+    let bytes = decode_atto_address_bytes(address)?;
+
+    if bytes[0] != ATTO_ADDRESS_ALGORITHM_V1 {
+        return Err(SignerError::AddressDerivationFailed(format!(
+            "unsupported Atto address algorithm byte: expected {ATTO_ADDRESS_ALGORITHM_V1}, got {}",
+            bytes[0]
+        )));
+    }
+
+    let payload: [u8; 33] = bytes[..33].try_into().expect("payload length is fixed");
+    let expected_checksum = atto_checksum(&payload);
+    if bytes[33..] != expected_checksum {
+        return Err(SignerError::AddressDerivationFailed(
+            "invalid Atto address checksum".into(),
+        ));
+    }
+
+    let public_key: [u8; 32] = bytes[1..33].try_into().expect("public key length is fixed");
+    Ok(public_key)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttoNetwork {
+    Live,
+    Beta,
+    Dev,
+    Local,
+}
+
+impl AttoNetwork {
+    fn code(self) -> u8 {
+        match self {
+            Self::Live => 0,
+            Self::Beta => 1,
+            Self::Dev => 2,
+            Self::Local => 3,
+        }
+    }
+
+    fn api_name(self) -> &'static str {
+        match self {
+            Self::Live => "LIVE",
+            Self::Beta => "BETA",
+            Self::Dev => "DEV",
+            Self::Local => "LOCAL",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoSendBlock {
+    pub network: AttoNetwork,
+    pub version: u16,
+    pub public_key: [u8; 32],
+    pub height: u64,
+    pub balance: u64,
+    pub timestamp_ms: i64,
+    pub previous: [u8; 32],
+    pub receiver_public_key: [u8; 32],
+    pub amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoReceiveBlock {
+    pub network: AttoNetwork,
+    pub version: u16,
+    pub public_key: [u8; 32],
+    pub height: u64,
+    pub balance: u64,
+    pub timestamp_ms: i64,
+    pub previous: [u8; 32],
+    pub send_hash: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoOpenBlock {
+    pub network: AttoNetwork,
+    pub version: u16,
+    pub public_key: [u8; 32],
+    pub balance: u64,
+    pub timestamp_ms: i64,
+    pub send_hash: [u8; 32],
+    pub representative_public_key: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoChangeBlock {
+    pub network: AttoNetwork,
+    pub version: u16,
+    pub public_key: [u8; 32],
+    pub height: u64,
+    pub balance: u64,
+    pub timestamp_ms: i64,
+    pub previous: [u8; 32],
+    pub representative_public_key: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttoBlock {
+    Open(AttoOpenBlock),
+    Receive(AttoReceiveBlock),
+    Send(AttoSendBlock),
+    Change(AttoChangeBlock),
+}
+
+impl AttoBlock {
+    pub const OPEN_SIZE: usize = 119;
+    pub const RECEIVE_SIZE: usize = 126;
+    pub const SEND_SIZE: usize = 134;
+    pub const CHANGE_SIZE: usize = 126;
+    const ALGORITHM_V1: u8 = 0;
+
+    pub fn to_buffer(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.block_size());
+        match self {
+            Self::Open(block) => {
+                Self::write_common(&mut out, 0, block.network, block.version, &block.public_key);
+                Self::write_u64_le(&mut out, block.balance);
+                Self::write_i64_le(&mut out, block.timestamp_ms);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.send_hash);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.representative_public_key);
+            }
+            Self::Receive(block) => {
+                Self::write_common(&mut out, 1, block.network, block.version, &block.public_key);
+                Self::write_u64_le(&mut out, block.height);
+                Self::write_u64_le(&mut out, block.balance);
+                Self::write_i64_le(&mut out, block.timestamp_ms);
+                out.extend_from_slice(&block.previous);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.send_hash);
+            }
+            Self::Send(block) => {
+                Self::write_common(&mut out, 2, block.network, block.version, &block.public_key);
+                Self::write_u64_le(&mut out, block.height);
+                Self::write_u64_le(&mut out, block.balance);
+                Self::write_i64_le(&mut out, block.timestamp_ms);
+                out.extend_from_slice(&block.previous);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.receiver_public_key);
+                Self::write_u64_le(&mut out, block.amount);
+            }
+            Self::Change(block) => {
+                Self::write_common(&mut out, 3, block.network, block.version, &block.public_key);
+                Self::write_u64_le(&mut out, block.height);
+                Self::write_u64_le(&mut out, block.balance);
+                Self::write_i64_le(&mut out, block.timestamp_ms);
+                out.extend_from_slice(&block.previous);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.representative_public_key);
+            }
+        }
+        debug_assert_eq!(out.len(), self.block_size());
+        out
+    }
+
+    pub fn hash(&self) -> [u8; 32] {
+        atto_block_hash(&self.to_buffer())
+    }
+
+    pub fn block_size(&self) -> usize {
+        match self {
+            Self::Open(_) => Self::OPEN_SIZE,
+            Self::Receive(_) => Self::RECEIVE_SIZE,
+            Self::Send(_) => Self::SEND_SIZE,
+            Self::Change(_) => Self::CHANGE_SIZE,
+        }
+    }
+
+    pub fn to_api_json_value(&self) -> Value {
+        match self {
+            Self::Open(block) => json!({
+                "type": "OPEN",
+                "network": block.network.api_name(),
+                "version": block.version,
+                "algorithm": "V1",
+                "publicKey": hex::encode_upper(block.public_key),
+                "balance": block.balance,
+                "timestamp": block.timestamp_ms,
+                "sendHashAlgorithm": "V1",
+                "sendHash": hex::encode_upper(block.send_hash),
+                "representativeAlgorithm": "V1",
+                "representativePublicKey": hex::encode_upper(block.representative_public_key),
+                "height": 1,
+                "address": atto_address(&block.public_key),
+                "representativeAddress": atto_address(&block.representative_public_key),
+            }),
+            Self::Receive(block) => json!({
+                "type": "RECEIVE",
+                "network": block.network.api_name(),
+                "version": block.version,
+                "algorithm": "V1",
+                "publicKey": hex::encode_upper(block.public_key),
+                "height": block.height,
+                "balance": block.balance,
+                "timestamp": block.timestamp_ms,
+                "previous": hex::encode_upper(block.previous),
+                "sendHashAlgorithm": "V1",
+                "sendHash": hex::encode_upper(block.send_hash),
+                "address": atto_address(&block.public_key),
+            }),
+            Self::Send(block) => json!({
+                "type": "SEND",
+                "network": block.network.api_name(),
+                "version": block.version,
+                "algorithm": "V1",
+                "publicKey": hex::encode_upper(block.public_key),
+                "height": block.height,
+                "balance": block.balance,
+                "timestamp": block.timestamp_ms,
+                "previous": hex::encode_upper(block.previous),
+                "receiverAlgorithm": "V1",
+                "receiverPublicKey": hex::encode_upper(block.receiver_public_key),
+                "amount": block.amount,
+                "address": atto_address(&block.public_key),
+                "receiverAddress": atto_address(&block.receiver_public_key),
+            }),
+            Self::Change(block) => json!({
+                "type": "CHANGE",
+                "network": block.network.api_name(),
+                "version": block.version,
+                "algorithm": "V1",
+                "publicKey": hex::encode_upper(block.public_key),
+                "height": block.height,
+                "balance": block.balance,
+                "timestamp": block.timestamp_ms,
+                "previous": hex::encode_upper(block.previous),
+                "representativeAlgorithm": "V1",
+                "representativePublicKey": hex::encode_upper(block.representative_public_key),
+                "address": atto_address(&block.public_key),
+                "representativeAddress": atto_address(&block.representative_public_key),
+            }),
+        }
+    }
+
+    fn write_common(
+        out: &mut Vec<u8>,
+        block_type: u8,
+        network: AttoNetwork,
+        version: u16,
+        public_key: &[u8; 32],
+    ) {
+        out.push(block_type);
+        out.push(network.code());
+        out.extend_from_slice(&version.to_le_bytes());
+        out.push(Self::ALGORITHM_V1);
+        out.extend_from_slice(public_key);
+    }
+
+    fn write_u64_le(out: &mut Vec<u8>, value: u64) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_i64_le(out: &mut Vec<u8>, value: i64) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoSignedTransaction {
+    pub block: AttoBlock,
+    pub signature: [u8; 64],
+    pub work: [u8; 8],
+}
+
+impl AttoSignedTransaction {
+    pub fn new(block: AttoBlock, signature: [u8; 64], work: [u8; 8]) -> Self {
+        Self {
+            block,
+            signature,
+            work,
+        }
+    }
+
+    pub fn to_buffer(&self) -> Vec<u8> {
+        let mut out = self.block.to_buffer();
+        out.extend_from_slice(&self.signature);
+        out.extend_from_slice(&self.work);
+        out
+    }
+
+    pub fn to_api_json_value(&self) -> Value {
+        let mut value = self.block.to_api_json_value();
+        if let Value::Object(ref mut object) = value {
+            object.insert(
+                "signature".to_string(),
+                Value::String(hex::encode_upper(self.signature)),
+            );
+            object.insert(
+                "work".to_string(),
+                Value::String(hex::encode_upper(self.work)),
+            );
+        }
+        value
+    }
+}
+
+pub fn atto_block_hash(block_bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Blake2b::<U32>::new();
+    hasher.update(block_bytes);
+    hasher.finalize().into()
+}
+
+fn atto_block_size_from_prefix(tx_bytes: &[u8]) -> Result<usize, SignerError> {
+    let block_type = tx_bytes.first().copied().ok_or_else(|| {
+        SignerError::InvalidTransaction("empty Atto transaction/block payload".into())
+    })?;
+    match block_type {
+        0 => Ok(AttoBlock::OPEN_SIZE),
+        1 => Ok(AttoBlock::RECEIVE_SIZE),
+        2 => Ok(AttoBlock::SEND_SIZE),
+        3 => Ok(AttoBlock::CHANGE_SIZE),
+        other => Err(SignerError::InvalidTransaction(format!(
+            "unsupported Atto block type byte {other}; expected canonical block bytes or 32-byte canonical block hash"
+        ))),
+    }
+}
+
+fn atto_unsigned_parts(tx_bytes: &[u8]) -> Result<(&[u8], &[u8]), SignerError> {
+    let block_size = atto_block_size_from_prefix(tx_bytes)?;
+    if tx_bytes.len() == block_size {
+        Ok((&tx_bytes[..block_size], &[]))
+    } else if tx_bytes.len() == block_size + 8 {
+        Ok((&tx_bytes[..block_size], &tx_bytes[block_size..]))
+    } else if tx_bytes.len() == block_size + 64 + 8 {
+        Err(SignerError::InvalidTransaction(
+            "Atto payload is already signed; pass canonical block bytes plus optional 8-byte work"
+                .into(),
+        ))
+    } else {
+        Err(SignerError::InvalidTransaction(format!(
+            "invalid Atto payload length: block type expects {block_size} block bytes, got {} bytes",
+            tx_bytes.len()
+        )))
+    }
+}
+
+fn atto_network_from_code(code: u8) -> Result<AttoNetwork, SignerError> {
+    match code {
+        0 => Ok(AttoNetwork::Live),
+        1 => Ok(AttoNetwork::Beta),
+        2 => Ok(AttoNetwork::Dev),
+        3 => Ok(AttoNetwork::Local),
+        other => Err(SignerError::InvalidTransaction(format!(
+            "unsupported Atto network byte {other}"
+        ))),
+    }
+}
+
+fn read_array<const N: usize>(bytes: &[u8], offset: &mut usize) -> Result<[u8; N], SignerError> {
+    let end = *offset + N;
+    let slice = bytes.get(*offset..end).ok_or_else(|| {
+        SignerError::InvalidTransaction(format!(
+            "truncated Atto payload while reading {N} bytes at offset {}",
+            *offset
+        ))
+    })?;
+    *offset = end;
+    slice.try_into().map_err(|_| {
+        SignerError::InvalidTransaction(format!("invalid Atto payload field length {N}"))
+    })
+}
+
+fn read_u8(bytes: &[u8], offset: &mut usize) -> Result<u8, SignerError> {
+    Ok(read_array::<1>(bytes, offset)?[0])
+}
+
+fn read_u16_le(bytes: &[u8], offset: &mut usize) -> Result<u16, SignerError> {
+    Ok(u16::from_le_bytes(read_array::<2>(bytes, offset)?))
+}
+
+fn read_u64_le(bytes: &[u8], offset: &mut usize) -> Result<u64, SignerError> {
+    Ok(u64::from_le_bytes(read_array::<8>(bytes, offset)?))
+}
+
+fn read_i64_le(bytes: &[u8], offset: &mut usize) -> Result<i64, SignerError> {
+    Ok(i64::from_le_bytes(read_array::<8>(bytes, offset)?))
+}
+
+fn read_algorithm_v1(bytes: &[u8], offset: &mut usize, label: &str) -> Result<(), SignerError> {
+    let algorithm = read_u8(bytes, offset)?;
+    if algorithm != AttoBlock::ALGORITHM_V1 {
+        return Err(SignerError::InvalidTransaction(format!(
+            "unsupported Atto {label} algorithm byte {algorithm}"
+        )));
+    }
+    Ok(())
+}
+
+fn atto_block_from_bytes(block_bytes: &[u8]) -> Result<AttoBlock, SignerError> {
+    let expected = atto_block_size_from_prefix(block_bytes)?;
+    if block_bytes.len() != expected {
+        return Err(SignerError::InvalidTransaction(format!(
+            "invalid Atto block length: expected {expected} bytes, got {}",
+            block_bytes.len()
+        )));
+    }
+
+    let mut offset = 0;
+    let block_type = read_u8(block_bytes, &mut offset)?;
+    let network = atto_network_from_code(read_u8(block_bytes, &mut offset)?)?;
+    let version = read_u16_le(block_bytes, &mut offset)?;
+    read_algorithm_v1(block_bytes, &mut offset, "block")?;
+    let public_key = read_array::<32>(block_bytes, &mut offset)?;
+
+    match block_type {
+        0 => {
+            let balance = read_u64_le(block_bytes, &mut offset)?;
+            let timestamp_ms = read_i64_le(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "send hash")?;
+            let send_hash = read_array::<32>(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "representative")?;
+            let representative_public_key = read_array::<32>(block_bytes, &mut offset)?;
+            Ok(AttoBlock::Open(AttoOpenBlock {
+                network,
+                version,
+                public_key,
+                balance,
+                timestamp_ms,
+                send_hash,
+                representative_public_key,
+            }))
+        }
+        1 => {
+            let height = read_u64_le(block_bytes, &mut offset)?;
+            let balance = read_u64_le(block_bytes, &mut offset)?;
+            let timestamp_ms = read_i64_le(block_bytes, &mut offset)?;
+            let previous = read_array::<32>(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "send hash")?;
+            let send_hash = read_array::<32>(block_bytes, &mut offset)?;
+            Ok(AttoBlock::Receive(AttoReceiveBlock {
+                network,
+                version,
+                public_key,
+                height,
+                balance,
+                timestamp_ms,
+                previous,
+                send_hash,
+            }))
+        }
+        2 => {
+            let height = read_u64_le(block_bytes, &mut offset)?;
+            let balance = read_u64_le(block_bytes, &mut offset)?;
+            let timestamp_ms = read_i64_le(block_bytes, &mut offset)?;
+            let previous = read_array::<32>(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "receiver")?;
+            let receiver_public_key = read_array::<32>(block_bytes, &mut offset)?;
+            let amount = read_u64_le(block_bytes, &mut offset)?;
+            Ok(AttoBlock::Send(AttoSendBlock {
+                network,
+                version,
+                public_key,
+                height,
+                balance,
+                timestamp_ms,
+                previous,
+                receiver_public_key,
+                amount,
+            }))
+        }
+        3 => {
+            let height = read_u64_le(block_bytes, &mut offset)?;
+            let balance = read_u64_le(block_bytes, &mut offset)?;
+            let timestamp_ms = read_i64_le(block_bytes, &mut offset)?;
+            let previous = read_array::<32>(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "representative")?;
+            let representative_public_key = read_array::<32>(block_bytes, &mut offset)?;
+            Ok(AttoBlock::Change(AttoChangeBlock {
+                network,
+                version,
+                public_key,
+                height,
+                balance,
+                timestamp_ms,
+                previous,
+                representative_public_key,
+            }))
+        }
+        other => Err(SignerError::InvalidTransaction(format!(
+            "unsupported Atto block type byte {other}"
+        ))),
+    }
+}
+
+pub fn atto_signed_transaction_to_api_json_value(
+    signed_bytes: &[u8],
+) -> Result<Value, SignerError> {
+    let block_size = atto_block_size_from_prefix(signed_bytes)?;
+    let expected = block_size + 64 + 8;
+    if signed_bytes.len() != expected {
+        return Err(SignerError::InvalidTransaction(format!(
+            "Atto signed transaction must be {expected} bytes ({block_size} block + 64 signature + 8 work), got {}",
+            signed_bytes.len()
+        )));
+    }
+    let block = atto_block_from_bytes(&signed_bytes[..block_size])?;
+    let signature = signed_bytes[block_size..block_size + 64]
+        .try_into()
+        .expect("signature slice length is fixed");
+    let work = signed_bytes[block_size + 64..expected]
+        .try_into()
+        .expect("work slice length is fixed");
+    Ok(AttoSignedTransaction::new(block, signature, work).to_api_json_value())
+}
+
+pub fn atto_signed_transaction_hash_hex(signed_bytes: &[u8]) -> Result<String, SignerError> {
+    let block_size = atto_block_size_from_prefix(signed_bytes)?;
+    if signed_bytes.len() < block_size {
+        return Err(SignerError::InvalidTransaction(format!(
+            "invalid Atto signed transaction length: expected at least {block_size} block bytes, got {}",
+            signed_bytes.len()
+        )));
+    }
+    Ok(hex::encode_upper(atto_block_hash(
+        &signed_bytes[..block_size],
+    )))
+}
+
+/// Atto chain signer metadata and local Ed25519 primitives.
+///
+/// Canonical block bytes follow Atto Commons `AttoBlock.toBuffer()`. The block
+/// hash is BLAKE2b-256 over those bytes, and Ed25519 signs that 32-byte hash.
+/// Full transaction bytes are `block || signature64 || work8`; work is encoded
+/// for broadcast but deliberately excluded from the signature.
+pub struct AttoSigner;
+
+impl AttoSigner {
+    fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
+        let key_bytes: [u8; 32] = private_key.try_into().map_err(|_| {
+            SignerError::InvalidPrivateKey(format!("expected 32 bytes, got {}", private_key.len()))
+        })?;
+        Ok(SigningKey::from_bytes(&key_bytes))
+    }
+
+    fn signed_message_digest(public_key: &[u8; 32], message: &[u8]) -> [u8; 64] {
+        let mut hasher = Blake2b::<U64>::new();
+        hasher.update(ATTO_SIGNED_MESSAGE_DOMAIN);
+        hasher.update(public_key);
+        hasher.update((message.len() as u64).to_le_bytes());
+        hasher.update(message);
+        hasher.finalize().into()
+    }
+}
+
+impl ChainSigner for AttoSigner {
+    fn chain_type(&self) -> ChainType {
+        ChainType::Atto
+    }
+
+    fn curve(&self) -> Curve {
+        Curve::Ed25519
+    }
+
+    fn coin_type(&self) -> u32 {
+        ATTO_COIN_TYPE
+    }
+
+    fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key: VerifyingKey = signing_key.verifying_key();
+        Ok(atto_address(verifying_key.as_bytes()))
+    }
+
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key: VerifyingKey = signing_key.verifying_key();
+        let signature = signing_key.sign(message);
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: Some(verifying_key.to_bytes().to_vec()),
+        })
+    }
+
+    fn sign_transaction(
+        &self,
+        private_key: &[u8],
+        tx_bytes: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        if tx_bytes.len() == 32 {
+            return self.sign(private_key, tx_bytes);
+        }
+        let (block_bytes, _) = atto_unsigned_parts(tx_bytes)?;
+        let hash = atto_block_hash(block_bytes);
+        self.sign(private_key, &hash)
+    }
+
+    fn extract_signable_bytes<'a>(&self, tx_bytes: &'a [u8]) -> Result<&'a [u8], SignerError> {
+        let (block_bytes, _) = atto_unsigned_parts(tx_bytes)?;
+        Ok(block_bytes)
+    }
+
+    fn encode_signed_transaction(
+        &self,
+        tx_bytes: &[u8],
+        signature: &SignOutput,
+    ) -> Result<Vec<u8>, SignerError> {
+        if signature.signature.len() != 64 {
+            return Err(SignerError::InvalidTransaction(format!(
+                "Atto signatures must be 64 bytes, got {} bytes",
+                signature.signature.len()
+            )));
+        }
+
+        let (block_bytes, work) = atto_unsigned_parts(tx_bytes)?;
+        let mut signed = Vec::with_capacity(block_bytes.len() + 64 + 8);
+        signed.extend_from_slice(block_bytes);
+        signed.extend_from_slice(&signature.signature);
+        if work.is_empty() {
+            signed.extend_from_slice(&[0u8; 8]);
+        } else {
+            signed.extend_from_slice(work);
+        }
+        Ok(signed)
+    }
+
+    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let public_key = signing_key.verifying_key().to_bytes();
+        let digest = Self::signed_message_digest(&public_key, message);
+        let signature = signing_key.sign(&digest);
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: Some(public_key.to_vec()),
+        })
+    }
+
+    fn default_derivation_path(&self, index: u32) -> String {
+        format!("m/44'/{ATTO_COIN_TYPE}'/{index}'")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chains::signer_for_chain;
+    use crate::hd::HdDeriver;
+    use crate::mnemonic::Mnemonic;
+    use ed25519_dalek::Verifier;
+
+    const ABANDON_PHRASE: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn derive_key(index: u32) -> Vec<u8> {
+        let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
+        let signer = AttoSigner;
+        let key = HdDeriver::derive_from_mnemonic(
+            &mnemonic,
+            "",
+            &signer.default_derivation_path(index),
+            Curve::Ed25519,
+        )
+        .unwrap();
+        key.expose().to_vec()
+    }
+
+    #[test]
+    fn chain_properties() {
+        let signer = AttoSigner;
+        assert_eq!(signer.chain_type(), ChainType::Atto);
+        assert_eq!(signer.curve(), Curve::Ed25519);
+        assert_eq!(signer.coin_type(), ATTO_COIN_TYPE);
+        assert_eq!(signer.default_derivation_path(0), "m/44'/1869902945'/0'");
+    }
+
+    #[test]
+    fn address_has_atto_uri_shape() {
+        let key = derive_key(0);
+        let signer = AttoSigner;
+        let address = signer.derive_address(&key).unwrap();
+        assert!(address.starts_with("atto://"));
+        assert_eq!(address.len(), "atto://".len() + 61);
+        assert!(address["atto://".len()..]
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || ('2'..='7').contains(&c)));
+    }
+
+    #[test]
+    fn address_decodes_to_original_pubkey() {
+        // Fixture generated from OWS' Atto codec contract: algorithm byte 0,
+        // RFC 4648 lowercase base32 without padding, BLAKE2b-5 checksum.
+        let pubkey = [0x42u8; 32];
+        let address = atto_address(&pubkey);
+        assert_eq!(
+            address,
+            "atto://abbeeqscijbeeqscijbeeqscijbeeqscijbeeqscijbeeqscijbefcvpqter6"
+        );
+        assert_eq!(atto_pubkey_from_address(&address).unwrap(), pubkey);
+    }
+
+    #[test]
+    fn address_decoder_accepts_contract_example() {
+        // Public Atto address example without source private key, so this only
+        // verifies address decoding.
+        let address = "atto://aaferyy3quqiyugpambc452bu2oqh7hrcazz4vnvem2meaa6thwf4vkiuiwyw";
+        let pubkey = atto_pubkey_from_address(address).unwrap();
+        assert_eq!(pubkey.len(), 32);
+    }
+
+    #[test]
+    fn address_decoder_rejects_invalid_prefix_case_length_alphabet_algorithm_and_checksum() {
+        let valid = atto_address(&[0x42u8; 32]);
+
+        let uppercase_body = format!("atto://{}", valid["atto://".len()..].to_uppercase());
+        for (address, expected_error) in [
+            (valid.replacen("atto://", "nano://", 1), "prefix"),
+            (valid.to_uppercase(), "prefix"),
+            (uppercase_body, "alphabet"),
+            (format!("{}a", valid), "61"),
+            (valid.replacen('a', "0", 1), "prefix"),
+            (valid.replacen('b', "0", 1), "alphabet"),
+        ] {
+            let err = atto_pubkey_from_address(&address).unwrap_err();
+            assert!(
+                err.to_string().contains(expected_error),
+                "expected {expected_error:?} in {err} for {address}"
+            );
+        }
+
+        let mut decoded = decode_atto_address_bytes(&valid).unwrap();
+        decoded[0] = 1;
+        let bad_algorithm = format!("atto://{}", encode_base32_lower_no_pad(&decoded));
+        let err = atto_pubkey_from_address(&bad_algorithm).unwrap_err();
+        assert!(err.to_string().contains("algorithm"));
+
+        let mut bad_checksum = valid.clone();
+        let last = bad_checksum.pop().unwrap();
+        bad_checksum.push(if last == 'a' { 'b' } else { 'a' });
+        let err = atto_pubkey_from_address(&bad_checksum).unwrap_err();
+        assert!(err.to_string().contains("checksum"));
+    }
+
+    #[test]
+    fn sign_transaction_requires_canonical_atto_block_payload() {
+        let key = derive_key(0);
+        let signer = AttoSigner;
+        let err = signer.sign_transaction(&key, b"not a block").unwrap_err();
+        assert!(err.to_string().contains("unsupported Atto block type"));
+
+        let block = fixture_receive_block();
+        let signature = signer.sign_transaction(&key, &block.to_buffer()).unwrap();
+        assert_eq!(signature.signature.len(), 64);
+    }
+
+    #[test]
+    fn sign_message_uses_atto_domain_separated_hash() {
+        let key = derive_key(0);
+        let signer = AttoSigner;
+        let message = b"atto message";
+        let output = signer.sign_message(&key, message).unwrap();
+        let public_key =
+            VerifyingKey::from_bytes(&output.public_key.unwrap().try_into().unwrap()).unwrap();
+        let signature = ed25519_dalek::Signature::from_bytes(&output.signature.try_into().unwrap());
+
+        let mut preimage = Vec::new();
+        preimage.extend_from_slice(b"ATTO Signed Message v1");
+        preimage.extend_from_slice(public_key.as_bytes());
+        preimage.extend_from_slice(&(message.len() as u64).to_le_bytes());
+        preimage.extend_from_slice(message);
+        let digest = Blake2b::<U64>::digest(&preimage);
+
+        public_key.verify(&digest, &signature).unwrap();
+        assert!(public_key.verify(message, &signature).is_err());
+    }
+
+    #[test]
+    fn official_send_fixture_serializes_to_canonical_block_bytes_and_hash() {
+        let block = fixture_send_block();
+        assert_eq!(block.to_buffer().len(), 134);
+        assert_eq!(
+            hex::encode_upper(block.to_buffer()),
+            concat!(
+                "0203000000",
+                "A5E7E4B3B93150314E1177D5B9DE0057626B16A4B3C3F1DB37DF67628A5EF457",
+                "0200000000000000",
+                "0100000000000000",
+                "FB1D08E38C010000",
+                "6CC2D3A7513723B1BA59DE784BA546BAF6447464D0BA3D80004752D6F9F4BA23",
+                "00",
+                "552254E101B51B22080D084C12C94BF7DFC5BE0D973025D62C0BC1FF4D9B145F",
+                "0100000000000000"
+            )
+        );
+        assert_eq!(
+            hex::encode_upper(block.hash()),
+            "15601F3C70D7D27F104A7076DB399BE9123241A3ECCE6E833B676720B4E1F43E"
+        );
+    }
+
+    #[test]
+    fn all_block_variants_have_canonical_lengths_and_api_json_fields() {
+        let cases = [
+            (fixture_open_block(), 119, "OPEN"),
+            (fixture_receive_block(), 126, "RECEIVE"),
+            (fixture_send_block(), 134, "SEND"),
+            (fixture_change_block(), 126, "CHANGE"),
+        ];
+        for (block, expected_len, expected_type) in cases {
+            assert_eq!(block.to_buffer().len(), expected_len, "{expected_type}");
+            let json = block.to_api_json_value();
+            assert_eq!(json["type"], expected_type);
+            assert_eq!(json["network"], "LOCAL");
+            assert_eq!(json["algorithm"], "V1");
+            assert_eq!(json["version"], 0);
+            assert!(json.get("address").is_some());
+            assert!(json["balance"].is_number());
+        }
+    }
+
+    #[test]
+    fn signs_block_hash_and_encodes_transaction_without_signing_work() {
+        let key = derive_key(0);
+        let block = fixture_send_block();
+        let mut unsigned = block.to_buffer();
+        unsigned.extend_from_slice(&[0xA5; 8]);
+
+        let signer = signer_for_chain(ChainType::Atto);
+        let signable = signer.extract_signable_bytes(&unsigned).unwrap();
+        assert_eq!(signable, block.to_buffer().as_slice());
+
+        let output = signer.sign_transaction(&key, &unsigned).unwrap();
+        assert_eq!(output.signature.len(), 64);
+        let public_key =
+            VerifyingKey::from_bytes(&output.public_key.clone().unwrap().try_into().unwrap())
+                .unwrap();
+        let signature =
+            ed25519_dalek::Signature::from_bytes(&output.signature.clone().try_into().unwrap());
+        public_key.verify(&block.hash(), &signature).unwrap();
+        assert!(public_key.verify(&unsigned, &signature).is_err());
+
+        let signed = signer
+            .encode_signed_transaction(&unsigned, &output)
+            .unwrap();
+        assert_eq!(signed.len(), 134 + 64 + 8);
+        assert_eq!(&signed[..134], block.to_buffer().as_slice());
+        assert_eq!(&signed[134..198], output.signature.as_slice());
+        assert_eq!(&signed[198..], &[0xA5; 8]);
+    }
+
+    #[test]
+    fn signed_transaction_api_json_contains_signature_and_work_hex() {
+        let block = fixture_receive_block();
+        let signature = [0x11u8; 64];
+        let work = [0x22u8; 8];
+        let json = AttoSignedTransaction::new(block, signature, work).to_api_json_value();
+        assert_eq!(json["type"], "RECEIVE");
+        assert_eq!(json["signature"], "11".repeat(64));
+        assert_eq!(json["work"], "22".repeat(8));
+    }
+
+    #[test]
+    fn signed_transaction_bytes_convert_to_api_json_and_hash() {
+        let block = fixture_receive_block();
+        let signed = AttoSignedTransaction::new(block.clone(), [0x11; 64], [0x22; 8]);
+        let bytes = signed.to_buffer();
+
+        let json = atto_signed_transaction_to_api_json_value(&bytes).unwrap();
+        let hash = atto_signed_transaction_hash_hex(&bytes).unwrap();
+
+        assert_eq!(json["type"], "RECEIVE");
+        assert_eq!(json["signature"], "11".repeat(64));
+        assert_eq!(json["work"], "22".repeat(8));
+        assert!(json["address"].as_str().unwrap().starts_with("atto://"));
+        assert_eq!(hash, hex::encode_upper(block.hash()));
+    }
+
+    #[test]
+    fn signed_transaction_api_json_rejects_missing_work_bytes() {
+        let block = fixture_receive_block();
+        let mut bytes = block.to_buffer();
+        bytes.extend_from_slice(&[0x11; 64]);
+
+        let err = atto_signed_transaction_to_api_json_value(&bytes).unwrap_err();
+
+        assert!(err.to_string().contains("signature + 8 work"), "{err}");
+    }
+
+    fn hex32(s: &str) -> [u8; 32] {
+        hex::decode(s).unwrap().try_into().unwrap()
+    }
+
+    fn fixture_send_block() -> AttoBlock {
+        AttoBlock::Send(AttoSendBlock {
+            network: AttoNetwork::Local,
+            version: 0,
+            public_key: hex32("A5E7E4B3B93150314E1177D5B9DE0057626B16A4B3C3F1DB37DF67628A5EF457"),
+            height: 2,
+            balance: 1,
+            timestamp_ms: 1704616009211,
+            previous: hex32("6CC2D3A7513723B1BA59DE784BA546BAF6447464D0BA3D80004752D6F9F4BA23"),
+            receiver_public_key: hex32(
+                "552254E101B51B22080D084C12C94BF7DFC5BE0D973025D62C0BC1FF4D9B145F",
+            ),
+            amount: 1,
+        })
+    }
+
+    fn fixture_receive_block() -> AttoBlock {
+        AttoBlock::Receive(AttoReceiveBlock {
+            network: AttoNetwork::Local,
+            version: 0,
+            public_key: hex32("39B56483A0DE38D9578CAF7EA791C2FEC96B318C7BD9989207B575334C5D9F1B"),
+            height: 2,
+            balance: 18_000_000_000_000_000_000,
+            timestamp_ms: 1704616009216,
+            previous: hex32("03783A08F51486A66A602439D9164894F07F150B548911086DAE4E4F57A9C4DD"),
+            send_hash: hex32("EE5FDA9A1ACEC7A09231792C345CDF5CD29F1059E5C413535D9FCA66A1FB2F49"),
+        })
+    }
+
+    fn fixture_open_block() -> AttoBlock {
+        AttoBlock::Open(AttoOpenBlock {
+            network: AttoNetwork::Local,
+            version: 0,
+            public_key: hex32("15625A4831C8F1312F1DB41550D0FD6C730FCC259ACE0FF88B500EA96783A348"),
+            balance: 18_000_000_000_000_000_000,
+            timestamp_ms: 1704616008836,
+            send_hash: hex32("4DC7257C0F492B8C7AC2D8DE4A6DC4078B060BB42FDB6F8032A839AAA9048DB0"),
+            representative_public_key: hex32(
+                "69C010A8A74924D083D1FC8234861B4B357530F42341484B4EBDA6B99F047105",
+            ),
+        })
+    }
+
+    fn fixture_change_block() -> AttoBlock {
+        AttoBlock::Change(AttoChangeBlock {
+            network: AttoNetwork::Local,
+            version: 0,
+            public_key: hex32("2415EE860847B3A1CE8B605267E83481D8426A4C42F8128EA72D72F0AD072DCC"),
+            height: 2,
+            balance: 18_000_000_000_000_000_000,
+            timestamp_ms: 1704616009221,
+            previous: hex32("AD675BD718F3D96F9B89C58A8BF80741D5EDB6741D235B070D56E84098894DD5"),
+            representative_public_key: hex32(
+                "69C010A8A74924D083D1FC8234861B4B357530F42341484B4EBDA6B99F047105",
+            ),
+        })
+    }
+}

--- a/ows/crates/ows-signer/src/chains/atto.rs
+++ b/ows/crates/ows-signer/src/chains/atto.rs
@@ -1,0 +1,1063 @@
+use crate::curve::Curve;
+use crate::traits::{ChainSigner, SignOutput, SignerError};
+use blake2::digest::{consts::U32, consts::U5, consts::U64, Digest};
+use blake2::Blake2b;
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use ows_core::ChainType;
+use serde_json::{json, Value};
+
+const ATTO_COIN_TYPE: u32 = 1_869_902_945;
+const ATTO_ADDRESS_ALGORITHM_V1: u8 = 0;
+const ATTO_SIGNED_MESSAGE_DOMAIN: &[u8] = b"ATTO Signed Message v1";
+const RFC4648_BASE32_LOWER: &[u8; 32] = b"abcdefghijklmnopqrstuvwxyz234567";
+
+/// Encode bytes using RFC 4648 base32 without padding, lowercased.
+fn encode_base32_lower_no_pad(data: &[u8]) -> String {
+    let mut out = String::with_capacity((data.len() * 8).div_ceil(5));
+    let mut buffer: u16 = 0;
+    let mut bits: u8 = 0;
+
+    for &byte in data {
+        buffer = (buffer << 8) | byte as u16;
+        bits += 8;
+        while bits >= 5 {
+            let shift = bits - 5;
+            let index = ((buffer >> shift) & 0x1f) as usize;
+            out.push(RFC4648_BASE32_LOWER[index] as char);
+            bits -= 5;
+            buffer &= (1 << bits) - 1;
+        }
+    }
+
+    if bits > 0 {
+        let index = ((buffer << (5 - bits)) & 0x1f) as usize;
+        out.push(RFC4648_BASE32_LOWER[index] as char);
+    }
+
+    out
+}
+
+fn decode_base32_lower_no_pad(body: &str) -> Result<Vec<u8>, SignerError> {
+    let mut out = Vec::with_capacity(body.len() * 5 / 8);
+    let mut buffer: u16 = 0;
+    let mut bits: u8 = 0;
+
+    for (idx, byte) in body.bytes().enumerate() {
+        let value = match byte {
+            b'a'..=b'z' => byte - b'a',
+            b'2'..=b'7' => byte - b'2' + 26,
+            b'A'..=b'Z' => {
+                return Err(SignerError::AddressDerivationFailed(format!(
+                    "invalid Atto address alphabet: uppercase character at body index {idx}"
+                )))
+            }
+            _ => {
+                return Err(SignerError::AddressDerivationFailed(format!(
+                    "invalid Atto address alphabet: character {:?} at body index {idx}",
+                    byte as char
+                )))
+            }
+        };
+
+        buffer = (buffer << 5) | value as u16;
+        bits += 5;
+        while bits >= 8 {
+            let shift = bits - 8;
+            out.push(((buffer >> shift) & 0xff) as u8);
+            bits -= 8;
+            buffer &= (1 << bits) - 1;
+        }
+    }
+
+    if bits > 0 && buffer != 0 {
+        return Err(SignerError::AddressDerivationFailed(
+            "invalid Atto address padding bits".into(),
+        ));
+    }
+
+    Ok(out)
+}
+
+fn atto_checksum(payload: &[u8; 33]) -> [u8; 5] {
+    let mut hasher = Blake2b::<U5>::new();
+    hasher.update(payload);
+    hasher.finalize().into()
+}
+
+pub fn atto_address(pubkey: &[u8; 32]) -> String {
+    let mut bytes = [0u8; 38];
+    bytes[0] = ATTO_ADDRESS_ALGORITHM_V1;
+    bytes[1..33].copy_from_slice(pubkey);
+
+    let payload: [u8; 33] = bytes[..33].try_into().expect("payload length is fixed");
+    bytes[33..].copy_from_slice(&atto_checksum(&payload));
+
+    format!("atto://{}", encode_base32_lower_no_pad(&bytes))
+}
+
+fn decode_atto_address_bytes(address: &str) -> Result<[u8; 38], SignerError> {
+    let body = address.strip_prefix("atto://").ok_or_else(|| {
+        SignerError::AddressDerivationFailed("invalid Atto address prefix: expected atto://".into())
+    })?;
+
+    if body.len() != 61 {
+        return Err(SignerError::AddressDerivationFailed(format!(
+            "invalid Atto address length: expected 61 base32 characters, got {}",
+            body.len()
+        )));
+    }
+
+    let decoded = decode_base32_lower_no_pad(body)?;
+    let bytes: [u8; 38] = decoded.try_into().map_err(|decoded: Vec<u8>| {
+        SignerError::AddressDerivationFailed(format!(
+            "invalid Atto address payload length: expected 38 bytes, got {}",
+            decoded.len()
+        ))
+    })?;
+
+    Ok(bytes)
+}
+
+pub fn atto_pubkey_from_address(address: &str) -> Result<[u8; 32], SignerError> {
+    let bytes = decode_atto_address_bytes(address)?;
+
+    if bytes[0] != ATTO_ADDRESS_ALGORITHM_V1 {
+        return Err(SignerError::AddressDerivationFailed(format!(
+            "unsupported Atto address algorithm byte: expected {ATTO_ADDRESS_ALGORITHM_V1}, got {}",
+            bytes[0]
+        )));
+    }
+
+    let payload: [u8; 33] = bytes[..33].try_into().expect("payload length is fixed");
+    let expected_checksum = atto_checksum(&payload);
+    if bytes[33..] != expected_checksum {
+        return Err(SignerError::AddressDerivationFailed(
+            "invalid Atto address checksum".into(),
+        ));
+    }
+
+    let public_key: [u8; 32] = bytes[1..33].try_into().expect("public key length is fixed");
+    Ok(public_key)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttoNetwork {
+    Live,
+    Beta,
+    Dev,
+    Local,
+}
+
+impl AttoNetwork {
+    fn code(self) -> u8 {
+        match self {
+            Self::Live => 0,
+            Self::Beta => 1,
+            Self::Dev => 2,
+            Self::Local => 3,
+        }
+    }
+
+    fn api_name(self) -> &'static str {
+        match self {
+            Self::Live => "LIVE",
+            Self::Beta => "BETA",
+            Self::Dev => "DEV",
+            Self::Local => "LOCAL",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoSendBlock {
+    pub network: AttoNetwork,
+    pub version: u16,
+    pub public_key: [u8; 32],
+    pub height: u64,
+    pub balance: u64,
+    pub timestamp_ms: i64,
+    pub previous: [u8; 32],
+    pub receiver_public_key: [u8; 32],
+    pub amount: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoReceiveBlock {
+    pub network: AttoNetwork,
+    pub version: u16,
+    pub public_key: [u8; 32],
+    pub height: u64,
+    pub balance: u64,
+    pub timestamp_ms: i64,
+    pub previous: [u8; 32],
+    pub send_hash: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoOpenBlock {
+    pub network: AttoNetwork,
+    pub version: u16,
+    pub public_key: [u8; 32],
+    pub balance: u64,
+    pub timestamp_ms: i64,
+    pub send_hash: [u8; 32],
+    pub representative_public_key: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoChangeBlock {
+    pub network: AttoNetwork,
+    pub version: u16,
+    pub public_key: [u8; 32],
+    pub height: u64,
+    pub balance: u64,
+    pub timestamp_ms: i64,
+    pub previous: [u8; 32],
+    pub representative_public_key: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttoBlock {
+    Open(AttoOpenBlock),
+    Receive(AttoReceiveBlock),
+    Send(AttoSendBlock),
+    Change(AttoChangeBlock),
+}
+
+impl AttoBlock {
+    pub const OPEN_SIZE: usize = 119;
+    pub const RECEIVE_SIZE: usize = 126;
+    pub const SEND_SIZE: usize = 134;
+    pub const CHANGE_SIZE: usize = 126;
+    const ALGORITHM_V1: u8 = 0;
+
+    pub fn to_buffer(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.block_size());
+        match self {
+            Self::Open(block) => {
+                Self::write_common(&mut out, 0, block.network, block.version, &block.public_key);
+                Self::write_u64_le(&mut out, block.balance);
+                Self::write_i64_le(&mut out, block.timestamp_ms);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.send_hash);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.representative_public_key);
+            }
+            Self::Receive(block) => {
+                Self::write_common(&mut out, 1, block.network, block.version, &block.public_key);
+                Self::write_u64_le(&mut out, block.height);
+                Self::write_u64_le(&mut out, block.balance);
+                Self::write_i64_le(&mut out, block.timestamp_ms);
+                out.extend_from_slice(&block.previous);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.send_hash);
+            }
+            Self::Send(block) => {
+                Self::write_common(&mut out, 2, block.network, block.version, &block.public_key);
+                Self::write_u64_le(&mut out, block.height);
+                Self::write_u64_le(&mut out, block.balance);
+                Self::write_i64_le(&mut out, block.timestamp_ms);
+                out.extend_from_slice(&block.previous);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.receiver_public_key);
+                Self::write_u64_le(&mut out, block.amount);
+            }
+            Self::Change(block) => {
+                Self::write_common(&mut out, 3, block.network, block.version, &block.public_key);
+                Self::write_u64_le(&mut out, block.height);
+                Self::write_u64_le(&mut out, block.balance);
+                Self::write_i64_le(&mut out, block.timestamp_ms);
+                out.extend_from_slice(&block.previous);
+                out.push(Self::ALGORITHM_V1);
+                out.extend_from_slice(&block.representative_public_key);
+            }
+        }
+        debug_assert_eq!(out.len(), self.block_size());
+        out
+    }
+
+    pub fn hash(&self) -> [u8; 32] {
+        atto_block_hash(&self.to_buffer())
+    }
+
+    pub fn block_size(&self) -> usize {
+        match self {
+            Self::Open(_) => Self::OPEN_SIZE,
+            Self::Receive(_) => Self::RECEIVE_SIZE,
+            Self::Send(_) => Self::SEND_SIZE,
+            Self::Change(_) => Self::CHANGE_SIZE,
+        }
+    }
+
+    pub fn to_api_json_value(&self) -> Value {
+        match self {
+            Self::Open(block) => json!({
+                "type": "OPEN",
+                "network": block.network.api_name(),
+                "version": block.version,
+                "algorithm": "V1",
+                "publicKey": hex::encode_upper(block.public_key),
+                "balance": block.balance,
+                "timestamp": block.timestamp_ms,
+                "sendHashAlgorithm": "V1",
+                "sendHash": hex::encode_upper(block.send_hash),
+                "representativeAlgorithm": "V1",
+                "representativePublicKey": hex::encode_upper(block.representative_public_key),
+                "height": 1,
+                "address": atto_address(&block.public_key),
+                "representativeAddress": atto_address(&block.representative_public_key),
+            }),
+            Self::Receive(block) => json!({
+                "type": "RECEIVE",
+                "network": block.network.api_name(),
+                "version": block.version,
+                "algorithm": "V1",
+                "publicKey": hex::encode_upper(block.public_key),
+                "height": block.height,
+                "balance": block.balance,
+                "timestamp": block.timestamp_ms,
+                "previous": hex::encode_upper(block.previous),
+                "sendHashAlgorithm": "V1",
+                "sendHash": hex::encode_upper(block.send_hash),
+                "address": atto_address(&block.public_key),
+            }),
+            Self::Send(block) => json!({
+                "type": "SEND",
+                "network": block.network.api_name(),
+                "version": block.version,
+                "algorithm": "V1",
+                "publicKey": hex::encode_upper(block.public_key),
+                "height": block.height,
+                "balance": block.balance,
+                "timestamp": block.timestamp_ms,
+                "previous": hex::encode_upper(block.previous),
+                "receiverAlgorithm": "V1",
+                "receiverPublicKey": hex::encode_upper(block.receiver_public_key),
+                "amount": block.amount,
+                "address": atto_address(&block.public_key),
+                "receiverAddress": atto_address(&block.receiver_public_key),
+            }),
+            Self::Change(block) => json!({
+                "type": "CHANGE",
+                "network": block.network.api_name(),
+                "version": block.version,
+                "algorithm": "V1",
+                "publicKey": hex::encode_upper(block.public_key),
+                "height": block.height,
+                "balance": block.balance,
+                "timestamp": block.timestamp_ms,
+                "previous": hex::encode_upper(block.previous),
+                "representativeAlgorithm": "V1",
+                "representativePublicKey": hex::encode_upper(block.representative_public_key),
+                "address": atto_address(&block.public_key),
+                "representativeAddress": atto_address(&block.representative_public_key),
+            }),
+        }
+    }
+
+    fn write_common(
+        out: &mut Vec<u8>,
+        block_type: u8,
+        network: AttoNetwork,
+        version: u16,
+        public_key: &[u8; 32],
+    ) {
+        out.push(block_type);
+        out.push(network.code());
+        out.extend_from_slice(&version.to_le_bytes());
+        out.push(Self::ALGORITHM_V1);
+        out.extend_from_slice(public_key);
+    }
+
+    fn write_u64_le(out: &mut Vec<u8>, value: u64) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_i64_le(out: &mut Vec<u8>, value: i64) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttoSignedTransaction {
+    pub block: AttoBlock,
+    pub signature: [u8; 64],
+    pub work: [u8; 8],
+}
+
+impl AttoSignedTransaction {
+    pub fn new(block: AttoBlock, signature: [u8; 64], work: [u8; 8]) -> Self {
+        Self {
+            block,
+            signature,
+            work,
+        }
+    }
+
+    pub fn to_buffer(&self) -> Vec<u8> {
+        let mut out = self.block.to_buffer();
+        out.extend_from_slice(&self.signature);
+        out.extend_from_slice(&self.work);
+        out
+    }
+
+    pub fn to_api_json_value(&self) -> Value {
+        let mut value = self.block.to_api_json_value();
+        if let Value::Object(ref mut object) = value {
+            object.insert(
+                "signature".to_string(),
+                Value::String(hex::encode_upper(self.signature)),
+            );
+            object.insert(
+                "work".to_string(),
+                Value::String(hex::encode_upper(self.work)),
+            );
+        }
+        value
+    }
+}
+
+pub fn atto_block_hash(block_bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Blake2b::<U32>::new();
+    hasher.update(block_bytes);
+    hasher.finalize().into()
+}
+
+fn atto_block_size_from_prefix(tx_bytes: &[u8]) -> Result<usize, SignerError> {
+    let block_type = tx_bytes.first().copied().ok_or_else(|| {
+        SignerError::InvalidTransaction("empty Atto transaction/block payload".into())
+    })?;
+    match block_type {
+        0 => Ok(AttoBlock::OPEN_SIZE),
+        1 => Ok(AttoBlock::RECEIVE_SIZE),
+        2 => Ok(AttoBlock::SEND_SIZE),
+        3 => Ok(AttoBlock::CHANGE_SIZE),
+        other => Err(SignerError::InvalidTransaction(format!(
+            "unsupported Atto block type byte {other}; expected canonical block bytes or 32-byte canonical block hash"
+        ))),
+    }
+}
+
+fn atto_unsigned_parts(tx_bytes: &[u8]) -> Result<(&[u8], &[u8]), SignerError> {
+    let block_size = atto_block_size_from_prefix(tx_bytes)?;
+    if tx_bytes.len() == block_size {
+        Ok((&tx_bytes[..block_size], &[]))
+    } else if tx_bytes.len() == block_size + 8 {
+        Ok((&tx_bytes[..block_size], &tx_bytes[block_size..]))
+    } else if tx_bytes.len() == block_size + 64 + 8 {
+        Err(SignerError::InvalidTransaction(
+            "Atto payload is already signed; pass canonical block bytes plus optional 8-byte work"
+                .into(),
+        ))
+    } else {
+        Err(SignerError::InvalidTransaction(format!(
+            "invalid Atto payload length: block type expects {block_size} block bytes, got {} bytes",
+            tx_bytes.len()
+        )))
+    }
+}
+
+fn atto_network_from_code(code: u8) -> Result<AttoNetwork, SignerError> {
+    match code {
+        0 => Ok(AttoNetwork::Live),
+        1 => Ok(AttoNetwork::Beta),
+        2 => Ok(AttoNetwork::Dev),
+        3 => Ok(AttoNetwork::Local),
+        other => Err(SignerError::InvalidTransaction(format!(
+            "unsupported Atto network byte {other}"
+        ))),
+    }
+}
+
+fn read_array<const N: usize>(bytes: &[u8], offset: &mut usize) -> Result<[u8; N], SignerError> {
+    let end = *offset + N;
+    let slice = bytes.get(*offset..end).ok_or_else(|| {
+        SignerError::InvalidTransaction(format!(
+            "truncated Atto payload while reading {N} bytes at offset {}",
+            *offset
+        ))
+    })?;
+    *offset = end;
+    slice.try_into().map_err(|_| {
+        SignerError::InvalidTransaction(format!("invalid Atto payload field length {N}"))
+    })
+}
+
+fn read_u8(bytes: &[u8], offset: &mut usize) -> Result<u8, SignerError> {
+    Ok(read_array::<1>(bytes, offset)?[0])
+}
+
+fn read_u16_le(bytes: &[u8], offset: &mut usize) -> Result<u16, SignerError> {
+    Ok(u16::from_le_bytes(read_array::<2>(bytes, offset)?))
+}
+
+fn read_u64_le(bytes: &[u8], offset: &mut usize) -> Result<u64, SignerError> {
+    Ok(u64::from_le_bytes(read_array::<8>(bytes, offset)?))
+}
+
+fn read_i64_le(bytes: &[u8], offset: &mut usize) -> Result<i64, SignerError> {
+    Ok(i64::from_le_bytes(read_array::<8>(bytes, offset)?))
+}
+
+fn read_algorithm_v1(bytes: &[u8], offset: &mut usize, label: &str) -> Result<(), SignerError> {
+    let algorithm = read_u8(bytes, offset)?;
+    if algorithm != AttoBlock::ALGORITHM_V1 {
+        return Err(SignerError::InvalidTransaction(format!(
+            "unsupported Atto {label} algorithm byte {algorithm}"
+        )));
+    }
+    Ok(())
+}
+
+fn atto_block_from_bytes(block_bytes: &[u8]) -> Result<AttoBlock, SignerError> {
+    let expected = atto_block_size_from_prefix(block_bytes)?;
+    if block_bytes.len() != expected {
+        return Err(SignerError::InvalidTransaction(format!(
+            "invalid Atto block length: expected {expected} bytes, got {}",
+            block_bytes.len()
+        )));
+    }
+
+    let mut offset = 0;
+    let block_type = read_u8(block_bytes, &mut offset)?;
+    let network = atto_network_from_code(read_u8(block_bytes, &mut offset)?)?;
+    let version = read_u16_le(block_bytes, &mut offset)?;
+    read_algorithm_v1(block_bytes, &mut offset, "block")?;
+    let public_key = read_array::<32>(block_bytes, &mut offset)?;
+
+    match block_type {
+        0 => {
+            let balance = read_u64_le(block_bytes, &mut offset)?;
+            let timestamp_ms = read_i64_le(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "send hash")?;
+            let send_hash = read_array::<32>(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "representative")?;
+            let representative_public_key = read_array::<32>(block_bytes, &mut offset)?;
+            Ok(AttoBlock::Open(AttoOpenBlock {
+                network,
+                version,
+                public_key,
+                balance,
+                timestamp_ms,
+                send_hash,
+                representative_public_key,
+            }))
+        }
+        1 => {
+            let height = read_u64_le(block_bytes, &mut offset)?;
+            let balance = read_u64_le(block_bytes, &mut offset)?;
+            let timestamp_ms = read_i64_le(block_bytes, &mut offset)?;
+            let previous = read_array::<32>(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "send hash")?;
+            let send_hash = read_array::<32>(block_bytes, &mut offset)?;
+            Ok(AttoBlock::Receive(AttoReceiveBlock {
+                network,
+                version,
+                public_key,
+                height,
+                balance,
+                timestamp_ms,
+                previous,
+                send_hash,
+            }))
+        }
+        2 => {
+            let height = read_u64_le(block_bytes, &mut offset)?;
+            let balance = read_u64_le(block_bytes, &mut offset)?;
+            let timestamp_ms = read_i64_le(block_bytes, &mut offset)?;
+            let previous = read_array::<32>(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "receiver")?;
+            let receiver_public_key = read_array::<32>(block_bytes, &mut offset)?;
+            let amount = read_u64_le(block_bytes, &mut offset)?;
+            Ok(AttoBlock::Send(AttoSendBlock {
+                network,
+                version,
+                public_key,
+                height,
+                balance,
+                timestamp_ms,
+                previous,
+                receiver_public_key,
+                amount,
+            }))
+        }
+        3 => {
+            let height = read_u64_le(block_bytes, &mut offset)?;
+            let balance = read_u64_le(block_bytes, &mut offset)?;
+            let timestamp_ms = read_i64_le(block_bytes, &mut offset)?;
+            let previous = read_array::<32>(block_bytes, &mut offset)?;
+            read_algorithm_v1(block_bytes, &mut offset, "representative")?;
+            let representative_public_key = read_array::<32>(block_bytes, &mut offset)?;
+            Ok(AttoBlock::Change(AttoChangeBlock {
+                network,
+                version,
+                public_key,
+                height,
+                balance,
+                timestamp_ms,
+                previous,
+                representative_public_key,
+            }))
+        }
+        other => Err(SignerError::InvalidTransaction(format!(
+            "unsupported Atto block type byte {other}"
+        ))),
+    }
+}
+
+pub fn atto_signed_transaction_to_api_json_value(
+    signed_bytes: &[u8],
+) -> Result<Value, SignerError> {
+    let block_size = atto_block_size_from_prefix(signed_bytes)?;
+    let expected = block_size + 64 + 8;
+    if signed_bytes.len() != expected {
+        return Err(SignerError::InvalidTransaction(format!(
+            "Atto signed transaction must be {expected} bytes ({block_size} block + 64 signature + 8 work), got {}",
+            signed_bytes.len()
+        )));
+    }
+    let block = atto_block_from_bytes(&signed_bytes[..block_size])?;
+    let signature = signed_bytes[block_size..block_size + 64]
+        .try_into()
+        .expect("signature slice length is fixed");
+    let work = signed_bytes[block_size + 64..expected]
+        .try_into()
+        .expect("work slice length is fixed");
+    Ok(AttoSignedTransaction::new(block, signature, work).to_api_json_value())
+}
+
+pub fn atto_signed_transaction_hash_hex(signed_bytes: &[u8]) -> Result<String, SignerError> {
+    let block_size = atto_block_size_from_prefix(signed_bytes)?;
+    if signed_bytes.len() < block_size {
+        return Err(SignerError::InvalidTransaction(format!(
+            "invalid Atto signed transaction length: expected at least {block_size} block bytes, got {}",
+            signed_bytes.len()
+        )));
+    }
+    Ok(hex::encode_upper(atto_block_hash(
+        &signed_bytes[..block_size],
+    )))
+}
+
+/// Atto chain signer metadata and local Ed25519 primitives.
+///
+/// Canonical block bytes follow Atto Commons `AttoBlock.toBuffer()`. The block
+/// hash is BLAKE2b-256 over those bytes, and Ed25519 signs that 32-byte hash.
+/// Full transaction bytes are `block || signature64 || work8`; work is encoded
+/// for broadcast but deliberately excluded from the signature.
+pub struct AttoSigner;
+
+impl AttoSigner {
+    fn signing_key(private_key: &[u8]) -> Result<SigningKey, SignerError> {
+        let key_bytes: [u8; 32] = private_key.try_into().map_err(|_| {
+            SignerError::InvalidPrivateKey(format!("expected 32 bytes, got {}", private_key.len()))
+        })?;
+        Ok(SigningKey::from_bytes(&key_bytes))
+    }
+
+    fn signed_message_digest(public_key: &[u8; 32], message: &[u8]) -> [u8; 64] {
+        let mut hasher = Blake2b::<U64>::new();
+        hasher.update(ATTO_SIGNED_MESSAGE_DOMAIN);
+        hasher.update(public_key);
+        hasher.update((message.len() as u64).to_be_bytes());
+        hasher.update(message);
+        hasher.finalize().into()
+    }
+}
+
+impl ChainSigner for AttoSigner {
+    fn chain_type(&self) -> ChainType {
+        ChainType::Atto
+    }
+
+    fn curve(&self) -> Curve {
+        Curve::Ed25519
+    }
+
+    fn coin_type(&self) -> u32 {
+        ATTO_COIN_TYPE
+    }
+
+    fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key: VerifyingKey = signing_key.verifying_key();
+        Ok(atto_address(verifying_key.as_bytes()))
+    }
+
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let verifying_key: VerifyingKey = signing_key.verifying_key();
+        let signature = signing_key.sign(message);
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: Some(verifying_key.to_bytes().to_vec()),
+        })
+    }
+
+    fn sign_transaction(
+        &self,
+        private_key: &[u8],
+        tx_bytes: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        if tx_bytes.len() == 32 {
+            return self.sign(private_key, tx_bytes);
+        }
+        let (block_bytes, _) = atto_unsigned_parts(tx_bytes)?;
+        let hash = atto_block_hash(block_bytes);
+        self.sign(private_key, &hash)
+    }
+
+    fn extract_signable_bytes<'a>(&self, tx_bytes: &'a [u8]) -> Result<&'a [u8], SignerError> {
+        let (block_bytes, _) = atto_unsigned_parts(tx_bytes)?;
+        Ok(block_bytes)
+    }
+
+    fn encode_signed_transaction(
+        &self,
+        tx_bytes: &[u8],
+        signature: &SignOutput,
+    ) -> Result<Vec<u8>, SignerError> {
+        if signature.signature.len() != 64 {
+            return Err(SignerError::InvalidTransaction(format!(
+                "Atto signatures must be 64 bytes, got {} bytes",
+                signature.signature.len()
+            )));
+        }
+
+        let (block_bytes, work) = atto_unsigned_parts(tx_bytes)?;
+        let mut signed = Vec::with_capacity(block_bytes.len() + 64 + 8);
+        signed.extend_from_slice(block_bytes);
+        signed.extend_from_slice(&signature.signature);
+        if work.is_empty() {
+            signed.extend_from_slice(&[0u8; 8]);
+        } else {
+            signed.extend_from_slice(work);
+        }
+        Ok(signed)
+    }
+
+    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        let signing_key = Self::signing_key(private_key)?;
+        let public_key = signing_key.verifying_key().to_bytes();
+        let digest = Self::signed_message_digest(&public_key, message);
+        let signature = signing_key.sign(&digest);
+        Ok(SignOutput {
+            signature: signature.to_bytes().to_vec(),
+            recovery_id: None,
+            public_key: Some(public_key.to_vec()),
+        })
+    }
+
+    fn default_derivation_path(&self, index: u32) -> String {
+        format!("m/44'/{ATTO_COIN_TYPE}'/{index}'")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chains::signer_for_chain;
+    use crate::hd::HdDeriver;
+    use crate::mnemonic::Mnemonic;
+    use ed25519_dalek::Verifier;
+
+    const ABANDON_PHRASE: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn derive_key(index: u32) -> Vec<u8> {
+        let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
+        let signer = AttoSigner;
+        let key = HdDeriver::derive_from_mnemonic(
+            &mnemonic,
+            "",
+            &signer.default_derivation_path(index),
+            Curve::Ed25519,
+        )
+        .unwrap();
+        key.expose().to_vec()
+    }
+
+    #[test]
+    fn chain_properties() {
+        let signer = AttoSigner;
+        assert_eq!(signer.chain_type(), ChainType::Atto);
+        assert_eq!(signer.curve(), Curve::Ed25519);
+        assert_eq!(signer.coin_type(), ATTO_COIN_TYPE);
+        assert_eq!(signer.default_derivation_path(0), "m/44'/1869902945'/0'");
+    }
+
+    #[test]
+    fn address_has_atto_uri_shape() {
+        let key = derive_key(0);
+        let signer = AttoSigner;
+        let address = signer.derive_address(&key).unwrap();
+        assert!(address.starts_with("atto://"));
+        assert_eq!(address.len(), "atto://".len() + 61);
+        assert!(address["atto://".len()..]
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || ('2'..='7').contains(&c)));
+    }
+
+    #[test]
+    fn address_decodes_to_original_pubkey() {
+        // Fixture generated from OWS' Atto codec contract: algorithm byte 0,
+        // RFC 4648 lowercase base32 without padding, BLAKE2b-5 checksum.
+        let pubkey = [0x42u8; 32];
+        let address = atto_address(&pubkey);
+        assert_eq!(
+            address,
+            "atto://abbeeqscijbeeqscijbeeqscijbeeqscijbeeqscijbeeqscijbefcvpqter6"
+        );
+        assert_eq!(atto_pubkey_from_address(&address).unwrap(), pubkey);
+    }
+
+    #[test]
+    fn address_decoder_accepts_contract_example() {
+        // Public Atto address example without source private key, so this only
+        // verifies address decoding.
+        let address = "atto://aaferyy3quqiyugpambc452bu2oqh7hrcazz4vnvem2meaa6thwf4vkiuiwyw";
+        let pubkey = atto_pubkey_from_address(address).unwrap();
+        assert_eq!(pubkey.len(), 32);
+    }
+
+    #[test]
+    fn address_decoder_rejects_invalid_prefix_case_length_alphabet_algorithm_and_checksum() {
+        let valid = atto_address(&[0x42u8; 32]);
+
+        let uppercase_body = format!("atto://{}", valid["atto://".len()..].to_uppercase());
+        for (address, expected_error) in [
+            (valid.replacen("atto://", "nano://", 1), "prefix"),
+            (valid.to_uppercase(), "prefix"),
+            (uppercase_body, "alphabet"),
+            (format!("{}a", valid), "61"),
+            (valid.replacen('a', "0", 1), "prefix"),
+            (valid.replacen('b', "0", 1), "alphabet"),
+        ] {
+            let err = atto_pubkey_from_address(&address).unwrap_err();
+            assert!(
+                err.to_string().contains(expected_error),
+                "expected {expected_error:?} in {err} for {address}"
+            );
+        }
+
+        let mut decoded = decode_atto_address_bytes(&valid).unwrap();
+        decoded[0] = 1;
+        let bad_algorithm = format!("atto://{}", encode_base32_lower_no_pad(&decoded));
+        let err = atto_pubkey_from_address(&bad_algorithm).unwrap_err();
+        assert!(err.to_string().contains("algorithm"));
+
+        let mut bad_checksum = valid.clone();
+        let last = bad_checksum.pop().unwrap();
+        bad_checksum.push(if last == 'a' { 'b' } else { 'a' });
+        let err = atto_pubkey_from_address(&bad_checksum).unwrap_err();
+        assert!(err.to_string().contains("checksum"));
+    }
+
+    #[test]
+    fn sign_transaction_requires_canonical_atto_block_payload() {
+        let key = derive_key(0);
+        let signer = AttoSigner;
+        let err = signer.sign_transaction(&key, b"not a block").unwrap_err();
+        assert!(err.to_string().contains("unsupported Atto block type"));
+
+        let block = fixture_receive_block();
+        let signature = signer.sign_transaction(&key, &block.to_buffer()).unwrap();
+        assert_eq!(signature.signature.len(), 64);
+    }
+
+    #[test]
+    fn sign_message_uses_atto_domain_separated_hash() {
+        let key = derive_key(0);
+        let signer = AttoSigner;
+        let message = b"atto message";
+        let output = signer.sign_message(&key, message).unwrap();
+        let public_key =
+            VerifyingKey::from_bytes(&output.public_key.unwrap().try_into().unwrap()).unwrap();
+        let signature = ed25519_dalek::Signature::from_bytes(&output.signature.try_into().unwrap());
+
+        let mut preimage = Vec::new();
+        preimage.extend_from_slice(b"ATTO Signed Message v1");
+        preimage.extend_from_slice(public_key.as_bytes());
+        preimage.extend_from_slice(&(message.len() as u64).to_be_bytes());
+        preimage.extend_from_slice(message);
+        let digest = Blake2b::<U64>::digest(&preimage);
+
+        public_key.verify(&digest, &signature).unwrap();
+        assert!(public_key.verify(message, &signature).is_err());
+    }
+
+    #[test]
+    fn official_send_fixture_serializes_to_canonical_block_bytes_and_hash() {
+        let block = fixture_send_block();
+        assert_eq!(block.to_buffer().len(), 134);
+        assert_eq!(
+            hex::encode_upper(block.to_buffer()),
+            concat!(
+                "0203000000",
+                "A5E7E4B3B93150314E1177D5B9DE0057626B16A4B3C3F1DB37DF67628A5EF457",
+                "0200000000000000",
+                "0100000000000000",
+                "FB1D08E38C010000",
+                "6CC2D3A7513723B1BA59DE784BA546BAF6447464D0BA3D80004752D6F9F4BA23",
+                "00",
+                "552254E101B51B22080D084C12C94BF7DFC5BE0D973025D62C0BC1FF4D9B145F",
+                "0100000000000000"
+            )
+        );
+        assert_eq!(
+            hex::encode_upper(block.hash()),
+            "15601F3C70D7D27F104A7076DB399BE9123241A3ECCE6E833B676720B4E1F43E"
+        );
+    }
+
+    #[test]
+    fn all_block_variants_have_canonical_lengths_and_api_json_fields() {
+        let cases = [
+            (fixture_open_block(), 119, "OPEN"),
+            (fixture_receive_block(), 126, "RECEIVE"),
+            (fixture_send_block(), 134, "SEND"),
+            (fixture_change_block(), 126, "CHANGE"),
+        ];
+        for (block, expected_len, expected_type) in cases {
+            assert_eq!(block.to_buffer().len(), expected_len, "{expected_type}");
+            let json = block.to_api_json_value();
+            assert_eq!(json["type"], expected_type);
+            assert_eq!(json["network"], "LOCAL");
+            assert_eq!(json["algorithm"], "V1");
+            assert_eq!(json["version"], 0);
+            assert!(json.get("address").is_some());
+            assert!(json["balance"].is_number());
+        }
+    }
+
+    #[test]
+    fn signs_block_hash_and_encodes_transaction_without_signing_work() {
+        let key = derive_key(0);
+        let block = fixture_send_block();
+        let mut unsigned = block.to_buffer();
+        unsigned.extend_from_slice(&[0xA5; 8]);
+
+        let signer = signer_for_chain(ChainType::Atto);
+        let signable = signer.extract_signable_bytes(&unsigned).unwrap();
+        assert_eq!(signable, block.to_buffer().as_slice());
+
+        let output = signer.sign_transaction(&key, &unsigned).unwrap();
+        assert_eq!(output.signature.len(), 64);
+        let public_key =
+            VerifyingKey::from_bytes(&output.public_key.clone().unwrap().try_into().unwrap())
+                .unwrap();
+        let signature =
+            ed25519_dalek::Signature::from_bytes(&output.signature.clone().try_into().unwrap());
+        public_key.verify(&block.hash(), &signature).unwrap();
+        assert!(public_key.verify(&unsigned, &signature).is_err());
+
+        let signed = signer
+            .encode_signed_transaction(&unsigned, &output)
+            .unwrap();
+        assert_eq!(signed.len(), 134 + 64 + 8);
+        assert_eq!(&signed[..134], block.to_buffer().as_slice());
+        assert_eq!(&signed[134..198], output.signature.as_slice());
+        assert_eq!(&signed[198..], &[0xA5; 8]);
+    }
+
+    #[test]
+    fn signed_transaction_api_json_contains_signature_and_work_hex() {
+        let block = fixture_receive_block();
+        let signature = [0x11u8; 64];
+        let work = [0x22u8; 8];
+        let json = AttoSignedTransaction::new(block, signature, work).to_api_json_value();
+        assert_eq!(json["type"], "RECEIVE");
+        assert_eq!(json["signature"], "11".repeat(64));
+        assert_eq!(json["work"], "22".repeat(8));
+    }
+
+    #[test]
+    fn signed_transaction_bytes_convert_to_api_json_and_hash() {
+        let block = fixture_receive_block();
+        let signed = AttoSignedTransaction::new(block.clone(), [0x11; 64], [0x22; 8]);
+        let bytes = signed.to_buffer();
+
+        let json = atto_signed_transaction_to_api_json_value(&bytes).unwrap();
+        let hash = atto_signed_transaction_hash_hex(&bytes).unwrap();
+
+        assert_eq!(json["type"], "RECEIVE");
+        assert_eq!(json["signature"], "11".repeat(64));
+        assert_eq!(json["work"], "22".repeat(8));
+        assert!(json["address"].as_str().unwrap().starts_with("atto://"));
+        assert_eq!(hash, hex::encode_upper(block.hash()));
+    }
+
+    #[test]
+    fn signed_transaction_api_json_rejects_missing_work_bytes() {
+        let block = fixture_receive_block();
+        let mut bytes = block.to_buffer();
+        bytes.extend_from_slice(&[0x11; 64]);
+
+        let err = atto_signed_transaction_to_api_json_value(&bytes).unwrap_err();
+
+        assert!(err.to_string().contains("signature + 8 work"), "{err}");
+    }
+
+    fn hex32(s: &str) -> [u8; 32] {
+        hex::decode(s).unwrap().try_into().unwrap()
+    }
+
+    fn fixture_send_block() -> AttoBlock {
+        AttoBlock::Send(AttoSendBlock {
+            network: AttoNetwork::Local,
+            version: 0,
+            public_key: hex32("A5E7E4B3B93150314E1177D5B9DE0057626B16A4B3C3F1DB37DF67628A5EF457"),
+            height: 2,
+            balance: 1,
+            timestamp_ms: 1704616009211,
+            previous: hex32("6CC2D3A7513723B1BA59DE784BA546BAF6447464D0BA3D80004752D6F9F4BA23"),
+            receiver_public_key: hex32(
+                "552254E101B51B22080D084C12C94BF7DFC5BE0D973025D62C0BC1FF4D9B145F",
+            ),
+            amount: 1,
+        })
+    }
+
+    fn fixture_receive_block() -> AttoBlock {
+        AttoBlock::Receive(AttoReceiveBlock {
+            network: AttoNetwork::Local,
+            version: 0,
+            public_key: hex32("39B56483A0DE38D9578CAF7EA791C2FEC96B318C7BD9989207B575334C5D9F1B"),
+            height: 2,
+            balance: 18_000_000_000_000_000_000,
+            timestamp_ms: 1704616009216,
+            previous: hex32("03783A08F51486A66A602439D9164894F07F150B548911086DAE4E4F57A9C4DD"),
+            send_hash: hex32("EE5FDA9A1ACEC7A09231792C345CDF5CD29F1059E5C413535D9FCA66A1FB2F49"),
+        })
+    }
+
+    fn fixture_open_block() -> AttoBlock {
+        AttoBlock::Open(AttoOpenBlock {
+            network: AttoNetwork::Local,
+            version: 0,
+            public_key: hex32("15625A4831C8F1312F1DB41550D0FD6C730FCC259ACE0FF88B500EA96783A348"),
+            balance: 18_000_000_000_000_000_000,
+            timestamp_ms: 1704616008836,
+            send_hash: hex32("4DC7257C0F492B8C7AC2D8DE4A6DC4078B060BB42FDB6F8032A839AAA9048DB0"),
+            representative_public_key: hex32(
+                "69C010A8A74924D083D1FC8234861B4B357530F42341484B4EBDA6B99F047105",
+            ),
+        })
+    }
+
+    fn fixture_change_block() -> AttoBlock {
+        AttoBlock::Change(AttoChangeBlock {
+            network: AttoNetwork::Local,
+            version: 0,
+            public_key: hex32("2415EE860847B3A1CE8B605267E83481D8426A4C42F8128EA72D72F0AD072DCC"),
+            height: 2,
+            balance: 18_000_000_000_000_000_000,
+            timestamp_ms: 1704616009221,
+            previous: hex32("AD675BD718F3D96F9B89C58A8BF80741D5EDB6741D235B070D56E84098894DD5"),
+            representative_public_key: hex32(
+                "69C010A8A74924D083D1FC8234861B4B357530F42341484B4EBDA6B99F047105",
+            ),
+        })
+    }
+}

--- a/ows/crates/ows-signer/src/chains/mod.rs
+++ b/ows/crates/ows-signer/src/chains/mod.rs
@@ -1,3 +1,4 @@
+pub mod atto;
 pub mod bitcoin;
 pub mod cosmos;
 pub mod evm;
@@ -11,6 +12,7 @@ pub mod ton;
 pub mod tron;
 pub mod xrpl;
 
+pub use self::atto::AttoSigner;
 pub use self::bitcoin::BitcoinSigner;
 pub use self::cosmos::CosmosSigner;
 pub use self::evm::EvmSigner;
@@ -42,5 +44,6 @@ pub fn signer_for_chain(chain: ChainType) -> Box<dyn ChainSigner> {
         ChainType::Xrpl => Box::new(XrplSigner),
         ChainType::Nano => Box::new(NanoSigner),
         ChainType::Near => Box::new(NearSigner),
+        ChainType::Atto => Box::new(AttoSigner),
     }
 }

--- a/ows/crates/ows-signer/src/lib.rs
+++ b/ows/crates/ows-signer/src/lib.rs
@@ -239,7 +239,7 @@ mod integration_tests {
     fn test_sign_roundtrip_ed25519_chains() {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
 
-        for chain in [ChainType::Solana, ChainType::Ton] {
+        for chain in [ChainType::Solana, ChainType::Ton, ChainType::Atto] {
             let signer = signer_for_chain(chain);
             let path = signer.default_derivation_path(0);
             let key =


### PR DESCRIPTION
## What

Adds Atto chain support to OWS, including chain registry metadata, wallet derivation/import, message signing, transaction signing, work generation, and transaction publishing.

## Why

Atto is fast, feeless digital cash built for payments. It uses an account-chain model, where each account maintains its own chain, with its own protocol, address format, transaction encoding, signing rules, and network APIs.

This makes Atto a natural fit for OWS. Atto’s lack of fees and low-latency finality, currently around 150ms confirmation time, is especially powerful for agent payments and machine-driven payment flows where multi-second settlement times or per-transaction network fees directly affect the user experience.

With this PR, Atto can use the same flows as other supported chains: account derivation, wallet material import, message signing, Atto block signing, work attachment where required, and transaction publishing.

## Testing

  - [x] `cargo test --workspace` passes
  - [x] `cargo clippy --workspace -- -D warnings` is clean
  - [ ] `npm test` passes (if Node bindings changed)
  - [x] Tested manually with `ows` CLI

  ## Notes

Node/npm binding updates are intentionally left out of this PR to keep the Atto review focused on the Rust core, signer, library and CLI.