### PR TITLE
docs: add Community Extensions section to examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,3 +22,13 @@ Get test USDC on Base Sepolia: https://faucet.circle.com
     node examples/x402-pay-request.js
     node examples/x402-discover-services.js
     node examples/agent-with-policy.js
+
+## Community Extensions
+
+Projects that extend the OWS policy engine for a specific use case:
+
+| Project | Extends | Description |
+|---|---|---|
+| [ZKX](https://github.com/TechCortes/ZKX-Zero-Knowledge-Proof-for-Agentic-Banking) | Policy Engine | Registers a `zkx:kyc` feature — anonymous micropayments under a FATF Rec. 16 threshold, Groth16 zero-knowledge proof of identity above it. No PII ever collected or transmitted. |
+
+Building something on OWS? Open a PR adding it here.


### PR DESCRIPTION
Adds a place in `examples/README.md` to list third-party projects that extend the OWS policy engine for specific use cases — there wasn't one yet. Starting with [ZKX](https://github.com/TechCortes/ZKX-Zero-Knowledge-Proof-for-Agentic-Banking), which registers a `zkx:kyc` wallet-standard feature: anonymous agent micropayments below a FATF Rec. 16 threshold, a Groth16 zero-knowledge proof of identity above it, no PII collected or transmitted at any point.

Small, additive, doc-only — happy to adjust format/placement if you'd prefer this elsewhere.