### PR TITLE
fix(examples): drive x402 examples through the ows CLI

### DIFF
--- a/examples/x402-discover-services.js
+++ b/examples/x402-discover-services.js
@@ -1,43 +1,33 @@
 /**
  * x402-discover-services.js
  *
- * Discover x402-enabled payable services in the OWS marketplace.
+ * Discover x402-enabled services from the Bazaar directory.
+ * Discovery lives in the `ows` CLI, not the Node SDK, so this example drives
+ * the CLI through child_process.
+ *
+ * Prereqs:
+ *   npm install -g @open-wallet-standard/core
  *
  * Usage:
  *   node examples/x402-discover-services.js
  *   node examples/x402-discover-services.js ai
  */
 
-import { discover } from "@open-wallet-standard/core";
+import { execFileSync } from "child_process";
 
-const query = process.argv[2] || null;
+const query = process.argv[2];
 
-async function main() {
+function main() {
   console.log("Discovering x402 services" + (query ? " matching: " + query : "") + "...");
   console.log("-".repeat(50));
 
   try {
-    const result = await discover(query, 10, 0);
-
-    console.log("Total services found:", result.total);
-    console.log("Showing:", result.services.length);
-    console.log("");
-
-    for (const svc of result.services) {
-      console.log("Name    :", svc.name);
-      console.log("URL     :", svc.url);
-      console.log("Price   :", svc.price);
-      console.log("Network :", svc.network);
-      console.log("Tags    :", svc.tags.join(", ") || "none");
-      console.log("Desc    :", svc.description);
-      console.log("-".repeat(50));
-    }
-
-    if (result.total > result.services.length) {
-      console.log("More services available — use offset to page through results.");
-    }
+    // ows pay discover [--query <q>] [--limit N] [--offset N]
+    const args = ["pay", "discover", "--limit", "10"];
+    if (query) args.push("--query", query);
+    execFileSync("ows", args, { stdio: "inherit" });
   } catch (err) {
-    console.error("Error:", err.message);
+    console.error("Discovery failed:", err.message);
     process.exit(1);
   }
 }

--- a/examples/x402-pay-request.js
+++ b/examples/x402-pay-request.js
@@ -1,39 +1,39 @@
 /**
  * x402-pay-request.js
  *
- * Make a paid HTTP request to an x402-enabled API endpoint.
- * OWS handles the 402 -> sign -> retry flow automatically.
+ * Make a paid request to an x402-enabled API endpoint.
+ * x402 lives in the `ows` CLI, not the Node SDK, so this example drives the
+ * CLI through child_process. The CLI handles the 402 -> sign -> retry flow.
+ *
+ * Prereqs:
+ *   npm install -g @open-wallet-standard/core
+ *   ows wallet create --name my-wallet
  *
  * Usage:
  *   node examples/x402-pay-request.js
  */
 
-import { pay } from "@open-wallet-standard/core";
+import { execFileSync } from "child_process";
 
 const WALLET_NAME = "my-wallet";
 const API_URL = "https://api.cdp.coinbase.com/platform/v1/price?ids=ethereum";
 
-async function main() {
-  console.log("Making x402 payment request...");
+function main() {
+  console.log("Making an x402 payment request through the ows CLI...");
   console.log("Wallet :", WALLET_NAME);
   console.log("URL    :", API_URL);
   console.log("-".repeat(50));
 
   try {
-    const result = await pay(WALLET_NAME, API_URL, "GET");
-
-    console.log("Status :", result.status);
-    console.log("Protocol:", result.protocol);
-
-    if (result.payment) {
-      console.log("Payment :", result.payment.amount, result.payment.token, "on", result.payment.network);
-    } else {
-      console.log("Payment : none required");
-    }
-
-    console.log("Response:", result.body.slice(0, 200));
+    // ows pay request <url> --wallet <name> [--method GET] [--body '{...}']
+    // Add "--no-passphrase" for a wallet created without a passphrase.
+    execFileSync(
+      "ows",
+      ["pay", "request", API_URL, "--wallet", WALLET_NAME, "--method", "GET"],
+      { stdio: "inherit" }
+    );
   } catch (err) {
-    console.error("Error:", err.message);
+    console.error("Payment request failed:", err.message);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## What
Rework the two x402 examples to use the `ows pay` CLI instead of importing `pay` / `discover` from the Node SDK.

## Why
The x402 examples import `pay` and `discover` from `@open-wallet-standard/core`, but the Node SDK does not export them. x402 payments and discovery are CLI features, so the examples did not run as written. This drives the CLI through `child_process`, the same pattern `agent-with-policy.js` uses for `ows policy create`.

## Testing
- Flags verified against the CLI: `ows pay request <url> --wallet <name> [--method] [--body]` and `ows pay discover [--query] [--limit] [--offset]`.
- `node --check` passes on both files.

## Notes
Follow-up to #207.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only example changes with no production SDK or CLI behavior modified.
> 
> **Overview**
> **Fixes broken x402 examples** by replacing `@open-wallet-standard/core` imports of `discover` and `pay` with **`execFileSync("ows", …)`**, matching how other examples invoke CLI-only features.
> 
> **`x402-discover-services.js`** runs `ows pay discover --limit 10` and optional `--query`, with CLI output inherited instead of manually printing service fields from SDK results.
> 
> **`x402-pay-request.js`** runs `ows pay request <url> --wallet my-wallet --method GET` and documents wallet/passphrase prereqs in the header comments.
> 
> Both scripts are **sync** (no `async`/`await`) and update copy to point at the **Bazaar** directory and global **`ows`** install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 960c8624d41aa883e3c760b1ec27cba76eb3bf74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->