### PR TITLE
fix(node): add repository field to package.json for npm provenance

### DIFF
--- a/bindings/node-adapters/package.json
+++ b/bindings/node-adapters/package.json
@@ -53,5 +53,9 @@
   "license": "MIT",
   "files": [
     "src"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-wallet-standard/core.git"
+  }
 }

--- a/bindings/node/npm/darwin-arm64/package.json
+++ b/bindings/node/npm/darwin-arm64/package.json
@@ -12,5 +12,9 @@
     "ows-node.darwin-arm64.node",
     "ows"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-wallet-standard/core.git"
+  }
 }

--- a/bindings/node/npm/darwin-x64/package.json
+++ b/bindings/node/npm/darwin-x64/package.json
@@ -12,5 +12,9 @@
     "ows-node.darwin-x64.node",
     "ows"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-wallet-standard/core.git"
+  }
 }

--- a/bindings/node/npm/linux-arm64-gnu/package.json
+++ b/bindings/node/npm/linux-arm64-gnu/package.json
@@ -12,5 +12,9 @@
     "ows-node.linux-arm64-gnu.node",
     "ows"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-wallet-standard/core.git"
+  }
 }

--- a/bindings/node/npm/linux-x64-gnu/package.json
+++ b/bindings/node/npm/linux-x64-gnu/package.json
@@ -12,5 +12,9 @@
     "ows-node.linux-x64-gnu.node",
     "ows"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-wallet-standard/core.git"
+  }
 }

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -42,5 +42,9 @@
     "index.d.ts",
     "bin/ows",
     "README.md"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-wallet-standard/core.git"
+  }
 }


### PR DESCRIPTION
## What
Adds a `repository` field to the Node binding `package.json` files: the main package, the adapters package, and the four platform packages.

## Why
#236 switched npm publishing to OIDC trusted publishing, which emits a provenance statement. The provenance validates that each `package.json` declares a `repository.url` matching the publishing repo. These had none, so the v1.4.1 `publish-npm` job failed:

`E422 ... "repository.url" is "", expected to match "https://github.com/open-wallet-standard/core" from provenance`

crates.io and PyPI published 1.4.1 fine; only npm was blocked.

## Testing
- All six package.json parse as valid JSON.
- Exercised by the next tagged release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only JSON edits with no runtime or dependency behavior changes.
> 
> **Overview**
> Adds a **`repository`** block (`git+https://github.com/open-wallet-standard/core.git`) to six Node-related **`package.json`** files: **`@open-wallet-standard/core`**, **`@open-wallet-standard/adapters`**, and the four platform optional packages under **`bindings/node/npm/`**.
> 
> This aligns package metadata with npm **OIDC trusted publishing / provenance**, which requires **`repository.url`** to match the publishing repo—without it, the v1.4.1 npm publish failed with E422 while other registries succeeded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a11701030881eebf681f456817953d94e37f1ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->