### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/bindings/node-adapters/package-lock.json
+++ b/bindings/node-adapters/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-wallet-standard/adapters",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-wallet-standard/adapters",
-      "version": "1.3.2",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.0.0",

--- a/bindings/node-adapters/package.json
+++ b/bindings/node-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/adapters",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "description": "Framework adapters for the Open Wallet Standard — viem, Solana, and more",
   "main": "src/index.js",
   "types": "src/index.d.ts",
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm test"
   },
   "dependencies": {
-    "@open-wallet-standard/core": "^1.3.2",
+    "@open-wallet-standard/core": "^1.4.1",
     "@noble/curves": "^1.0.0"
   },
   "peerDependencies": {

--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -1519,7 +1519,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-core"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "ows-node"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-node"
-version = "1.3.2"
+version = "1.4.1"
 edition = "2021"
 description = "Node.js native bindings for the Open Wallet Standard"
 

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-darwin-arm64",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "os": [
     "darwin"
   ],

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-darwin-x64",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "os": [
     "darwin"
   ],

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-linux-arm64-gnu",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "os": [
     "linux"
   ],

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core-linux-x64-gnu",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "os": [
     "linux"
   ],

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-wallet-standard/core",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-wallet-standard/core",
-      "version": "1.3.2",
+      "version": "1.4.1",
       "license": "MIT",
       "bin": {
         "ows": "bin/ows"
@@ -15,10 +15,10 @@
         "@napi-rs/cli": "^2.18.0"
       },
       "optionalDependencies": {
-        "@open-wallet-standard/core-darwin-arm64": "1.3.2",
-        "@open-wallet-standard/core-darwin-x64": "1.3.2",
-        "@open-wallet-standard/core-linux-arm64-gnu": "1.3.2",
-        "@open-wallet-standard/core-linux-x64-gnu": "1.3.2"
+        "@open-wallet-standard/core-darwin-arm64": "1.4.1",
+        "@open-wallet-standard/core-darwin-x64": "1.4.1",
+        "@open-wallet-standard/core-linux-arm64-gnu": "1.4.1",
+        "@open-wallet-standard/core-linux-x64-gnu": "1.4.1"
       }
     },
     "node_modules/@napi-rs/cli": {

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-wallet-standard/core",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "description": "Node.js native bindings for the Open Wallet Standard",
   "main": "index.js",
   "types": "index.d.ts",
@@ -31,10 +31,10 @@
     "@napi-rs/cli": "^2.18.0"
   },
   "optionalDependencies": {
-    "@open-wallet-standard/core-linux-x64-gnu": "1.3.2",
-    "@open-wallet-standard/core-linux-arm64-gnu": "1.3.2",
-    "@open-wallet-standard/core-darwin-x64": "1.3.2",
-    "@open-wallet-standard/core-darwin-arm64": "1.3.2"
+    "@open-wallet-standard/core-linux-x64-gnu": "1.4.1",
+    "@open-wallet-standard/core-linux-arm64-gnu": "1.4.1",
+    "@open-wallet-standard/core-darwin-x64": "1.4.1",
+    "@open-wallet-standard/core-darwin-arm64": "1.4.1"
   },
   "license": "MIT",
   "files": [

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1440,7 +1440,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-core"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "ows-python"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "ows-core",
  "ows-lib",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-python"
-version = "1.3.2"
+version = "1.4.1"
 edition = "2021"
 description = "Python native bindings for the Open Wallet Standard"
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "open-wallet-standard"
-version = "1.3.2"
+version = "1.4.1"
 description = "Python native bindings for the Open Wallet Standard"
 requires-python = ">=3.8"
 license = { text = "MIT" }

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -1596,7 +1596,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "ows-cli"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "ows-core"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "chrono",
  "serde",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "ows-lib"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "ows-pay"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "ows-signer"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/ows/crates/ows-cli/Cargo.toml
+++ b/ows/crates/ows-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-cli"
-version = "1.3.2"
+version = "1.4.1"
 edition = "2021"
 license = "MIT"
 description = "CLI for the Open Wallet Standard"
@@ -12,9 +12,9 @@ name = "ows"
 path = "src/main.rs"
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=1.3.2" }
-ows-signer = { path = "../ows-signer", version = "=1.3.2" }
-ows-lib = { path = "../ows-lib", version = "=1.3.2" }
+ows-core = { path = "../ows-core", version = "=1.4.1" }
+ows-signer = { path = "../ows-signer", version = "=1.4.1" }
+ows-lib = { path = "../ows-lib", version = "=1.4.1" }
 clap = { version = "4", features = ["derive", "env"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -25,8 +25,8 @@ tempfile = "3"
 rpassword = "7"
 serde = { version = "1", features = ["derive"] }
 zeroize = "1"
-ows-pay = { path = "../ows-pay", version = "=1.3.2" }
+ows-pay = { path = "../ows-pay", version = "=1.4.1" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
-ows-signer = { path = "../ows-signer", version = "=1.3.2", features = ["fast-kdf"] }
+ows-signer = { path = "../ows-signer", version = "=1.4.1", features = ["fast-kdf"] }

--- a/ows/crates/ows-core/Cargo.toml
+++ b/ows/crates/ows-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-core"
-version = "1.3.2"
+version = "1.4.1"
 edition = "2021"
 license = "MIT"
 description = "Core types and traits for the Open Wallet Standard"

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-lib"
-version = "1.3.2"
+version = "1.4.1"
 edition = "2021"
 license = "MIT"
 description = "High-level library API for the Open Wallet Standard"
@@ -12,8 +12,8 @@ default = []
 fast-kdf = ["ows-signer/fast-kdf"]
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=1.3.2" }
-ows-signer = { path = "../ows-signer", version = "=1.3.2" }
+ows-core = { path = "../ows-core", version = "=1.4.1" }
+ows-signer = { path = "../ows-signer", version = "=1.4.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -35,4 +35,4 @@ sha3 = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"] }
 ed25519-dalek = "2"
 bs58 = "0.5"
-ows-signer = { path = "../ows-signer", version = "=1.3.2", features = ["fast-kdf"] }
+ows-signer = { path = "../ows-signer", version = "=1.4.1", features = ["fast-kdf"] }

--- a/ows/crates/ows-pay/Cargo.toml
+++ b/ows/crates/ows-pay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-pay"
-version = "1.3.2"
+version = "1.4.1"
 edition = "2021"
 license = "MIT"
 description = "Payment client for the Open Wallet Standard (x402)"
@@ -8,7 +8,7 @@ repository = "https://github.com/open-wallet-standard/core"
 
 [dependencies]
 # Core types (ChainType, parse_chain, etc.)
-ows-core = { path = "../ows-core", version = "=1.3.2" }
+ows-core = { path = "../ows-core", version = "=1.4.1" }
 
 # HTTP
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ows-signer"
-version = "1.3.2"
+version = "1.4.1"
 edition = "2021"
 license = "MIT"
 description = "Cryptographic signing and key management for the Open Wallet Standard"
@@ -12,7 +12,7 @@ default = []
 fast-kdf = []
 
 [dependencies]
-ows-core = { path = "../ows-core", version = "=1.3.2" }
+ows-core = { path = "../ows-core", version = "=1.4.1" }
 bitcoin = { version = "0.32", features = ["base64"] }
 xrpl-rust = { version = "1.1.0", default-features = false, features = ["core"] }
 k256 = { version = "0.13", features = ["ecdsa", "arithmetic"] }

--- a/skills/ows/SKILL.md
+++ b/skills/ows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ows
 description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, and NEAR via CLI, Node.js, or Python.
-version: 1.3.2
+version: 1.4.1
 metadata:
   openclaw:
     requires:

--- a/website-docs/index.html
+++ b/website-docs/index.html
@@ -16,7 +16,7 @@
     <aside class="docs-sidebar">
       <div class="docs-sidebar-brand">
         <a href="./">OWS</a>
-        <span class="version">v1.3</span>
+        <span class="version">v1.4</span>
       </div>
       <div class="docs-sidebar-nav">
         <a href="./" class="active">Overview</a>
@@ -43,7 +43,7 @@
     </aside>
 
     <main class="docs-content">
-      <h1>Open Wallet Standard v1.3.2</h1>
+      <h1>Open Wallet Standard v1.4.1</h1>
       <p class="subtitle">An open standard for local wallet storage, delegated agent access, and policy-gated signing.</p>
 
       <h2>Abstract</h2>

--- a/website-docs/js/docs.js
+++ b/website-docs/js/docs.js
@@ -73,7 +73,7 @@ function buildSidebar(currentSlug) {
   // Brand
   html += '<div class="docs-sidebar-brand">';
   html += '<a href="./">OWS</a>';
-  html += '<span class="version">v1.3</span>';
+  html += '<span class="version">v1.4</span>';
   html += '</div>';
 
   // Nav


### PR DESCRIPTION
## Summary

Automated version bump to `1.4.1` triggered by tag [`v1.4.1`](https://github.com/open-wallet-standard/core/releases/tag/v1.4.1).

### Changes
- Rust crate versions (`Cargo.toml`)
- Python binding version (`pyproject.toml`, `Cargo.toml`)
- Node binding version (`package.json`, `Cargo.toml`, platform packages)
- Skill manifest version (`SKILL.md`)
- Docs site version badge and heading (`website-docs/`)
- Regenerated READMEs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and lockfile updates with no runtime or security logic changes.
> 
> **Overview**
> **Release metadata only:** bumps the monorepo from **1.3.2** to **1.4.1** so published artifacts and docs stay aligned with tag `v1.4.1`.
> 
> Rust workspace crates (`ows-core`, `ows-lib`, `ows-signer`, `ows-cli`, `ows-pay`, Node/Python binding crates) get updated package versions and matching `=1.4.1` path dependency pins in `Cargo.toml`, with corresponding `Cargo.lock` entries. Node packages `@open-wallet-standard/core`, platform-specific optional native packages, and `@open-wallet-standard/adapters` (including its `@open-wallet-standard/core` dependency and lockfiles) move to **1.4.1**. Python `open-wallet-standard` in `pyproject.toml` and the `ows-python` crate follow the same version. User-facing labels change in `skills/ows/SKILL.md` and the docs site (`v1.4` badge, `Open Wallet Standard v1.4.1` heading in `website-docs/`).
> 
> No application logic, APIs, or crypto behavior appear in the diff—only version strings and lockfile/package metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 525d5510725629d71e3fc9a0aa459feaef4c7052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->