### PR TITLE
feat(xrpl): inject SigningPubKey in signer so callers pass unsigned transactions

### DIFF
--- a/bindings/node/__test__/index.spec.mjs
+++ b/bindings/node/__test__/index.spec.mjs
@@ -239,10 +239,16 @@ describe('@open-wallet-standard/core', () => {
     // signs the digest. Any non-empty bytes verify the signing pipeline.
     const nearTxHex = '42'.repeat(80);
 
+    // XRPL signing decodes the tx to inject SigningPubKey, so it needs a real
+    // binary-encoded unsigned Payment (no SigningPubKey/TxnSignature).
+    const xrplTxHex =
+      '12000024000000016140000000000F424068400000000000000C8114AFF3C2E33458B30714CA16FFEE19952DD35C17C883145720939C1336A7356A70ED861D5934345C6B6360';
+
     const txHexByChain = {
       solana: solTxHex,
       nano: nanoTxHex,
       near: nearTxHex,
+      xrpl: xrplTxHex,
     };
 
     for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano', 'near']) {

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -1311,6 +1311,10 @@ mod tests {
         // sha256 -> ed25519 pipeline.
         let near_tx_hex = "42".repeat(80);
 
+        // XRPL signing decodes the tx to inject SigningPubKey, so it needs a real
+        // binary-encoded *unsigned* transaction (no SigningPubKey/TxnSignature).
+        let xrpl_tx_hex = "12000024000000016140000000000F424068400000000000000C8114AFF3C2E33458B30714CA16FFEE19952DD35C17C883145720939C1336A7356A70ED861D5934345C6B6360";
+
         let chains = [
             "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "xrpl", "near",
         ];
@@ -1319,6 +1323,8 @@ mod tests {
                 &solana_tx_hex
             } else if *chain == "near" {
                 &near_tx_hex
+            } else if *chain == "xrpl" {
+                xrpl_tx_hex
             } else {
                 generic_tx_hex
             };

--- a/ows/crates/ows-signer/src/chains/xrpl.rs
+++ b/ows/crates/ows-signer/src/chains/xrpl.rs
@@ -16,6 +16,28 @@ fn sha512_half(data: &[u8]) -> [u8; 32] {
         .expect("SHA-512 output is always 64 bytes")
 }
 
+/// secp256k1 public key (33 bytes) — XRPL's `SigningPubKey` value.
+fn derive_public_key(private_key: &[u8]) -> Result<Vec<u8>, SignerError> {
+    let signing_key = SigningKey::from_slice(private_key)
+        .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
+    Ok(PublicKey::from(signing_key.verifying_key())
+        .to_sec1_bytes()
+        .to_vec())
+}
+
+/// Reject a decoded transaction that already carries signature fields: OWS owns
+/// `SigningPubKey` and `TxnSignature`, so inputs must be unsigned.
+fn ensure_unsigned(json_tx: &serde_json::Value) -> Result<(), SignerError> {
+    for field in ["SigningPubKey", "TxnSignature"] {
+        if json_tx.get(field).is_some() {
+            return Err(SignerError::InvalidTransaction(format!(
+                "unsigned transaction must not contain {field}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// XRPL chain signer (secp256k1).
 ///
 /// Signing algorithm: `STX\0` prefix || serialized tx fields → SHA512-half →
@@ -49,10 +71,7 @@ impl ChainSigner for XrplSigner {
     ///
     /// Delegates to `xrpl::core::keypairs::derive_classic_address`.
     fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError> {
-        let signing_key = SigningKey::from_slice(private_key)
-            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
-
-        let pubkey_bytes = PublicKey::from(signing_key.verifying_key()).to_sec1_bytes();
+        let pubkey_bytes = derive_public_key(private_key)?;
 
         derive_classic_address(&hex::encode_upper(&pubkey_bytes))
             .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
@@ -71,10 +90,13 @@ impl ChainSigner for XrplSigner {
         let sig: k256::ecdsa::Signature = signing_key
             .sign_prehash(&digest)
             .map_err(|e| SignerError::SigningFailed(e.to_string()))?;
+        let public_key = PublicKey::from(signing_key.verifying_key())
+            .to_sec1_bytes()
+            .to_vec();
         Ok(SignOutput {
             signature: sig.to_der().as_bytes().to_vec(),
             recovery_id: None,
-            public_key: None,
+            public_key: Some(public_key),
         })
     }
 
@@ -83,12 +105,15 @@ impl ChainSigner for XrplSigner {
     /// `tx_bytes` must be the raw binary output of the XRPL binary codec's
     /// `encode(tx)` — the serialized transaction fields with no hash prefix.
     ///
-    /// Internally prepends the XRPL single-signing prefix `STX\0` (0x53545800),
-    /// computes the SHA512-half digest, and signs it with secp256k1 (k256) to
-    /// produce a DER-encoded signature.
+    /// `tx_bytes` must be unsigned: it is an error for `SigningPubKey` or
+    /// `TxnSignature` to already be present.
     ///
-    /// Returns a `SignOutput` carrying the DER signature; the `SigningPubKey` is
-    /// already embedded in `tx_bytes`, so no public key is returned here.
+    /// Injects the derived `SigningPubKey`, prepends the XRPL single-signing prefix
+    /// `STX\0` (0x53545800), computes the SHA512-half digest, and signs it with
+    /// secp256k1 (k256) to produce a DER-encoded signature.
+    ///
+    /// Returns a `SignOutput` carrying the DER signature and the public key, which
+    /// `encode_signed_transaction` writes back as `SigningPubKey`.
     fn sign_transaction(
         &self,
         private_key: &[u8],
@@ -100,11 +125,25 @@ impl ChainSigner for XrplSigner {
             ));
         }
 
+        let public_key = derive_public_key(private_key)?;
+
+        // Inject SigningPubKey, then re-encode: these are the bytes the signature covers.
+        let tx_hex = hex::encode_upper(tx_bytes);
+        let mut json_tx = xrpl_decode(&tx_hex)
+            .map_err(|e| SignerError::InvalidTransaction(format!("xrpl decode failed: {}", e)))?;
+        ensure_unsigned(&json_tx)?;
+        json_tx["SigningPubKey"] = serde_json::Value::String(hex::encode_upper(&public_key));
+        let signable_hex = xrpl_encode(&json_tx)
+            .map_err(|e| SignerError::InvalidTransaction(format!("xrpl encode failed: {}", e)))?;
+        let signable = hex::decode(&signable_hex).map_err(|e| {
+            SignerError::InvalidTransaction(format!("invalid hex from encode: {}", e))
+        })?;
+
         // STX\0 (0x53545800) is the XRPL single-signing hash prefix, prepended to
         // the serialized fields before the SHA512-half digest that gets signed.
-        let mut prefixed = Vec::with_capacity(4 + tx_bytes.len());
+        let mut prefixed = Vec::with_capacity(4 + signable.len());
         prefixed.extend_from_slice(&[0x53, 0x54, 0x58, 0x00]);
-        prefixed.extend_from_slice(tx_bytes);
+        prefixed.extend_from_slice(&signable);
 
         // Sign the SHA512-half digest directly with k256 (low-S, DER), the same path
         // as `sign`. We deliberately do not route through xrpl-rust's keypair signer:
@@ -116,12 +155,13 @@ impl ChainSigner for XrplSigner {
 
     /// Encode a fully-signed XRPL transaction ready for broadcast.
     ///
-    /// `tx_bytes` must be the same binary-encoded unsigned transaction passed to
-    /// `sign_transaction` (no STX\0 prefix). The binary already contains `SigningPubKey`;
-    /// this method only injects `TxnSignature` into the decoded JSON before re-encoding.
+    /// `tx_bytes` must be the same unsigned transaction passed to
+    /// `sign_transaction` (no STX\0 prefix); it is an error for `SigningPubKey` or
+    /// `TxnSignature` to already be present. Writes `SigningPubKey` from
+    /// `signature.public_key` (required) and `TxnSignature` from the signature.
     ///
     /// Decodes the binary to JSON via `xrpl::core::binarycodec::decode`, injects
-    /// `TxnSignature`, then re-encodes to canonical XRPL binary via `encode`. The
+    /// the fields, then re-encodes to canonical XRPL binary via `encode`. The
     /// returned bytes can be uppercase-hex-encoded and submitted as `tx_blob` to
     /// the XRPL `submit` JSON-RPC method.
     fn encode_signed_transaction(
@@ -129,11 +169,17 @@ impl ChainSigner for XrplSigner {
         tx_bytes: &[u8],
         signature: &SignOutput,
     ) -> Result<Vec<u8>, SignerError> {
-        // Convert binary bytes to hex string for xrpl_decode.
         let tx_hex = hex::encode_upper(tx_bytes);
         let mut json_tx = xrpl_decode(&tx_hex)
             .map_err(|e| SignerError::InvalidTransaction(format!("xrpl decode failed: {}", e)))?;
+        ensure_unsigned(&json_tx)?;
 
+        let public_key = signature.public_key.as_ref().ok_or_else(|| {
+            SignerError::InvalidTransaction(
+                "encode_signed_transaction requires public_key in SignOutput".into(),
+            )
+        })?;
+        json_tx["SigningPubKey"] = serde_json::Value::String(hex::encode_upper(public_key));
         json_tx["TxnSignature"] =
             serde_json::Value::String(hex::encode_upper(&signature.signature));
 
@@ -168,6 +214,11 @@ mod tests {
     use crate::mnemonic::Mnemonic;
     const ABANDON_PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
+    /// An unsigned Payment from the `test_privkey` account (m/44'/144'/0'/0/0),
+    /// with no SigningPubKey or TxnSignature — the blob a caller hands to
+    /// `sign_transaction`. Generated by scripts/xrpl-demo/make-unsigned-tx.mjs.
+    const UNSIGNED_PAYMENT_HEX: &str = "12000024000000016140000000000F424068400000000000000C8114AFF3C2E33458B30714CA16FFEE19952DD35C17C883145720939C1336A7356A70ED861D5934345C6B6360";
+
     /// Known test private key (32 bytes).
     fn test_privkey() -> Vec<u8> {
         // Derived from abandon mnemonic at m/44'/144'/0'/0/0 with secp256k1
@@ -179,6 +230,18 @@ mod tests {
             .unwrap()
             .expose()
             .to_vec()
+    }
+
+    /// Reproduce the exact bytes `sign_transaction` hashes: the unsigned tx with
+    /// the signer's SigningPubKey injected, re-encoded, prefixed with STX\0.
+    fn signing_payload(privkey: &[u8], tx_bytes: &[u8]) -> Vec<u8> {
+        let pubkey = derive_public_key(privkey).unwrap();
+        let mut json = xrpl_decode(&hex::encode_upper(tx_bytes)).unwrap();
+        json["SigningPubKey"] = serde_json::Value::String(hex::encode_upper(&pubkey));
+        let signable = hex::decode(xrpl_encode(&json).unwrap()).unwrap();
+        let mut prefixed = vec![0x53, 0x54, 0x58, 0x00];
+        prefixed.extend_from_slice(&signable);
+        prefixed
     }
 
     #[test]
@@ -238,9 +301,9 @@ mod tests {
     fn test_sign_transaction_single() {
         let privkey = test_privkey();
         let signer = XrplSigner;
-        let tx_bytes = b"fake_unsigned_tx_bytes";
+        let tx_bytes = hex::decode(UNSIGNED_PAYMENT_HEX).unwrap();
 
-        let result = signer.sign_transaction(&privkey, tx_bytes).unwrap();
+        let result = signer.sign_transaction(&privkey, &tx_bytes).unwrap();
 
         // DER signature starts with 0x30
         assert_eq!(result.signature[0], 0x30, "expected DER sequence tag 0x30");
@@ -251,18 +314,17 @@ mod tests {
             result.signature.len()
         );
         assert!(result.recovery_id.is_none());
-        // SigningPubKey is already embedded in tx_bytes; sign_transaction does not return it.
-        assert!(result.public_key.is_none());
+        assert!(result.public_key.is_some());
     }
 
     #[test]
     fn test_sign_transaction_deterministic() {
         let privkey = test_privkey();
         let signer = XrplSigner;
-        let tx_bytes = b"deterministic_test_tx";
+        let tx_bytes = hex::decode(UNSIGNED_PAYMENT_HEX).unwrap();
 
-        let sig1 = signer.sign_transaction(&privkey, tx_bytes).unwrap();
-        let sig2 = signer.sign_transaction(&privkey, tx_bytes).unwrap();
+        let sig1 = signer.sign_transaction(&privkey, &tx_bytes).unwrap();
+        let sig2 = signer.sign_transaction(&privkey, &tx_bytes).unwrap();
         assert_eq!(
             sig1.signature, sig2.signature,
             "secp256k1 (RFC6979) must be deterministic"
@@ -289,7 +351,8 @@ mod tests {
         assert_eq!(privkey[0], 0x00, "test key must have a leading zero byte");
 
         let signer = XrplSigner;
-        let result = signer.sign_transaction(&privkey, b"leading_zero_scalar_tx");
+        let tx_bytes = hex::decode(UNSIGNED_PAYMENT_HEX).unwrap();
+        let result = signer.sign_transaction(&privkey, &tx_bytes);
         assert!(
             result.is_ok(),
             "leading-zero-scalar key must sign: {:?}",
@@ -299,11 +362,10 @@ mod tests {
         assert_eq!(sig.signature[0], 0x30, "expected DER signature tag");
 
         // Prove the signature is cryptographically valid, not just well-formed: it
-        // must verify against the key's public key over the same SHA512-half digest.
+        // must verify against the key's public key over the SHA512-half digest of
+        // the bytes actually signed — i.e. the tx with SigningPubKey injected.
         use k256::ecdsa::signature::hazmat::PrehashVerifier;
-        let mut prefixed = vec![0x53, 0x54, 0x58, 0x00];
-        prefixed.extend_from_slice(b"leading_zero_scalar_tx");
-        let digest = sha512_half(&prefixed);
+        let digest = sha512_half(&signing_payload(&privkey, &tx_bytes));
         let der = k256::ecdsa::Signature::from_der(&sig.signature).expect("valid DER");
         let sk = SigningKey::from_slice(&privkey).unwrap();
         sk.verifying_key()
@@ -313,22 +375,20 @@ mod tests {
 
     #[test]
     fn test_sign_transaction_equals_sign_of_sha512_half() {
-        // sign_transaction(privkey, bytes) must equal sign(privkey, sha512_half(STX\0 || bytes))
-        // because sign_transaction internally prepends the STX\0 prefix before hashing.
+        // sign_transaction must equal sign(sha512_half(STX\0 || encode(tx + SigningPubKey))):
+        // it injects the signer's SigningPubKey, prepends the STX\0 prefix, then hashes.
         let privkey = test_privkey();
         let signer = XrplSigner;
-        let tx_bytes = b"some_unsigned_tx_bytes";
+        let tx_bytes = hex::decode(UNSIGNED_PAYMENT_HEX).unwrap();
 
-        let sig_tx = signer.sign_transaction(&privkey, tx_bytes).unwrap();
+        let sig_tx = signer.sign_transaction(&privkey, &tx_bytes).unwrap();
 
-        let mut prefixed = vec![0x53, 0x54, 0x58, 0x00];
-        prefixed.extend_from_slice(tx_bytes);
-        let digest = sha512_half(&prefixed);
+        let digest = sha512_half(&signing_payload(&privkey, &tx_bytes));
         let sig_direct = signer.sign(&privkey, &digest).unwrap();
 
         assert_eq!(
             sig_tx.signature, sig_direct.signature,
-            "sign_transaction must be equivalent to sign(sha512_half(STX\\0 || bytes))"
+            "sign_transaction must equal sign(sha512_half(STX\\0 || tx-with-SigningPubKey))"
         );
     }
 
@@ -383,14 +443,45 @@ mod tests {
             hex::decode("AA83B3DC1205119B4B6F09CF9895C9359B56F5A81BB9BB0450C87BE041113B58")
                 .unwrap();
 
-        // Binary-encoded unsigned Payment tx — no STX\0 prefix.
-        let tx_bytes = hex::decode("12000024000000016140000000000F424068400000000000000C7321035D8892C99D4F17B2775EC428ED65B6335A5D588AC2057B81C8C38C59C72B68D98114B22CCE5BFD693ED7FA15B57B6B5370551B7E6DB58314F667B0CA50CC7709A220B0561B85E53A48461FA8").unwrap();
+        // Binary-encoded unsigned Payment tx — no STX\0 prefix, no SigningPubKey.
+        let tx_bytes = hex::decode("12000024000000016140000000000F424068400000000000000C8114B22CCE5BFD693ED7FA15B57B6B5370551B7E6DB58314F667B0CA50CC7709A220B0561B85E53A48461FA8").unwrap();
 
         let result = signer.sign_transaction(&privkey, &tx_bytes).unwrap();
 
         let expected_sig = "3045022100AEBCB8F0C9AD93782F5E082B5B96E06FE8A05E14858B24A348E1C330BCAC1ED50220109D79503119EE830253A12122D1C4333F2038FB81C76B84C670BF4DCD986B13";
         assert_eq!(hex::encode_upper(&result.signature), expected_sig);
-        assert!(result.public_key.is_none());
+        assert!(result.public_key.is_some());
+    }
+
+    /// Caller omits SigningPubKey entirely; the signer injects it and the signed
+    /// blob is byte-identical to the canonical vector that carried it.
+    #[test]
+    fn test_sign_without_signing_pubkey_injects_it() {
+        let signer = XrplSigner;
+        let privkey =
+            hex::decode("AA83B3DC1205119B4B6F09CF9895C9359B56F5A81BB9BB0450C87BE041113B58")
+                .unwrap();
+
+        // Take the known-vector tx (which carries SigningPubKey) and strip it, to
+        // simulate a caller that does not know the pubkey.
+        let with_pubkey = "12000024000000016140000000000F424068400000000000000C7321035D8892C99D4F17B2775EC428ED65B6335A5D588AC2057B81C8C38C59C72B68D98114B22CCE5BFD693ED7FA15B57B6B5370551B7E6DB58314F667B0CA50CC7709A220B0561B85E53A48461FA8";
+        let mut json = xrpl_decode(with_pubkey).unwrap();
+        json.as_object_mut().unwrap().remove("SigningPubKey");
+        let without_pubkey = hex::decode(xrpl_encode(&json).unwrap()).unwrap();
+        assert!(
+            !hex::encode_upper(&without_pubkey).contains("035D8892C99D4F17B2775EC428ED65B6335"),
+            "precondition: SigningPubKey must be absent from the input"
+        );
+
+        let out = signer.sign_transaction(&privkey, &without_pubkey).unwrap();
+        let expected_sig = "3045022100AEBCB8F0C9AD93782F5E082B5B96E06FE8A05E14858B24A348E1C330BCAC1ED50220109D79503119EE830253A12122D1C4333F2038FB81C76B84C670BF4DCD986B13";
+        assert_eq!(hex::encode_upper(&out.signature), expected_sig);
+
+        let blob = signer
+            .encode_signed_transaction(&without_pubkey, &out)
+            .unwrap();
+        let expected_blob = "12000024000000016140000000000F424068400000000000000C7321035D8892C99D4F17B2775EC428ED65B6335A5D588AC2057B81C8C38C59C72B68D974473045022100AEBCB8F0C9AD93782F5E082B5B96E06FE8A05E14858B24A348E1C330BCAC1ED50220109D79503119EE830253A12122D1C4333F2038FB81C76B84C670BF4DCD986B138114B22CCE5BFD693ED7FA15B57B6B5370551B7E6DB58314F667B0CA50CC7709A220B0561B85E53A48461FA8";
+        assert_eq!(hex::encode_upper(&blob), expected_blob);
     }
 
     /// Known vector: encode_signed_transaction injects SigningPubKey
@@ -402,14 +493,17 @@ mod tests {
         let signer = XrplSigner;
 
         // Binary-encoded unsigned tx — same vector as test_sign_transaction_matches_known_vector.
-        let tx_bytes = hex::decode("12000024000000016140000000000F424068400000000000000C7321035D8892C99D4F17B2775EC428ED65B6335A5D588AC2057B81C8C38C59C72B68D98114B22CCE5BFD693ED7FA15B57B6B5370551B7E6DB58314F667B0CA50CC7709A220B0561B85E53A48461FA8").unwrap();
+        let tx_bytes = hex::decode("12000024000000016140000000000F424068400000000000000C8114B22CCE5BFD693ED7FA15B57B6B5370551B7E6DB58314F667B0CA50CC7709A220B0561B85E53A48461FA8").unwrap();
 
         let signature = hex::decode("3045022100AEBCB8F0C9AD93782F5E082B5B96E06FE8A05E14858B24A348E1C330BCAC1ED50220109D79503119EE830253A12122D1C4333F2038FB81C76B84C670BF4DCD986B13").unwrap();
 
         let sign_output = SignOutput {
             signature,
             recovery_id: None,
-            public_key: None,
+            public_key: Some(
+                hex::decode("035D8892C99D4F17B2775EC428ED65B6335A5D588AC2057B81C8C38C59C72B68D9")
+                    .unwrap(),
+            ),
         };
 
         let encoded = signer
@@ -438,6 +532,29 @@ mod tests {
             "expected 'xrpl decode failed' error, got: {}",
             err
         );
+    }
+
+    #[test]
+    fn test_rejects_already_signed_inputs() {
+        let signer = XrplSigner;
+        let privkey = test_privkey();
+        let sign_output = SignOutput {
+            signature: vec![0x30],
+            recovery_id: None,
+            public_key: Some(derive_public_key(&privkey).unwrap()),
+        };
+
+        // A tx that already carries SigningPubKey, and one that carries TxnSignature.
+        let with_pubkey = hex::decode("12000024000000016140000000000F424068400000000000000C7321035D8892C99D4F17B2775EC428ED65B6335A5D588AC2057B81C8C38C59C72B68D98114B22CCE5BFD693ED7FA15B57B6B5370551B7E6DB58314F667B0CA50CC7709A220B0561B85E53A48461FA8").unwrap();
+        let unsigned = hex::decode(UNSIGNED_PAYMENT_HEX).unwrap();
+        let mut json = xrpl_decode(&hex::encode_upper(&unsigned)).unwrap();
+        json["TxnSignature"] = serde_json::Value::String("3045".into());
+        let with_signature = hex::decode(xrpl_encode(&json).unwrap()).unwrap();
+
+        for tx in [&with_pubkey, &with_signature] {
+            assert!(signer.sign_transaction(&privkey, tx).is_err());
+            assert!(signer.encode_signed_transaction(tx, &sign_output).is_err());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

- `sign_transaction` now derives the signer's secp256k1 public key, injects it as `SigningPubKey` before hashing, signs the transaction, and returns both the signature and the public key.
- `encode_signed_transaction` makes use of `public_key` present in `SignOutput`.
- Both now require an **unsigned** tx — they reject input that already contains `SigningPubKey` or `TxnSignature`.

## Why

Previously the caller had to embed `SigningPubKey` in the unsigned blob before signing, even though OWS already holds the private key and is the only party that can know the correct value. That forced consumers (e.g. the Node SDK) to re-derive the public key just to build a valid XRPL transaction. Now a caller hands OWS a plain unsigned transaction and OWS correctly returns the signature (`signTransaction`) and also, correctly submits the transaction (`signAndSend`).


## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `npm test` passes (if Node bindings changed)
- [x] Tested manually with `ows` CLI

