### PR TITLE
ci(release): publish npm via OIDC trusted publishing, drop NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,9 @@ jobs:
     needs: [node-addons, build]
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      id-token: write
+      contents: read
 
     defaults:
       run:
@@ -270,9 +273,10 @@ jobs:
           cp cli-binaries/ows-linux-x86_64   npm/linux-x64-gnu/ows  && chmod +x npm/linux-x64-gnu/ows
           cp cli-binaries/ows-linux-aarch64  npm/linux-arm64-gnu/ows && chmod +x npm/linux-arm64-gnu/ows
 
+      - name: Upgrade npm for OIDC trusted publishing (needs >= 11.5.1)
+        run: npm install --global npm@latest
+
       - name: Publish platform packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for dir in npm/*/; do
             output=$(npm publish "$dir" --access public 2>&1) || {
@@ -287,14 +291,15 @@ jobs:
           done
 
       - name: Publish main package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --ignore-scripts
 
   publish-npm-adapters:
     needs: publish-npm
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      id-token: write
+      contents: read
 
     defaults:
       run:
@@ -316,9 +321,10 @@ jobs:
       - name: Install dependencies
         run: npm install --ignore-scripts
 
+      - name: Upgrade npm for OIDC trusted publishing (needs >= 11.5.1)
+        run: npm install --global npm@latest
+
       - name: Publish adapters package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --ignore-scripts
 
   publish-crates:


### PR DESCRIPTION
## What
`publish-npm` and `publish-npm-adapters` now authenticate to npm via OIDC trusted publishing (`permissions: id-token: write` + `contents: read`) instead of the `NODE_AUTH_TOKEN` / `NPM_TOKEN` secret, matching how `publish-pypi` and `publish-crates` already work. Both jobs also get an `npm install -g npm@latest` step so the runner has npm >= 11.5.1 (node 22 ships npm 10.x), which trusted publishing requires.

## Why
The v1.4.0 release published to crates.io and PyPI but `publish-npm` failed with `E404` on the platform packages: the long-lived `NPM_TOKEN` had lost publish rights on the scope. Trusted publishing drops the token dependency entirely, so npm publishing can't break this way again. The trusted publisher is already configured on npm pointing at this repo.

## Testing
- YAML parses cleanly.
- The publish jobs only run on `push: tags`, so this is exercised by the next tagged release. After merge, re-cut/re-tag v1.4.0 (or v1.4.1) and the npm packages publish over OIDC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how release npm authentication works; a misconfigured npm trusted publisher or npm version step could block releases until the next tag, but scope is limited to the two npm publish jobs.
> 
> **Overview**
> **Release workflow npm jobs** now publish with **OIDC trusted publishing** instead of a long-lived **`NPM_TOKEN` / `NODE_AUTH_TOKEN`**.
> 
> For **`publish-npm`** and **`publish-npm-adapters`**, the diff adds **`permissions: id-token: write`** and **`contents: read`**, removes the publish-step env that injected the npm token, and adds **`npm install --global npm@latest`** so the runner meets npm **≥ 11.5.1** (required for trusted publishing on Node 22’s bundled npm 10.x). Publish commands themselves are unchanged aside from relying on OIDC auth—aligned with **`publish-pypi`**’s tokenless pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b16ac4e5d487dd08e4489bf9c11f3e4f6cacb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->