### PR TITLE
fix: replace rpc.nano.to with public PoW fallback endpoints for Nano

### DIFF
--- a/ows/crates/ows-lib/src/nano_rpc.rs
+++ b/ows/crates/ows-lib/src/nano_rpc.rs
@@ -121,15 +121,23 @@ fn work_generate_single(
         .ok_or_else(|| OwsLibError::BroadcastFailed("no work in work_generate response".into()))
 }
 
-/// Default PoW fallback endpoint, tried when the primary RPC fails work_generate.
-const FALLBACK_WORK_URL: &str = "https://rpc.nano.to";
+/// Public PoW fallback endpoints tried when the primary RPC and NANO_WORK_URL fail.
+///
+/// All listed nodes support `work_generate` for unauthenticated clients.
+/// `https://rpc.nano.to` was removed because it requires a free API key.
+/// Source: https://publicnodes.somenano.com/
+const FALLBACK_WORK_URLS: &[&str] = &[
+    "https://nano.mehl.no/node",
+    "https://proxy.powernode.cc/proxy",
+    "https://rainstorm.city/api",
+];
 
 /// Request proof-of-work with multi-endpoint fallback.
 ///
 /// Tries endpoints in order:
 /// 1. The primary `rpc_url`
 /// 2. URLs from `NANO_WORK_URL` env var (semicolon-separated URLs)
-/// 3. Built-in fallback endpoint
+/// 3. Built-in public fallback endpoints (all support unauthenticated work_generate)
 ///
 /// All remote errors are collected and logged to stderr. If every remote fails
 /// and `NANO_CPU_POW=1` is set, a future CPU fallback would go here.
@@ -145,8 +153,10 @@ pub fn work_generate(rpc_url: &str, hash: &str, difficulty: &str) -> Result<Stri
         }
     }
 
-    if !endpoints.iter().any(|e| e == FALLBACK_WORK_URL) {
-        endpoints.push(FALLBACK_WORK_URL.to_string());
+    for fallback in FALLBACK_WORK_URLS {
+        if !endpoints.iter().any(|e| e == *fallback) {
+            endpoints.push(fallback.to_string());
+        }
     }
 
     let mut last_error = None;


### PR DESCRIPTION
Closes #220

## Problem

The hardcoded `FALLBACK_WORK_URL` (`https://rpc.nano.to`) requires a free API key for `work_generate`, causing PoW generation to fail for unauthenticated users when `NANO_WORK_URL` is not configured.

## Fix

Replace the single `FALLBACK_WORK_URL` constant with `FALLBACK_WORK_URLS`, a slice of three public nodes that support unauthenticated `work_generate`:

- `https://nano.mehl.no/node`
- `https://proxy.powernode.cc/proxy`
- `https://rainstorm.city/api`

Source: https://publicnodes.somenano.com/

## Behaviour

The existing fallback logic is preserved:
1. Primary `rpc_url` is tried first
2. `NANO_WORK_URL` env var endpoints are tried next
3. Built-in public fallbacks are tried last

Having multiple fallbacks also improves reliability — if one public node goes down, the others are still tried.

## Tests

All 159 existing tests pass.