### PR TITLE
feat: Cardano chain support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ Rust API:
 - `BalanceInfo.value` and `.price` are `Option<f64>`, absent on chains without pricing
 - `enforce_policy_and_decrypt_key` is split into `load_authorized_wallet` and
   `enforce_policies_and_decrypt_key`
+- `signer_for_chain` and `signer_for_chain_type` return
+  `Result<Box<dyn ChainSigner>, SignerError>`: Cardano rejects a `cip34:` reference it
+  does not know (`SignerError::UnsupportedChain`) rather than assuming mainnet
 
 Node and Python SDKs — arity changes only. Every new parameter is at the **end** of
 the list, so existing positional calls are unaffected:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Cardano support across mainnet, preprod and preview (`cip34:` CAIP-2 namespace):
+  Ed25519-BIP32 curve with CIP-3 Icarus master-key derivation, CIP-1852 payment and
+  stake paths, Shelley base/enterprise/reward addresses, CIP-8 COSE message signing,
+  CBOR transaction signing and submission, and ADA/native-asset balance queries via
+  Koios
+- `PolicyContext.request_type` names the operation being authorized
+  (`sign_transaction`, `sign_message`, `sign_hash`, `sign_typed_data`)
+- `TransactionContext.effects`: per-address, per-asset movement a transaction causes,
+  populated by chains whose signer implements flow analysis (Cardano today)
+- `TransactionContext.chain_extra`: opaque per-chain JSON for detail `effects` cannot
+  carry. Cardano reports contingent collateral loss in `chain_extra.collateral_effects`
+- `ChainSigner`: `make_transaction_context`, `default_derivation_paths`, `encode_keys`,
+  `verify_sign_message_address` and `transaction_context_needs_rpc`, all defaulted
+- Optional `address` argument on `sign_message` / `sign_typed_data`, which refuses to
+  sign for an address the key does not derive (`AddressMismatch`)
+
+### Breaking
+
+These are contract changes and warrant a major version; the number itself is set by
+the release tag (`.github/workflows/version-bump.yml`).
+
+Policy contract, as executable policies see it on stdin:
+
+- `PolicyContext.transaction` is now **optional** and is omitted for `sign_typed_data`,
+  which previously carried a `TransactionContext` with `raw_hex: ""`. **A policy that
+  detected typed data by that empty string can fail open**: written as
+  `tx = payload.get("transaction") or {}`, the `raw_hex == ""` test becomes false, so a
+  policy that denied typed data signing now allows it, with no error and no log entry.
+  Branch on `request_type == "sign_typed_data"` instead. See `docs/03-policy-engine.md`
+  for the failure direction of each policy style. Rust consumers break at compile time.
+- `TransactionContext.to` and `.value` are removed in favour of `effects`. Neither was
+  ever populated by any chain, so a policy reading them always saw `null`.
+- `TransactionEffect.diff` amounts are signed decimal **strings**, not integers: wei
+  overflows an `i64` above ~9.22 ETH, and a JSON integer above 2^53 does not survive
+  `JSON.parse`. Parse with `int()` / `BigInt()`.
+
+Rust API:
+
+- `ChainSigner::sign_message` gains an `address: Option<&str>` parameter
+- `ows_pay::fund::get_balances` gains an `rpc_url` parameter (required for Cardano)
+- `BalanceInfo.value` and `.price` are `Option<f64>`, absent on chains without pricing
+- `enforce_policy_and_decrypt_key` is split into `load_authorized_wallet` and
+  `enforce_policies_and_decrypt_key`
+
+Node and Python SDKs — arity changes only. Every new parameter is at the **end** of
+the list, so existing positional calls are unaffected:
+
+- `sign_message(wallet, chain, message, passphrase?, encoding?, index?, vaultPath?, address?)`
+- `sign_typed_data(wallet, chain, typedDataJson, passphrase?, index?, vaultPath?, address?)`
+- `import_wallet_private_key(…, secp256k1Key?, ed25519Key?, ed25519Bip32Key?)`
+
 ## [0.2.18] - 2026-03-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Agent / CLI / App
 | Spark (Bitcoin L2) | secp256k1 | spark: prefixed | `m/84'/0'/0'/0/0` |
 | Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
 | XRPL | secp256k1 | base58check | `m/44'/144'/0'/0/0`|
+| Cardano | Ed25519-BIP32 (CIP-1852) | Shelley Bech32 base (`addr1…`) | Payment `m/1852'/1815'/0'/0/0` + stake `m/1852'/1815'/0'/2/0` |
 
 ## CLI Reference
 

--- a/bindings/node-adapters/README.md
+++ b/bindings/node-adapters/README.md
@@ -77,7 +77,7 @@ const signature = await account.sign("hello");
 const txHash = await account.sendTransaction("deadbeef...");
 ```
 
-`chain` accepts WDK short names (`"evm"`, `"solana"`, `"btc"`, `"ton"`, `"tron"`, `"cosmos"`, `"sui"`, `"xrpl"`, `"filecoin"`, `"spark"`) or CAIP-2 identifiers.
+`chain` accepts WDK short names (`"evm"`, `"solana"`, `"btc"`, `"ton"`, `"tron"`, `"cosmos"`, `"sui"`, `"xrpl"`, `"filecoin"`, `"spark"`, `"cardano"`) or CAIP-2 identifiers.
 
 Options: `passphrase`, `index`, `rpcUrl`, `vaultPath`.
 

--- a/bindings/node-adapters/__test__/solana.spec.mjs
+++ b/bindings/node-adapters/__test__/solana.spec.mjs
@@ -45,7 +45,7 @@ describe('@open-wallet-standard/adapters — solana', () => {
   it('keypair matches OWS signMessage output', async () => {
     const keypair = owsToSolanaKeypair(walletName, { vaultPath: vaultDir });
     const messageHex = Buffer.from('verify-match').toString('hex');
-    const owsResult = signMessage(walletName, 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', messageHex, undefined, 'hex', undefined, vaultDir);
+    const owsResult = signMessage(walletName, 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', messageHex, undefined, 'hex', undefined, undefined, vaultDir);
     const { ed25519 } = await import('@noble/curves/ed25519');
     const keypairSig = Buffer.from(ed25519.sign(Buffer.from(messageHex, 'hex'), keypair.secretKey.slice(0, 32))).toString('hex');
     assert.equal(keypairSig, owsResult.signature);

--- a/bindings/node-adapters/__test__/solana.spec.mjs
+++ b/bindings/node-adapters/__test__/solana.spec.mjs
@@ -45,7 +45,7 @@ describe('@open-wallet-standard/adapters — solana', () => {
   it('keypair matches OWS signMessage output', async () => {
     const keypair = owsToSolanaKeypair(walletName, { vaultPath: vaultDir });
     const messageHex = Buffer.from('verify-match').toString('hex');
-    const owsResult = signMessage(walletName, 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', messageHex, undefined, 'hex', undefined, undefined, vaultDir);
+    const owsResult = signMessage(walletName, 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', messageHex, undefined, 'hex', undefined, vaultDir);
     const { ed25519 } = await import('@noble/curves/ed25519');
     const keypairSig = Buffer.from(ed25519.sign(Buffer.from(messageHex, 'hex'), keypair.secretKey.slice(0, 32))).toString('hex');
     assert.equal(keypairSig, owsResult.signature);

--- a/bindings/node-adapters/__test__/viem.spec.mjs
+++ b/bindings/node-adapters/__test__/viem.spec.mjs
@@ -41,7 +41,7 @@ describe('@open-wallet-standard/adapters — viem', () => {
   it('signMessage matches OWS SDK direct call', async () => {
     const account = owsToViemAccount(walletName, { vaultPath: vaultDir });
     const adapterSig = await account.signMessage({ message: 'parity-check' });
-    const directResult = owsSignMessage(walletName, 'eip155:1', 'parity-check', undefined, undefined, undefined, vaultDir);
+    const directResult = owsSignMessage(walletName, 'eip155:1', 'parity-check', undefined, undefined, undefined, undefined, vaultDir);
     const directSig = directResult.signature.startsWith('0x') ? directResult.signature : `0x${directResult.signature}`;
     assert.equal(adapterSig, directSig);
   });

--- a/bindings/node-adapters/__test__/viem.spec.mjs
+++ b/bindings/node-adapters/__test__/viem.spec.mjs
@@ -41,7 +41,7 @@ describe('@open-wallet-standard/adapters — viem', () => {
   it('signMessage matches OWS SDK direct call', async () => {
     const account = owsToViemAccount(walletName, { vaultPath: vaultDir });
     const adapterSig = await account.signMessage({ message: 'parity-check' });
-    const directResult = owsSignMessage(walletName, 'eip155:1', 'parity-check', undefined, undefined, undefined, undefined, vaultDir);
+    const directResult = owsSignMessage(walletName, 'eip155:1', 'parity-check', undefined, undefined, undefined, vaultDir);
     const directSig = directResult.signature.startsWith('0x') ? directResult.signature : `0x${directResult.signature}`;
     assert.equal(adapterSig, directSig);
   });

--- a/bindings/node-adapters/src/viem.js
+++ b/bindings/node-adapters/src/viem.js
@@ -18,7 +18,7 @@ function owsToViemAccount(walletNameOrId, options = {}) {
       const msg = typeof message === "string" ? message
         : typeof raw === "string" ? (raw.startsWith("0x") ? raw.slice(2) : Buffer.from(raw).toString("hex"))
         : Buffer.from(raw).toString("hex");
-      const result = signMessage(walletNameOrId, chain, msg, options.passphrase, typeof message === "string" ? undefined : "hex", options.index, options.vaultPath);
+      const result = signMessage(walletNameOrId, chain, msg, options.passphrase, typeof message === "string" ? undefined : "hex", options.index, undefined, options.vaultPath);
       return result.signature.startsWith("0x") ? result.signature : `0x${result.signature}`;
     },
     async signTransaction(transaction) {
@@ -33,7 +33,7 @@ function owsToViemAccount(walletNameOrId, options = {}) {
       return serializeTransaction(transaction, { r, s, yParity });
     },
     async signTypedData(typedData) {
-      const result = signTypedData(walletNameOrId, chain, JSON.stringify(typedData), options.passphrase, options.index, options.vaultPath);
+      const result = signTypedData(walletNameOrId, chain, JSON.stringify(typedData), options.passphrase, options.index, undefined, options.vaultPath);
       return result.signature.startsWith("0x") ? result.signature : `0x${result.signature}`;
     },
   });

--- a/bindings/node-adapters/src/viem.js
+++ b/bindings/node-adapters/src/viem.js
@@ -18,7 +18,7 @@ function owsToViemAccount(walletNameOrId, options = {}) {
       const msg = typeof message === "string" ? message
         : typeof raw === "string" ? (raw.startsWith("0x") ? raw.slice(2) : Buffer.from(raw).toString("hex"))
         : Buffer.from(raw).toString("hex");
-      const result = signMessage(walletNameOrId, chain, msg, options.passphrase, typeof message === "string" ? undefined : "hex", options.index, undefined, options.vaultPath);
+      const result = signMessage(walletNameOrId, chain, msg, options.passphrase, typeof message === "string" ? undefined : "hex", options.index, options.vaultPath);
       return result.signature.startsWith("0x") ? result.signature : `0x${result.signature}`;
     },
     async signTransaction(transaction) {
@@ -33,7 +33,7 @@ function owsToViemAccount(walletNameOrId, options = {}) {
       return serializeTransaction(transaction, { r, s, yParity });
     },
     async signTypedData(typedData) {
-      const result = signTypedData(walletNameOrId, chain, JSON.stringify(typedData), options.passphrase, options.index, undefined, options.vaultPath);
+      const result = signTypedData(walletNameOrId, chain, JSON.stringify(typedData), options.passphrase, options.index, options.vaultPath);
       return result.signature.startsWith("0x") ? result.signature : `0x${result.signature}`;
     },
   });

--- a/bindings/node-adapters/src/wdk.js
+++ b/bindings/node-adapters/src/wdk.js
@@ -67,7 +67,7 @@ function owsToWdkAccount(walletNameOrId, chain, options = {}) {
         ? Buffer.from(message).toString("hex")
         : message;
       const encoding = Buffer.isBuffer(message) || message instanceof Uint8Array ? "hex" : "utf8";
-      const result = signMessage(walletNameOrId, caipChain, msg, options.passphrase, encoding, idx, options.vaultPath);
+      const result = signMessage(walletNameOrId, caipChain, msg, options.passphrase, encoding, idx, undefined, options.vaultPath);
       return Uint8Array.from(Buffer.from(result.signature, "hex"));
     },
 

--- a/bindings/node-adapters/src/wdk.js
+++ b/bindings/node-adapters/src/wdk.js
@@ -67,7 +67,7 @@ function owsToWdkAccount(walletNameOrId, chain, options = {}) {
         ? Buffer.from(message).toString("hex")
         : message;
       const encoding = Buffer.isBuffer(message) || message instanceof Uint8Array ? "hex" : "utf8";
-      const result = signMessage(walletNameOrId, caipChain, msg, options.passphrase, encoding, idx, undefined, options.vaultPath);
+      const result = signMessage(walletNameOrId, caipChain, msg, options.passphrase, encoding, idx, options.vaultPath);
       return Uint8Array.from(Buffer.from(result.signature, "hex"));
     },
 

--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -35,6 +35,18 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -183,6 +195,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -194,10 +212,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-url"
+version = "1.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bech32"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
 name = "bech32"
@@ -277,6 +310,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -299,7 +338,16 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -308,7 +356,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -317,7 +365,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -340,6 +388,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cardano-serialization-lib"
+version = "14.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a894086cb078655b52a9478ae50e1f7b11f3a16fb02e2f11fe63b63644462c"
+dependencies = [
+ "bech32 0.7.3",
+ "cbor_event",
+ "cfg-if",
+ "clear_on_drop",
+ "cryptoxide 0.4.4",
+ "digest 0.9.0",
+ "ed25519-bip32",
+ "getrandom 0.2.17",
+ "hashlink",
+ "hex",
+ "itertools 0.10.5",
+ "js-sys",
+ "noop_proc_macro",
+ "num",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_os",
+ "schemars 0.8.22",
+ "serde",
+ "serde-wasm-bindgen 0.4.5",
+ "serde_json",
+ "sha2 0.9.9",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "cbor_event"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "089a0261d1bc59e54e8e11860031efd88593f0e61b921172c474f1f38c2f2d3c"
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +442,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -380,6 +474,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "coins-bip32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,11 +499,11 @@ checksum = "66c43ff7fd9ff522219058808a259e61423335767b1071d5b346de60d9219657"
 dependencies = [
  "bs58",
  "coins-core",
- "digest",
+ "digest 0.10.7",
  "hmac",
  "k256",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -407,7 +519,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -421,11 +533,11 @@ dependencies = [
  "bech32 0.9.1",
  "bs58",
  "const-hex",
- "digest",
- "generic-array",
+ "digest 0.10.7",
+ "generic-array 0.14.7",
  "ripemd",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -484,7 +596,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -496,10 +608,22 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
+
+[[package]]
+name = "cryptoxide"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42014d4c82e74bc17aaccc4bd75d3615d2b8236198de81c51bed5ddefaae6435"
+
+[[package]]
+name = "cryptoxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
 name = "ctor"
@@ -529,7 +653,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -614,11 +738,29 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecae1c064e29fcabb6c2e9939e53dc7da72ed90234ae36ebfe03a478742efbd1"
+dependencies = [
+ "generic-array 0.8.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -648,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -666,6 +808,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-bip32"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
+dependencies = [
+ "cryptoxide 0.4.4",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,7 +825,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -693,9 +844,9 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "pkcs8",
  "rand_core 0.6.4",
@@ -737,6 +888,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "emurgo-cardano-message-signing"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2136c6e1d3b4ef3f6ca14aef5677c7e480b3eaa38f63da30275655dbf7f866f"
+dependencies = [
+ "base64-url",
+ "byteorder",
+ "cbor_event",
+ "cryptoxide 0.3.6",
+ "hex",
+ "linked-hash-map",
+ "noop_proc_macro",
+ "pruefung",
+ "serde-wasm-bindgen 0.6.5",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -799,6 +968,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -818,6 +994,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -838,9 +1020,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2297fb0e3ea512e380da24b52dca3924028f59df5e3a17a18f81d8349ca7ebe"
+dependencies = [
+ "nodrop",
+ "typenum",
 ]
 
 [[package]]
@@ -861,8 +1056,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -873,21 +1070,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -947,6 +1131,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -962,6 +1155,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heapless"
@@ -1015,7 +1217,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1084,6 +1286,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1225,12 +1443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,7 +1498,22 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1306,11 +1533,10 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1324,7 +1550,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -1342,12 +1568,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1370,6 +1590,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "litemap"
@@ -1418,7 +1644,7 @@ version = "2.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "ctor",
  "napi-derive",
  "napi-sys",
@@ -1472,6 +1698,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,10 +1734,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -1493,6 +1765,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1534,6 +1828,7 @@ version = "1.3.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "ed25519-bip32",
  "getrandom 0.2.17",
  "hex",
  "ows-core",
@@ -1542,7 +1837,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -1572,22 +1867,27 @@ dependencies = [
  "bitcoin",
  "blake2",
  "bs58",
+ "cardano-serialization-lib",
  "coins-bip32",
  "coins-bip39",
- "digest",
+ "digest 0.10.7",
+ "ed25519-bip32",
  "ed25519-dalek",
+ "emurgo-cardano-message-signing",
  "hex",
  "hkdf",
  "hmac",
  "k256",
  "libc",
  "ows-core",
+ "pbkdf2",
  "rand 0.8.5",
+ "reqwest",
  "ripemd",
  "scrypt",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "signal-hook",
  "thiserror 2.0.18",
@@ -1612,8 +1912,9 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
+ "password-hash",
 ]
 
 [[package]]
@@ -1701,16 +2002,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,7 +2016,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -1751,10 +2042,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "pruefung"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734d1fcf58d4e4aa4118926d4d44b1ea8921e4064c30a0415ae273552ebdd784"
+dependencies = [
+ "digest 0.6.1",
+ "generic-array 0.8.4",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "bytes",
+ "getrandom 0.2.17",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1771,12 +2124,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -1827,6 +2174,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -1853,12 +2215,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1911,6 +2297,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.11",
+ "windows-registry",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,12 +2351,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1942,6 +2386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,10 +2401,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -1963,6 +2463,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1990,6 +2502,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scrypt"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,7 +2522,7 @@ dependencies = [
  "password-hash",
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2009,7 +2533,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -2060,6 +2584,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,6 +2619,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2101,6 +2658,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2136,13 +2705,26 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2151,7 +2733,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -2187,7 +2769,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2297,6 +2879,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2458,6 +3043,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,6 +3136,7 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -2619,12 +3215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,6 +3225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +3239,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2653,13 +3250,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2693,45 +3288,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
- "once_cell",
- "rustversion",
  "serde",
  "wasm-bindgen-macro",
- "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.115"
+name = "wasm-bindgen-backend"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
+ "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2739,47 +3314,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
- "unicode-ident",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
- "leb128fmt",
- "wasmparser",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.244.0"
+name = "webpki-roots"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
+name = "webpki-roots"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
+ "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2790,8 +3423,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -2823,12 +3456,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2927,88 +3590,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -3054,7 +3635,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "strum",
  "strum_macros",
  "thiserror-no-std",

--- a/bindings/node/Cargo.lock
+++ b/bindings/node/Cargo.lock
@@ -3725,6 +3725,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -31,7 +31,7 @@ Using viem, `@solana/web3.js`, or the Tether WDK? Install [`@open-wallet-standar
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("agent-treasury");
-// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
+// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, NEAR, and Cardano
 
 const sig = signMessage("agent-treasury", "evm", "hello");
 console.log(sig.signature);
@@ -50,6 +50,32 @@ ows sign message --wallet agent-treasury --chain evm --message "hello"
 ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
 ```
 
+## API Reference
+
+| Function | Description |
+|----------|-------------|
+| `createWallet(name, passphrase?, words?, vaultPath?)` | Create a new wallet with addresses for the current auto-derived chain set |
+| `importWalletMnemonic(name, mnemonic, passphrase?, index?, vaultPath?)` | Import a wallet from a BIP-39 mnemonic |
+| `importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?, ed25519Bip32Key?)` | Import a wallet from a private key |
+| `listWallets(vaultPath?)` | List all wallets in the vault |
+| `getWallet(nameOrId, vaultPath?)` | Get details of a specific wallet |
+| `deleteWallet(nameOrId, vaultPath?)` | Delete a wallet |
+| `exportWallet(nameOrId, passphrase?, vaultPath?)` | Export a wallet's mnemonic or keys |
+| `renameWallet(nameOrId, newName, vaultPath?)` | Rename a wallet |
+| `signMessage(wallet, chain, message, passphrase?, encoding?, index?, address?, vaultPath?)` | Sign a message with chain-specific formatting |
+| `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, address?, vaultPath?)` | Sign EIP-712 typed data (EVM only) |
+| `signTransaction(wallet, chain, txHex, passphrase?, index?, vaultPath?)` | Sign a raw transaction |
+| `signAndSend(wallet, chain, txHex, passphrase?, index?, rpcUrl?, vaultPath?)` | Sign and broadcast a transaction |
+| `generateMnemonic(words?)` | Generate a BIP-39 mnemonic phrase |
+| `deriveAddress(mnemonic, chain, index?)` | Derive an address from a mnemonic |
+| `createPolicy(policyJson, vaultPath?)` | Register a policy from a JSON string |
+| `listPolicies(vaultPath?)` | List all registered policies |
+| `getPolicy(id, vaultPath?)` | Get a single policy by ID |
+| `deletePolicy(id, vaultPath?)` | Delete a policy by ID |
+| `createApiKey(name, walletIds, policyIds, passphrase, expiresAt?, vaultPath?)` | Create an API key for agent access |
+| `listApiKeys(vaultPath?)` | List all API keys (tokens never returned) |
+| `revokeApiKey(id, vaultPath?)` | Revoke an API key |
+
 ## Supported Chains
 
 | Chain | Curve | Address Format | Derivation Path |
@@ -65,6 +91,7 @@ ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
 | Spark (Bitcoin L2) | secp256k1 | spark: prefixed | `m/84'/0'/0'/0/0` |
 | Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
 | NEAR | Ed25519 | implicit hex (64 chars) | `m/44'/397'/0'` |
+| Cardano | Ed25519-BIP32 (CIP-1852) | Shelley Bech32 base (`addr1…`) | Payment `m/1852'/1815'/0'/0/0` + stake `m/1852'/1815'/0'/2/0` |
 
 ## CLI Reference
 

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -62,8 +62,8 @@ ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
 | `deleteWallet(nameOrId, vaultPath?)` | Delete a wallet |
 | `exportWallet(nameOrId, passphrase?, vaultPath?)` | Export a wallet's mnemonic or keys |
 | `renameWallet(nameOrId, newName, vaultPath?)` | Rename a wallet |
-| `signMessage(wallet, chain, message, passphrase?, encoding?, index?, address?, vaultPath?)` | Sign a message with chain-specific formatting |
-| `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, address?, vaultPath?)` | Sign EIP-712 typed data (EVM only) |
+| `signMessage(wallet, chain, message, passphrase?, encoding?, index?, vaultPath?, address?)` | Sign a message with chain-specific formatting |
+| `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, vaultPath?, address?)` | Sign EIP-712 typed data (EVM only) |
 | `signTransaction(wallet, chain, txHex, passphrase?, index?, vaultPath?)` | Sign a raw transaction |
 | `signAndSend(wallet, chain, txHex, passphrase?, index?, rpcUrl?, vaultPath?)` | Sign and broadcast a transaction |
 | `generateMnemonic(words?)` | Generate a BIP-39 mnemonic phrase |

--- a/bindings/node/__test__/index.spec.mjs
+++ b/bindings/node/__test__/index.spec.mjs
@@ -54,7 +54,7 @@ describe('@open-wallet-standard/core', () => {
 
   it('derives addresses for all chains', () => {
     const phrase = generateMnemonic(12);
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano', 'near']) {
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano', 'near', 'cardano']) {
       const addr = deriveAddress(phrase, chain);
       assert.ok(addr.length > 0, `address should be non-empty for ${chain}`);
     }
@@ -62,10 +62,10 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Universal wallet lifecycle ----
 
-  it('creates a universal wallet with 12 accounts', () => {
+  it('creates a universal wallet with 15 accounts', () => {
     const wallet = createWallet('lifecycle-test', undefined, 12, vaultDir);
     assert.equal(wallet.name, 'lifecycle-test');
-    assert.equal(wallet.accounts.length, 12);
+    assert.equal(wallet.accounts.length, 15);
 
     const chainIds = wallet.accounts.map((a) => a.chainId);
     assert.ok(chainIds.some((c) => c.startsWith('eip155:')));
@@ -80,6 +80,7 @@ describe('@open-wallet-standard/core', () => {
     assert.ok(chainIds.some((c) => c.startsWith('xrpl:')));
     assert.ok(chainIds.some((c) => c.startsWith('nano:')));
     assert.ok(chainIds.some((c) => c.startsWith('near:')));
+    assert.ok(chainIds.some((c) => c.startsWith('cip34:')));
 
     // List
     const wallets = listWallets(vaultDir);
@@ -113,7 +114,7 @@ describe('@open-wallet-standard/core', () => {
 
     const wallet = importWalletMnemonic('mn-import', phrase, undefined, undefined, vaultDir);
     assert.equal(wallet.name, 'mn-import');
-    assert.equal(wallet.accounts.length, 12);
+    assert.equal(wallet.accounts.length, 15);
 
     const evmAcct = wallet.accounts.find((a) => a.chainId.startsWith('eip155:'));
     assert.equal(evmAcct.address, expectedEvm);
@@ -126,12 +127,12 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Private key import (secp256k1) ----
 
-  it('imports a secp256k1 private key with all 12 accounts', () => {
+  it('imports a secp256k1 private key with all 15 accounts', () => {
     const privkey = '4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318';
     const wallet = importWalletPrivateKey('pk-secp', privkey, undefined, vaultDir, 'evm');
 
     assert.equal(wallet.name, 'pk-secp');
-    assert.equal(wallet.accounts.length, 12, 'should have all 12 chain accounts');
+    assert.equal(wallet.accounts.length, 15, 'should have all 15 chain accounts');
 
     // Sign on EVM (provided key's curve)
     const evmSig = signMessage('pk-secp', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
@@ -141,7 +142,7 @@ describe('@open-wallet-standard/core', () => {
     const solSig = signMessage('pk-secp', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(solSig.signature.length > 0);
 
-    // Export returns JSON with both keys
+    // Export returns JSON with all keys
     const exported = JSON.parse(exportWallet('pk-secp', undefined, vaultDir));
     assert.equal(exported.secp256k1, privkey);
     assert.ok(exported.ed25519.length === 64, 'should have 32-byte ed25519 key in hex');
@@ -151,11 +152,11 @@ describe('@open-wallet-standard/core', () => {
 
   // ---- Private key import (ed25519) ----
 
-  it('imports an ed25519 private key with all 12 accounts', () => {
+  it('imports an ed25519 private key with all 15 accounts', () => {
     const privkey = '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60';
     const wallet = importWalletPrivateKey('pk-ed', privkey, undefined, vaultDir, 'solana');
 
-    assert.equal(wallet.accounts.length, 12);
+    assert.equal(wallet.accounts.length, 15);
 
     // Sign on Solana (provided key)
     const solSig = signMessage('pk-ed', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
@@ -172,33 +173,66 @@ describe('@open-wallet-standard/core', () => {
     deleteWallet('pk-ed', vaultDir);
   });
 
-  // ---- Private key import (both curves) ----
+  // ---- Private key import (ed25519-bip32) ----
 
-  it('imports both curve keys explicitly', () => {
+  it('imports an ed25519-bip32 private key with all 15 accounts', () => {
+    const privkey = 'f8a29231ee38d6c5bf715d5bac21c750577aa3798b22d79d65bf97d6fadea15adcd1ee1abdf78bd4be64731a12deb94d3671784112eb6f364b871851fd1c9a247384db9ad6003bbd08b3b1ddc0d07a597293ff85e961bf252b331262eddfad0d';
+    const wallet = importWalletPrivateKey('pk-ed-bip32', privkey, undefined, vaultDir, 'cardano');
+
+    assert.equal(wallet.accounts.length, 15);
+
+    // Sign on Cardano (provided key)
+    const cardanoSig = signMessage('pk-ed-bip32', 'cardano', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    assert.ok(cardanoSig.signature.length > 0);
+
+    // Sign on EVM (generated key)
+    const evmSig = signMessage('pk-ed-bip32', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    assert.ok(evmSig.signature.length > 0);
+
+    // Sign on TON (same ed25519 key)
+    const tonSig = signMessage('pk-ed-bip32', 'ton', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    assert.ok(tonSig.signature.length > 0);
+
+    // Sign on Solana (generated key)
+    const solSig = signMessage('pk-ed-bip32', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    assert.ok(solSig.signature.length > 0);
+
+    deleteWallet('pk-ed-bip32', vaultDir);
+  });
+
+  // ---- Private key import (all curves) ----
+
+  it('imports all curve keys explicitly', () => {
     const secpKey = '4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318';
     const edKey = '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60';
+    const edBip32Key = 'f8a29231ee38d6c5bf715d5bac21c750577aa3798b22d79d65bf97d6fadea15adcd1ee1abdf78bd4be64731a12deb94d3671784112eb6f364b871851fd1c9a247384db9ad6003bbd08b3b1ddc0d07a597293ff85e961bf252b331262eddfad0d';
 
     const wallet = importWalletPrivateKey(
-      'pk-both', '', undefined, vaultDir, undefined, secpKey, edKey
+      'pk-all', '', undefined, vaultDir, undefined, secpKey, edKey, edBip32Key
     );
 
-    assert.equal(wallet.name, 'pk-both');
-    assert.equal(wallet.accounts.length, 12, 'should have all 12 chain accounts');
+    assert.equal(wallet.name, 'pk-all');
+    assert.equal(wallet.accounts.length, 15, 'should have all 15 chain accounts');
 
     // Sign on EVM (secp256k1 key)
-    const evmSig = signMessage('pk-both', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const evmSig = signMessage('pk-all', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(evmSig.signature.length > 0);
 
     // Sign on Solana (ed25519 key)
-    const solSig = signMessage('pk-both', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const solSig = signMessage('pk-all', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(solSig.signature.length > 0);
 
-    // Export returns both provided keys
-    const exported = JSON.parse(exportWallet('pk-both', undefined, vaultDir));
+    // Sign on Cardano (ed25519-bip32 key)
+    const cardanoSig = signMessage('pk-all', 'cardano', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    assert.ok(cardanoSig.signature.length > 0);
+
+    // Export returns all provided keys
+    const exported = JSON.parse(exportWallet('pk-all', undefined, vaultDir));
     assert.equal(exported.secp256k1, secpKey);
     assert.equal(exported.ed25519, edKey);
+    assert.equal(exported.ed25519_bip32, edBip32Key);
 
-    deleteWallet('pk-both', vaultDir);
+    deleteWallet('pk-all', vaultDir);
   });
 
   // ---- Signing all chains ----
@@ -238,6 +272,9 @@ describe('@open-wallet-standard/core', () => {
     // NEAR transactions have no envelope; signer hashes via sha256 then ed25519
     // signs the digest. Any non-empty bytes verify the signing pipeline.
     const nearTxHex = '42'.repeat(80);
+    
+    // Valid Cardano Conway-era `FixedTransaction` CBOR fixture (from cardano-serialization-lib tests).
+    const cardanoTxHex = "84a700818258208b9c96823c19f2047f32210a330434b3d163e194ea17b2b702c0667f6fea7a7a000d80018182581d6138fe1dd1d91221a199ff0dacf41fdd5b87506b533d00e70fae8dae8f1abfbac06a021a0002b645031a03962de305a1581de1b3cabd3914ef99169ace1e8b545b635f809caa35f8b6c8bc69ae48061abf4009040e80a100828258207dc05ac55cdfb9cc24571d491d3a3bdbd7d48489a916d27fce3ffe5c9af1b7f55840d7eda8457f1814fe3333b7b1916e3b034e6d480f97f4f286b1443ef72383279718a3a3fddf127dae0505b01a48fd9ffe0f52d9d8c46d02bcb85d1d106c13aa048258201b3d6e1236891a921abf1a3f90a9fb1b2568b1096b6cd6d3eaaeb0ef0ee0802f58401ce4658303c3eb0f2b9705992ccd62de30423ade90219e2c4cfc9eb488c892ea28ba3110f0c062298447f4f6365499d97d31207075f9815c3fe530bd9a927402f5f6";
 
     // XRPL signing decodes the tx to inject SigningPubKey, so it needs a real
     // binary-encoded unsigned Payment (no SigningPubKey/TxnSignature).
@@ -249,9 +286,10 @@ describe('@open-wallet-standard/core', () => {
       nano: nanoTxHex,
       near: nearTxHex,
       xrpl: xrplTxHex,
+      cardano: cardanoTxHex,
     };
 
-    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano', 'near']) {
+    for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'xrpl', 'nano', 'near', 'cardano']) {
       const hex = txHexByChain[chain] ?? txHex;
       const result = signTransaction('tx-signer', chain, hex, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);

--- a/bindings/node/__test__/index.spec.mjs
+++ b/bindings/node/__test__/index.spec.mjs
@@ -134,11 +134,11 @@ describe('@open-wallet-standard/core', () => {
     assert.equal(wallet.accounts.length, 12, 'should have all 12 chain accounts');
 
     // Sign on EVM (provided key's curve)
-    const evmSig = signMessage('pk-secp', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
+    const evmSig = signMessage('pk-secp', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(evmSig.signature.length > 0);
 
     // Sign on Solana (generated key's curve)
-    const solSig = signMessage('pk-secp', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
+    const solSig = signMessage('pk-secp', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(solSig.signature.length > 0);
 
     // Export returns JSON with both keys
@@ -158,15 +158,15 @@ describe('@open-wallet-standard/core', () => {
     assert.equal(wallet.accounts.length, 12);
 
     // Sign on Solana (provided key)
-    const solSig = signMessage('pk-ed', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
+    const solSig = signMessage('pk-ed', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(solSig.signature.length > 0);
 
     // Sign on EVM (generated key)
-    const evmSig = signMessage('pk-ed', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
+    const evmSig = signMessage('pk-ed', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(evmSig.signature.length > 0);
 
     // Sign on TON (same ed25519 key)
-    const tonSig = signMessage('pk-ed', 'ton', 'hello', undefined, undefined, undefined, vaultDir);
+    const tonSig = signMessage('pk-ed', 'ton', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(tonSig.signature.length > 0);
 
     deleteWallet('pk-ed', vaultDir);
@@ -186,11 +186,11 @@ describe('@open-wallet-standard/core', () => {
     assert.equal(wallet.accounts.length, 12, 'should have all 12 chain accounts');
 
     // Sign on EVM (secp256k1 key)
-    const evmSig = signMessage('pk-both', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
+    const evmSig = signMessage('pk-both', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(evmSig.signature.length > 0);
 
     // Sign on Solana (ed25519 key)
-    const solSig = signMessage('pk-both', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
+    const solSig = signMessage('pk-both', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.ok(solSig.signature.length > 0);
 
     // Export returns both provided keys
@@ -210,7 +210,7 @@ describe('@open-wallet-standard/core', () => {
     // support generic off-chain message signing without a defined convention.
     // NEAR's V1 sign_message is raw ed25519 over the bytes (NEP-413 is a follow-up).
     for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'near']) {
-      const result = signMessage('all-chain-signer', chain, 'test', undefined, undefined, undefined, vaultDir);
+      const result = signMessage('all-chain-signer', chain, 'test', undefined, undefined, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);
     }
 
@@ -288,8 +288,8 @@ describe('@open-wallet-standard/core', () => {
   it('produces deterministic signatures', () => {
     createWallet('det-test', undefined, 12, vaultDir);
 
-    const sig1 = signMessage('det-test', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
-    const sig2 = signMessage('det-test', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
+    const sig1 = signMessage('det-test', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const sig2 = signMessage('det-test', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
     assert.equal(sig1.signature, sig2.signature);
 
     deleteWallet('det-test', vaultDir);
@@ -305,7 +305,7 @@ describe('@open-wallet-standard/core', () => {
 
   it('rejects non-existent wallet', () => {
     assert.throws(() => getWallet('nonexistent', vaultDir));
-    assert.throws(() => signMessage('nonexistent', 'evm', 'x', undefined, undefined, undefined, vaultDir));
+    assert.throws(() => signMessage('nonexistent', 'evm', 'x', undefined, undefined, undefined, undefined, vaultDir));
   });
 
   it('rejects invalid private key hex', () => {
@@ -395,6 +395,7 @@ describe('@open-wallet-standard/core', () => {
       key.token,
       undefined,
       undefined,
+      undefined,
       vaultDir,
     );
     assert.ok(msgSig.signature.length > 0);
@@ -460,7 +461,7 @@ describe('@open-wallet-standard/core', () => {
     });
 
     // Sign on allowed chain — should succeed
-    const sig = signTypedData(wallet.id, 'base', typedDataJson, key.token, null, vaultDir);
+    const sig = signTypedData(wallet.id, 'base', typedDataJson, key.token, null, null, vaultDir);
     assert.ok(sig.signature.length > 0, 'signature should be non-empty');
     assert.ok(sig.recoveryId != null, 'recoveryId should be present for EIP-712');
 
@@ -472,7 +473,7 @@ describe('@open-wallet-standard/core', () => {
       domain: { ...JSON.parse(typedDataJson).domain, chainId: 1 },
     });
     assert.throws(
-      () => signTypedData(wallet.id, 'ethereum', ethTypedDataJson, key.token, null, vaultDir),
+      () => signTypedData(wallet.id, 'ethereum', ethTypedDataJson, key.token, null, null, vaultDir),
       (err) => err.message.includes('not in allowlist'),
     );
 
@@ -530,6 +531,7 @@ describe('@open-wallet-standard/core', () => {
       JSON.stringify(typedData),
       key.token,
       null,
+      null,
       vaultDir,
     );
     assert.ok(allowed.signature.length > 0);
@@ -543,7 +545,7 @@ describe('@open-wallet-standard/core', () => {
     };
 
     assert.throws(
-      () => signTypedData(wallet.id, 'base', JSON.stringify(deniedTypedData), key.token, null, vaultDir),
+      () => signTypedData(wallet.id, 'base', JSON.stringify(deniedTypedData), key.token, null, null, vaultDir),
       (err) => err.message.includes('not in allowed list'),
     );
 

--- a/bindings/node/__test__/index.spec.mjs
+++ b/bindings/node/__test__/index.spec.mjs
@@ -272,7 +272,7 @@ describe('@open-wallet-standard/core', () => {
     // NEAR transactions have no envelope; signer hashes via sha256 then ed25519
     // signs the digest. Any non-empty bytes verify the signing pipeline.
     const nearTxHex = '42'.repeat(80);
-    
+
     // Valid Cardano Conway-era `FixedTransaction` CBOR fixture (from cardano-serialization-lib tests).
     const cardanoTxHex = "84a700818258208b9c96823c19f2047f32210a330434b3d163e194ea17b2b702c0667f6fea7a7a000d80018182581d6138fe1dd1d91221a199ff0dacf41fdd5b87506b533d00e70fae8dae8f1abfbac06a021a0002b645031a03962de305a1581de1b3cabd3914ef99169ace1e8b545b635f809caa35f8b6c8bc69ae48061abf4009040e80a100828258207dc05ac55cdfb9cc24571d491d3a3bdbd7d48489a916d27fce3ffe5c9af1b7f55840d7eda8457f1814fe3333b7b1916e3b034e6d480f97f4f286b1443ef72383279718a3a3fddf127dae0505b01a48fd9ffe0f52d9d8c46d02bcb85d1d106c13aa048258201b3d6e1236891a921abf1a3f90a9fb1b2568b1096b6cd6d3eaaeb0ef0ee0802f58401ce4658303c3eb0f2b9705992ccd62de30423ade90219e2c4cfc9eb488c892ea28ba3110f0c062298447f4f6365499d97d31207075f9815c3fe530bd9a927402f5f6";
 

--- a/bindings/node/__test__/index.spec.mjs
+++ b/bindings/node/__test__/index.spec.mjs
@@ -135,11 +135,11 @@ describe('@open-wallet-standard/core', () => {
     assert.equal(wallet.accounts.length, 15, 'should have all 15 chain accounts');
 
     // Sign on EVM (provided key's curve)
-    const evmSig = signMessage('pk-secp', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const evmSig = signMessage('pk-secp', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(evmSig.signature.length > 0);
 
     // Sign on Solana (generated key's curve)
-    const solSig = signMessage('pk-secp', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const solSig = signMessage('pk-secp', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(solSig.signature.length > 0);
 
     // Export returns JSON with all keys
@@ -159,15 +159,15 @@ describe('@open-wallet-standard/core', () => {
     assert.equal(wallet.accounts.length, 15);
 
     // Sign on Solana (provided key)
-    const solSig = signMessage('pk-ed', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const solSig = signMessage('pk-ed', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(solSig.signature.length > 0);
 
     // Sign on EVM (generated key)
-    const evmSig = signMessage('pk-ed', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const evmSig = signMessage('pk-ed', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(evmSig.signature.length > 0);
 
     // Sign on TON (same ed25519 key)
-    const tonSig = signMessage('pk-ed', 'ton', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const tonSig = signMessage('pk-ed', 'ton', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(tonSig.signature.length > 0);
 
     deleteWallet('pk-ed', vaultDir);
@@ -182,19 +182,19 @@ describe('@open-wallet-standard/core', () => {
     assert.equal(wallet.accounts.length, 15);
 
     // Sign on Cardano (provided key)
-    const cardanoSig = signMessage('pk-ed-bip32', 'cardano', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const cardanoSig = signMessage('pk-ed-bip32', 'cardano', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(cardanoSig.signature.length > 0);
 
     // Sign on EVM (generated key)
-    const evmSig = signMessage('pk-ed-bip32', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const evmSig = signMessage('pk-ed-bip32', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(evmSig.signature.length > 0);
 
     // Sign on TON (same ed25519 key)
-    const tonSig = signMessage('pk-ed-bip32', 'ton', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const tonSig = signMessage('pk-ed-bip32', 'ton', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(tonSig.signature.length > 0);
 
     // Sign on Solana (generated key)
-    const solSig = signMessage('pk-ed-bip32', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const solSig = signMessage('pk-ed-bip32', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(solSig.signature.length > 0);
 
     deleteWallet('pk-ed-bip32', vaultDir);
@@ -215,15 +215,15 @@ describe('@open-wallet-standard/core', () => {
     assert.equal(wallet.accounts.length, 15, 'should have all 15 chain accounts');
 
     // Sign on EVM (secp256k1 key)
-    const evmSig = signMessage('pk-all', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const evmSig = signMessage('pk-all', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(evmSig.signature.length > 0);
 
     // Sign on Solana (ed25519 key)
-    const solSig = signMessage('pk-all', 'solana', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const solSig = signMessage('pk-all', 'solana', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(solSig.signature.length > 0);
 
     // Sign on Cardano (ed25519-bip32 key)
-    const cardanoSig = signMessage('pk-all', 'cardano', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const cardanoSig = signMessage('pk-all', 'cardano', 'hello', undefined, undefined, undefined, vaultDir);
     assert.ok(cardanoSig.signature.length > 0);
 
     // Export returns all provided keys
@@ -244,7 +244,7 @@ describe('@open-wallet-standard/core', () => {
     // support generic off-chain message signing without a defined convention.
     // NEAR's V1 sign_message is raw ed25519 over the bytes (NEP-413 is a follow-up).
     for (const chain of ['evm', 'solana', 'sui', 'bitcoin', 'cosmos', 'tron', 'ton', 'filecoin', 'near']) {
-      const result = signMessage('all-chain-signer', chain, 'test', undefined, undefined, undefined, undefined, vaultDir);
+      const result = signMessage('all-chain-signer', chain, 'test', undefined, undefined, undefined, vaultDir);
       assert.ok(result.signature.length > 0, `signature should be non-empty for ${chain}`);
     }
 
@@ -326,8 +326,8 @@ describe('@open-wallet-standard/core', () => {
   it('produces deterministic signatures', () => {
     createWallet('det-test', undefined, 12, vaultDir);
 
-    const sig1 = signMessage('det-test', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
-    const sig2 = signMessage('det-test', 'evm', 'hello', undefined, undefined, undefined, undefined, vaultDir);
+    const sig1 = signMessage('det-test', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
+    const sig2 = signMessage('det-test', 'evm', 'hello', undefined, undefined, undefined, vaultDir);
     assert.equal(sig1.signature, sig2.signature);
 
     deleteWallet('det-test', vaultDir);
@@ -343,7 +343,7 @@ describe('@open-wallet-standard/core', () => {
 
   it('rejects non-existent wallet', () => {
     assert.throws(() => getWallet('nonexistent', vaultDir));
-    assert.throws(() => signMessage('nonexistent', 'evm', 'x', undefined, undefined, undefined, undefined, vaultDir));
+    assert.throws(() => signMessage('nonexistent', 'evm', 'x', undefined, undefined, undefined, vaultDir));
   });
 
   it('rejects invalid private key hex', () => {
@@ -433,7 +433,6 @@ describe('@open-wallet-standard/core', () => {
       key.token,
       undefined,
       undefined,
-      undefined,
       vaultDir,
     );
     assert.ok(msgSig.signature.length > 0);
@@ -499,7 +498,7 @@ describe('@open-wallet-standard/core', () => {
     });
 
     // Sign on allowed chain — should succeed
-    const sig = signTypedData(wallet.id, 'base', typedDataJson, key.token, null, null, vaultDir);
+    const sig = signTypedData(wallet.id, 'base', typedDataJson, key.token, null, vaultDir);
     assert.ok(sig.signature.length > 0, 'signature should be non-empty');
     assert.ok(sig.recoveryId != null, 'recoveryId should be present for EIP-712');
 
@@ -511,7 +510,7 @@ describe('@open-wallet-standard/core', () => {
       domain: { ...JSON.parse(typedDataJson).domain, chainId: 1 },
     });
     assert.throws(
-      () => signTypedData(wallet.id, 'ethereum', ethTypedDataJson, key.token, null, null, vaultDir),
+      () => signTypedData(wallet.id, 'ethereum', ethTypedDataJson, key.token, null, vaultDir),
       (err) => err.message.includes('not in allowlist'),
     );
 
@@ -569,7 +568,6 @@ describe('@open-wallet-standard/core', () => {
       JSON.stringify(typedData),
       key.token,
       null,
-      null,
       vaultDir,
     );
     assert.ok(allowed.signature.length > 0);
@@ -583,7 +581,7 @@ describe('@open-wallet-standard/core', () => {
     };
 
     assert.throws(
-      () => signTypedData(wallet.id, 'base', JSON.stringify(deniedTypedData), key.token, null, null, vaultDir),
+      () => signTypedData(wallet.id, 'base', JSON.stringify(deniedTypedData), key.token, null, vaultDir),
       (err) => err.message.includes('not in allowed list'),
     );
 

--- a/bindings/node/package-lock.json
+++ b/bindings/node/package-lock.json
@@ -37,6 +37,58 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
+    },
+    "node_modules/@open-wallet-standard/core-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-darwin-arm64/-/core-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-rvUsGU8eZtIMYFJ047nFKS79ajJeYCydvvh2B6bX0UUGf2NJZ4wUnxGqijxPiflz2xqzvbHXYZNzy3MIO4+fDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@open-wallet-standard/core-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-darwin-x64/-/core-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-a6u3CvWZY8sC1S92AMGnO1WFlMW3m38+3/IoKzhxcFvD8rVY0OA0ebH6qzYLT96/TaouXDwmMQV6yQmb1IjfzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@open-wallet-standard/core-linux-arm64-gnu": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.2.tgz",
+      "integrity": "sha512-wzyd7euZ5qvDr8dHf3eG2XP7iFgMmBUo35U7cWMLs6Yqjqz103SEjtMfNJEedZRb62f8P3Xhp9jdRLzaJvjk5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@open-wallet-standard/core-linux-x64-gnu": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@open-wallet-standard/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.2.tgz",
+      "integrity": "sha512-pVtyEP8EqR3rjqdBDCRuB9Rd4xs8+11gRVtWidwPeFz5QPq3c9VGZjGQtTZoiZBHCxKaq5pTQjC78J5lVuA0hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     }
   }
 }

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -110,13 +110,13 @@ pub fn import_wallet_mnemonic(
 }
 
 /// Import a wallet from a hex-encoded private key.
-/// All 6 chains are supported: the provided key is used for its curve's chains,
-/// and a random key is generated for the other curve.
+/// All OWS chain families are supported (15 accounts per `create_wallet`: 13 families plus Cardano Preprod and Preview). The provided key is used for its curve's chains,
+/// and random keys are generated for the other curves (three curves: secp256k1, Ed25519, Ed25519-BIP32).
 /// The optional `chain` parameter specifies the key's source chain (e.g. "evm", "solana")
 /// to determine which curve it uses. Defaults to "evm" (secp256k1).
 ///
-/// Alternatively, provide explicit keys for each curve via `secp256k1Key` and `ed25519Key`.
-/// When both are given, `privateKeyHex` and `chain` are ignored.
+/// Alternatively, provide explicit keys for each curve via `secp256k1Key`, `ed25519Key`, and `ed25519Bip32Key`.
+/// When all are given, `privateKeyHex` and `chain` are ignored.
 #[napi]
 pub fn import_wallet_private_key(
     name: String,
@@ -126,6 +126,7 @@ pub fn import_wallet_private_key(
     chain: Option<String>,
     secp256k1_key: Option<String>,
     ed25519_key: Option<String>,
+    ed25519_bip32_key: Option<String>,
 ) -> Result<WalletInfo> {
     ows_lib::import_wallet_private_key(
         &name,
@@ -135,7 +136,7 @@ pub fn import_wallet_private_key(
         vault_path(vault_path_opt).as_deref(),
         secp256k1_key.as_deref(),
         ed25519_key.as_deref(),
-        None,
+        ed25519_bip32_key.as_deref(),
     )
     .map(WalletInfo::from)
     .map_err(map_err)

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -135,6 +135,7 @@ pub fn import_wallet_private_key(
         vault_path(vault_path_opt).as_deref(),
         secp256k1_key.as_deref(),
         ed25519_key.as_deref(),
+        None,
     )
     .map(WalletInfo::from)
     .map_err(map_err)
@@ -226,6 +227,7 @@ pub fn sign_message(
     passphrase: Option<String>,
     encoding: Option<String>,
     index: Option<u32>,
+    address: Option<String>,
     vault_path_opt: Option<String>,
 ) -> Result<SignResult> {
     ows_lib::sign_message(
@@ -235,6 +237,7 @@ pub fn sign_message(
         passphrase.as_deref(),
         encoding.as_deref(),
         index,
+        address.as_deref(),
         vault_path(vault_path_opt).as_deref(),
     )
     .map(|r| SignResult {
@@ -252,6 +255,7 @@ pub fn sign_typed_data(
     typed_data_json: String,
     passphrase: Option<String>,
     index: Option<u32>,
+    address: Option<String>,
     vault_path_opt: Option<String>,
 ) -> Result<SignResult> {
     ows_lib::sign_typed_data(
@@ -260,6 +264,7 @@ pub fn sign_typed_data(
         &typed_data_json,
         passphrase.as_deref(),
         index,
+        address.as_deref(),
         vault_path(vault_path_opt).as_deref(),
     )
     .map(|r| SignResult {

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -228,8 +228,8 @@ pub fn sign_message(
     passphrase: Option<String>,
     encoding: Option<String>,
     index: Option<u32>,
-    address: Option<String>,
     vault_path_opt: Option<String>,
+    address: Option<String>,
 ) -> Result<SignResult> {
     ows_lib::sign_message(
         &wallet,
@@ -256,8 +256,8 @@ pub fn sign_typed_data(
     typed_data_json: String,
     passphrase: Option<String>,
     index: Option<u32>,
-    address: Option<String>,
     vault_path_opt: Option<String>,
+    address: Option<String>,
 ) -> Result<SignResult> {
     ows_lib::sign_typed_data(
         &wallet,

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -35,6 +35,18 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -174,6 +186,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -185,10 +203,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-url"
+version = "1.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bech32"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
 name = "bech32"
@@ -268,6 +301,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -290,7 +329,16 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -299,7 +347,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -308,7 +356,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -331,6 +379,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cardano-serialization-lib"
+version = "14.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a894086cb078655b52a9478ae50e1f7b11f3a16fb02e2f11fe63b63644462c"
+dependencies = [
+ "bech32 0.7.3",
+ "cbor_event",
+ "cfg-if",
+ "clear_on_drop",
+ "cryptoxide 0.4.4",
+ "digest 0.9.0",
+ "ed25519-bip32",
+ "getrandom 0.2.17",
+ "hashlink",
+ "hex",
+ "itertools 0.10.5",
+ "js-sys",
+ "noop_proc_macro",
+ "num",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_os",
+ "schemars 0.8.22",
+ "serde",
+ "serde-wasm-bindgen 0.4.5",
+ "serde_json",
+ "sha2 0.9.9",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "cbor_event"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "089a0261d1bc59e54e8e11860031efd88593f0e61b921172c474f1f38c2f2d3c"
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +433,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -371,6 +465,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "coins-bip32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,11 +490,11 @@ checksum = "66c43ff7fd9ff522219058808a259e61423335767b1071d5b346de60d9219657"
 dependencies = [
  "bs58",
  "coins-core",
- "digest",
+ "digest 0.10.7",
  "hmac",
  "k256",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -398,7 +510,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -412,11 +524,11 @@ dependencies = [
  "bech32 0.9.1",
  "bs58",
  "const-hex",
- "digest",
- "generic-array",
+ "digest 0.10.7",
+ "generic-array 0.14.7",
  "ripemd",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -466,7 +578,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -478,10 +590,22 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
+
+[[package]]
+name = "cryptoxide"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42014d4c82e74bc17aaccc4bd75d3615d2b8236198de81c51bed5ddefaae6435"
+
+[[package]]
+name = "cryptoxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
 name = "ctr"
@@ -501,7 +625,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -586,11 +710,29 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecae1c064e29fcabb6c2e9939e53dc7da72ed90234ae36ebfe03a478742efbd1"
+dependencies = [
+ "generic-array 0.8.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -620,7 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -638,6 +780,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-bip32"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
+dependencies = [
+ "cryptoxide 0.4.4",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,7 +797,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -665,9 +816,9 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "pkcs8",
  "rand_core 0.6.4",
@@ -709,6 +860,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "emurgo-cardano-message-signing"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2136c6e1d3b4ef3f6ca14aef5677c7e480b3eaa38f63da30275655dbf7f866f"
+dependencies = [
+ "base64-url",
+ "byteorder",
+ "cbor_event",
+ "cryptoxide 0.3.6",
+ "hex",
+ "linked-hash-map",
+ "noop_proc_macro",
+ "pruefung",
+ "serde-wasm-bindgen 0.6.5",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -771,6 +940,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -790,6 +966,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -810,9 +992,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2297fb0e3ea512e380da24b52dca3924028f59df5e3a17a18f81d8349ca7ebe"
+dependencies = [
+ "nodrop",
+ "typenum",
 ]
 
 [[package]]
@@ -833,8 +1028,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -845,21 +1042,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -919,6 +1103,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -934,6 +1127,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heapless"
@@ -987,7 +1189,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1056,6 +1258,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1197,12 +1415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,7 +1479,22 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1287,11 +1514,10 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1305,7 +1531,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -1325,12 +1551,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1561,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "litemap"
@@ -1393,6 +1619,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,10 +1655,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -1414,6 +1686,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1455,6 +1749,7 @@ version = "1.3.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "ed25519-bip32",
  "getrandom 0.2.17",
  "hex",
  "ows-core",
@@ -1463,7 +1758,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -1491,22 +1786,27 @@ dependencies = [
  "bitcoin",
  "blake2",
  "bs58",
+ "cardano-serialization-lib",
  "coins-bip32",
  "coins-bip39",
- "digest",
+ "digest 0.10.7",
+ "ed25519-bip32",
  "ed25519-dalek",
+ "emurgo-cardano-message-signing",
  "hex",
  "hkdf",
  "hmac",
  "k256",
  "libc",
  "ows-core",
+ "pbkdf2",
  "rand 0.8.5",
+ "reqwest",
  "ripemd",
  "scrypt",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "signal-hook",
  "thiserror 2.0.18",
@@ -1531,8 +1831,9 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
+ "password-hash",
 ]
 
 [[package]]
@@ -1626,16 +1927,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,7 +1941,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -1676,10 +1967,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "pruefung"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734d1fcf58d4e4aa4118926d4d44b1ea8921e4064c30a0415ae273552ebdd784"
+dependencies = [
+ "digest 0.6.1",
+ "generic-array 0.8.4",
 ]
 
 [[package]]
@@ -1746,6 +2047,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "bytes",
+ "getrandom 0.2.17",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,12 +2112,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -1815,6 +2162,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -1841,12 +2203,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1895,6 +2281,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.11",
+ "windows-registry",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,12 +2335,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1926,6 +2370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,10 +2385,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -1947,6 +2447,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1974,6 +2486,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scrypt"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,7 +2506,7 @@ dependencies = [
  "password-hash",
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1993,7 +2517,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -2044,6 +2568,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2603,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2085,6 +2642,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2120,13 +2689,26 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2135,7 +2717,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -2171,7 +2753,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2281,6 +2863,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2448,6 +3033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +3126,7 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -2603,12 +3199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,6 +3215,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +3229,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2643,13 +3240,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2683,45 +3278,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
- "once_cell",
- "rustversion",
  "serde",
  "wasm-bindgen-macro",
- "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.115"
+name = "wasm-bindgen-backend"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
+ "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2729,47 +3304,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
- "unicode-ident",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
- "leb128fmt",
- "wasmparser",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.244.0"
+name = "webpki-roots"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
+name = "webpki-roots"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
+ "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2780,8 +3413,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -2813,12 +3446,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2917,88 +3580,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -3044,7 +3625,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "strum",
  "strum_macros",
  "thiserror-no-std",

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -3715,6 +3715,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -46,10 +46,10 @@ print(sig["signature"])
 | `delete_wallet(name_or_id, vault_path?)` | Delete a wallet |
 | `export_wallet(name_or_id, passphrase?, vault_path?)` | Export a wallet's mnemonic or keys |
 | `rename_wallet(name_or_id, new_name, vault_path?)` | Rename a wallet |
-| `sign_message(wallet, chain, message, passphrase?, encoding?, index?, vault_path?)` | Sign a message with chain-specific formatting |
+| `sign_message(wallet, chain, message, passphrase?, encoding?, index?, address?, vault_path?)` | Sign a message with chain-specific formatting |
 | `sign_hash(wallet, chain, hash_hex, passphrase?, index?, vault_path?)` | Sign a raw 32-byte hash on a secp256k1-backed chain |
 | `sign_authorization(wallet, chain, address, nonce, passphrase?, index?, vault_path?)` | Sign an EIP-7702 authorization tuple |
-| `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, vault_path?)` | Sign EIP-712 typed data (EVM only) |
+| `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, address?, vault_path?)` | Sign EIP-712 typed data (EVM only) |
 | `sign_transaction(wallet, chain, tx_hex, passphrase?, index?, vault_path?)` | Sign a raw transaction |
 | `sign_and_send(wallet, chain, tx_hex, passphrase?, index?, rpc_url?, vault_path?)` | Sign and broadcast a transaction |
 | `generate_mnemonic(words?)` | Generate a BIP-39 mnemonic phrase |

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -40,7 +40,7 @@ print(sig["signature"])
 |----------|-------------|
 | `create_wallet(name, passphrase?, words?, vault_path?)` | Create a new wallet with addresses for the current auto-derived chain set |
 | `import_wallet_mnemonic(name, mnemonic, passphrase?, index?, vault_path?)` | Import a wallet from a BIP-39 mnemonic |
-| `import_wallet_private_key(name, private_key_hex, chain?, passphrase?, vault_path?, secp256k1_key?, ed25519_key?)` | Import a wallet from a private key |
+| `import_wallet_private_key(name, private_key_hex, chain?, passphrase?, vault_path?, secp256k1_key?, ed25519_key?, ed25519_bip32_key?)` | Import a wallet from a private key |
 | `list_wallets(vault_path?)` | List all wallets in the vault |
 | `get_wallet(name_or_id, vault_path?)` | Get details of a specific wallet |
 | `delete_wallet(name_or_id, vault_path?)` | Delete a wallet |
@@ -77,6 +77,7 @@ print(sig["signature"])
 | Spark (Bitcoin L2) | secp256k1 | spark: prefixed | `m/84'/0'/0'/0/0` |
 | Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
 | NEAR | Ed25519 | implicit hex (64 chars) | `m/44'/397'/0'` |
+| Cardano | Ed25519-BIP32 (CIP-1852) | Shelley Bech32 base (`addr1…`) | Payment `m/1852'/1815'/0'/0/0` + stake `m/1852'/1815'/0'/2/0` |
 
 ## Architecture
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -46,10 +46,10 @@ print(sig["signature"])
 | `delete_wallet(name_or_id, vault_path?)` | Delete a wallet |
 | `export_wallet(name_or_id, passphrase?, vault_path?)` | Export a wallet's mnemonic or keys |
 | `rename_wallet(name_or_id, new_name, vault_path?)` | Rename a wallet |
-| `sign_message(wallet, chain, message, passphrase?, encoding?, index?, address?, vault_path?)` | Sign a message with chain-specific formatting |
+| `sign_message(wallet, chain, message, passphrase?, encoding?, index?, vault_path?, address?)` | Sign a message with chain-specific formatting |
 | `sign_hash(wallet, chain, hash_hex, passphrase?, index?, vault_path?)` | Sign a raw 32-byte hash on a secp256k1-backed chain |
 | `sign_authorization(wallet, chain, address, nonce, passphrase?, index?, vault_path?)` | Sign an EIP-7702 authorization tuple |
-| `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, address?, vault_path?)` | Sign EIP-712 typed data (EVM only) |
+| `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, vault_path?, address?)` | Sign EIP-712 typed data (EVM only) |
 | `sign_transaction(wallet, chain, tx_hex, passphrase?, index?, vault_path?)` | Sign a raw transaction |
 | `sign_and_send(wallet, chain, tx_hex, passphrase?, index?, rpc_url?, vault_path?)` | Sign and broadcast a transaction |
 | `generate_mnemonic(words?)` | Generate a BIP-39 mnemonic phrase |

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -85,6 +85,7 @@ fn import_wallet_private_key(
         vault_path(vault_path_opt).as_deref(),
         secp256k1_key,
         ed25519_key,
+        None,
     )
     .map_err(map_err)?;
     Python::with_gil(|py| wallet_info_to_dict(py, &info))
@@ -176,7 +177,7 @@ fn sign_transaction(
 
 /// Sign a message.
 #[pyfunction]
-#[pyo3(signature = (wallet, chain, message, passphrase=None, encoding=None, index=None, vault_path_opt=None))]
+#[pyo3(signature = (wallet, chain, message, passphrase=None, encoding=None, index=None, address=None, vault_path_opt=None))]
 fn sign_message(
     wallet: &str,
     chain: &str,
@@ -184,6 +185,7 @@ fn sign_message(
     passphrase: Option<&str>,
     encoding: Option<&str>,
     index: Option<u32>,
+    address: Option<&str>,
     vault_path_opt: Option<String>,
 ) -> PyResult<PyObject> {
     let result = ows_lib::sign_message(
@@ -193,6 +195,7 @@ fn sign_message(
         passphrase,
         encoding,
         index,
+        address,
         vault_path(vault_path_opt).as_deref(),
     )
     .map_err(map_err)?;
@@ -207,13 +210,14 @@ fn sign_message(
 
 /// Sign EIP-712 typed structured data (EVM only).
 #[pyfunction]
-#[pyo3(signature = (wallet, chain, typed_data_json, passphrase=None, index=None, vault_path_opt=None))]
+#[pyo3(signature = (wallet, chain, typed_data_json, passphrase=None, index=None, address=None, vault_path_opt=None))]
 fn sign_typed_data(
     wallet: &str,
     chain: &str,
     typed_data_json: &str,
     passphrase: Option<&str>,
     index: Option<u32>,
+    address: Option<&str>,
     vault_path_opt: Option<String>,
 ) -> PyResult<PyObject> {
     let result = ows_lib::sign_typed_data(
@@ -222,6 +226,7 @@ fn sign_typed_data(
         typed_data_json,
         passphrase,
         index,
+        address,
         vault_path(vault_path_opt).as_deref(),
     )
     .map_err(map_err)?;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -65,9 +65,9 @@ fn import_wallet_mnemonic(
 }
 
 /// Import a wallet from a hex-encoded private key (derives addresses for all chains).
-/// Optionally specify explicit keys per curve via `secp256k1_key` and `ed25519_key`.
+/// Optionally specify explicit keys per curve via `secp256k1_key`, `ed25519_key`, and `ed25519_bip32_key`.
 #[pyfunction]
-#[pyo3(signature = (name, private_key_hex, chain=None, passphrase=None, vault_path_opt=None, secp256k1_key=None, ed25519_key=None))]
+#[pyo3(signature = (name, private_key_hex, chain=None, passphrase=None, vault_path_opt=None, secp256k1_key=None, ed25519_key=None, ed25519_bip32_key=None))]
 fn import_wallet_private_key(
     name: &str,
     private_key_hex: &str,
@@ -76,6 +76,7 @@ fn import_wallet_private_key(
     vault_path_opt: Option<String>,
     secp256k1_key: Option<&str>,
     ed25519_key: Option<&str>,
+    ed25519_bip32_key: Option<&str>,
 ) -> PyResult<PyObject> {
     let info = ows_lib::import_wallet_private_key(
         name,
@@ -85,7 +86,7 @@ fn import_wallet_private_key(
         vault_path(vault_path_opt).as_deref(),
         secp256k1_key,
         ed25519_key,
-        None,
+        ed25519_bip32_key,
     )
     .map_err(map_err)?;
     Python::with_gil(|py| wallet_info_to_dict(py, &info))

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -178,7 +178,7 @@ fn sign_transaction(
 
 /// Sign a message.
 #[pyfunction]
-#[pyo3(signature = (wallet, chain, message, passphrase=None, encoding=None, index=None, address=None, vault_path_opt=None))]
+#[pyo3(signature = (wallet, chain, message, passphrase=None, encoding=None, index=None, vault_path_opt=None, address=None))]
 fn sign_message(
     wallet: &str,
     chain: &str,
@@ -186,8 +186,8 @@ fn sign_message(
     passphrase: Option<&str>,
     encoding: Option<&str>,
     index: Option<u32>,
-    address: Option<&str>,
     vault_path_opt: Option<String>,
+    address: Option<&str>,
 ) -> PyResult<PyObject> {
     let result = ows_lib::sign_message(
         wallet,
@@ -211,15 +211,15 @@ fn sign_message(
 
 /// Sign EIP-712 typed structured data (EVM only).
 #[pyfunction]
-#[pyo3(signature = (wallet, chain, typed_data_json, passphrase=None, index=None, address=None, vault_path_opt=None))]
+#[pyo3(signature = (wallet, chain, typed_data_json, passphrase=None, index=None, vault_path_opt=None, address=None))]
 fn sign_typed_data(
     wallet: &str,
     chain: &str,
     typed_data_json: &str,
     passphrase: Option<&str>,
     index: Option<u32>,
-    address: Option<&str>,
     vault_path_opt: Option<String>,
+    address: Option<&str>,
 ) -> PyResult<PyObject> {
     let result = ows_lib::sign_typed_data(
         wallet,

--- a/bindings/python/tests/test_bindings.py
+++ b/bindings/python/tests/test_bindings.py
@@ -40,7 +40,7 @@ def test_derive_address_ethereum():
 
 def test_derive_address_all_supported_chains():
     phrase = ows.generate_mnemonic(12)
-    for chain in ["evm", "solana", "sui", "bitcoin", "cosmos", "tron", "ton", "filecoin", "xrpl", "nano", "near"]:
+    for chain in ["evm", "solana", "sui", "bitcoin", "cosmos", "tron", "ton", "filecoin", "xrpl", "nano", "near", "cardano"]:
         address = ows.derive_address(phrase, chain)
         assert len(address) > 0
 
@@ -49,7 +49,7 @@ def test_create_and_list_wallets(vault_dir):
     wallet = ows.create_wallet("test-wallet", vault_path_opt=vault_dir)
     assert wallet["name"] == "test-wallet"
     assert isinstance(wallet["accounts"], list)
-    assert len(wallet["accounts"]) == 12
+    assert len(wallet["accounts"]) == 15
 
     # Verify each chain family is present
     chain_ids = [a["chain_id"] for a in wallet["accounts"]]
@@ -65,6 +65,7 @@ def test_create_and_list_wallets(vault_dir):
     assert any(c.startswith("xrpl:") for c in chain_ids)
     assert any(c.startswith("nano:") for c in chain_ids)
     assert any(c.startswith("near:") for c in chain_ids)
+    assert any(c.startswith("cip34:") for c in chain_ids)
 
     wallets = ows.list_wallets(vault_path_opt=vault_dir)
     assert len(wallets) == 1
@@ -111,7 +112,7 @@ def test_import_wallet_mnemonic(vault_dir):
         "imported", phrase, vault_path_opt=vault_dir
     )
     assert wallet["name"] == "imported"
-    assert len(wallet["accounts"]) == 12
+    assert len(wallet["accounts"]) == 15
 
     # EVM account should match derived address
     evm_account = next(a for a in wallet["accounts"] if a["chain_id"].startswith("eip155:"))

--- a/docs/00-specification.md
+++ b/docs/00-specification.md
@@ -10,7 +10,7 @@ This document defines how to read the rest of the `docs/` set:
 
 - `01-storage-format.md`, `02-signing-interface.md`, `03-policy-engine.md`, `06-wallet-lifecycle.md`, `07-supported-chains.md`, and `08-conformance-and-security.md` are the **normative core**.
 - `04-agent-access-layer.md` and `05-key-isolation.md` define **optional access and deployment profiles**. They describe acceptable implementation patterns, but they do not require a specific package manager, programming language, or transport.
-- `quickstart.md`, `sdk-cli.md`, `sdk-node.md`, `sdk-python.md`, and `policy-engine-implementation.md` are **non-normative reference implementation documentation**.
+- `quickstart.md`, `sdk-cli.md`, `sdk-node.md`, `sdk-python.md`, `policy-engine-implementation.md`, and `cardano.md` are **non-normative reference implementation documentation**.
 
 If there is a conflict between a normative core document and a reference implementation document, the normative core document wins.
 

--- a/docs/03-policy-engine.md
+++ b/docs/03-policy-engine.md
@@ -244,7 +244,7 @@ The base JSON object available to policy evaluation:
 | `chain_id` | string | yes | CAIP-2 chain identifier |
 | `wallet_id` | string | yes | Wallet ID in scope for this request |
 | `api_key_id` | string | yes | The ID of the API key making this request |
-| `transaction` | object | yes | Transaction context. EVM includes parsed `to`, `value`, and `data` when available. All chains include `raw_hex`. |
+| `transaction` | object | no | Present for `sign_transaction`, `sign_message`, and `sign_hash` (the latter two surface their payload through `raw_hex`). Omitted for `sign_typed_data`, which exposes its payload via `typed_data.raw_json` instead. EVM tx flows include parsed `to`, `value`, and `data` when available. |
 | `spending` | object | yes | Lightweight spending metadata currently exposed by the engine |
 | `timestamp` | string | yes | ISO 8601 timestamp of the signing request |
 

--- a/docs/03-policy-engine.md
+++ b/docs/03-policy-engine.md
@@ -222,14 +222,15 @@ The base JSON object available to policy evaluation:
 
 ```json
 {
-  "chain_id": "eip155:8453",
+  "chain_id": "cip34:1-764824073",
   "wallet_id": "3198bc9c-6672-5ab3-d995-4942343ae5b6",
   "api_key_id": "7a2f1b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c",
   "transaction": {
-    "to": "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C",
-    "value": "100000000000000000",
-    "raw_hex": "0x02f8...",
-    "data": "0x"
+    "effects": [
+      { "address": "addr1qx2f...", "diff": [["lovelace", "-4200000"]] },
+      { "address": "addr1v9zk...", "diff": [["lovelace", "3000000"]] }
+    ],
+    "raw_hex": "84a400d9010281825820..."
   },
   "spending": {
     "daily_total": "50000000000000000",
@@ -244,11 +245,26 @@ The base JSON object available to policy evaluation:
 | `chain_id` | string | yes | CAIP-2 chain identifier |
 | `wallet_id` | string | yes | Wallet ID in scope for this request |
 | `api_key_id` | string | yes | The ID of the API key making this request |
-| `transaction` | object | no | Present for `sign_transaction`, `sign_message`, and `sign_hash` (the latter two surface their payload through `raw_hex`). Omitted for `sign_typed_data`, which exposes its payload via `typed_data.raw_json` instead. EVM tx flows include parsed `to`, `value`, and `data` when available. |
+| `transaction` | object | no | The signing payload. Present for `sign_transaction`, `sign_message`, and `sign_hash`; omitted for `sign_typed_data`, which exposes its payload via `typed_data.raw_json` instead. See below. |
 | `spending` | object | yes | Lightweight spending metadata currently exposed by the engine |
 | `timestamp` | string | yes | ISO 8601 timestamp of the signing request |
 
 For executable policies, the engine injects `policy_config` into the JSON payload when the policy file includes a `config` object.
+
+### `transaction` (optional)
+
+| Field | Type | Always Present | Description |
+|---|---|---|---|
+| `effects` | array | yes | Per-address asset movement the transaction causes. Empty on chains whose signer does not implement flow analysis. |
+| `effects[].address` | string | yes | The address whose balance changes |
+| `effects[].diff` | array | yes | `[asset, amount]` pairs. `amount` is a **signed decimal string** in the asset's smallest unit, so it has no upper bound — parse it with `int()` / `BigInt()`, never as a JSON number. The reserved asset id `"lovelace"` denotes ADA; a Cardano native asset is keyed by its hex policy id concatenated with its hex asset name. |
+| `raw_hex` | string | yes | The raw unsigned payload: the transaction bytes for `sign_transaction`, the message bytes for `sign_message`, the pre-image for `sign_hash` |
+| `chain_extra` | object | no | Chain-specific detail that `effects` cannot carry. Present only when a chain populates it; see the chain's own document (Cardano puts contingent collateral loss in `chain_extra.collateral_effects`). |
+| `data` | string | no | Reserved for calldata. Not populated by any chain in the reference implementation. |
+
+Only chains whose signer overrides `make_transaction_context` fill `effects`; today that is Cardano. Everywhere else — EVM included — `effects` is empty and `raw_hex` is the whole payload, so a policy that needs parsed transaction fields has to decode `raw_hex` itself.
+
+> **Earlier versions documented `transaction.to` and `transaction.value`.** Both fields existed on the struct but were never populated by any chain, on any code path, so a policy reading them always saw `null`. They are removed in favour of `effects`; nothing that worked has stopped working.
 
 ### `typed_data` (optional)
 
@@ -320,50 +336,71 @@ ows key create --name "claude-agent" --wallet agent-treasury --policy base-agent
 
 An API key can have multiple policies attached. All attached policies are evaluated — every policy must allow the transaction for it to proceed (AND semantics). Evaluation short-circuits on the first denial.
 
-## Example: Custom Simulation Policy
+## Example: Custom Spending Cap
+
+Per-transaction value caps are not a declarative rule, so a cap is an executable policy over `transaction.effects`.
 
 ```python
 #!/usr/bin/env python3
-"""Simulate transaction via eth_call before allowing."""
-import json, sys, urllib.request
+"""Cap the ADA one transaction may move out of the wallet's own addresses."""
+import json, sys
 
 ctx = json.load(sys.stdin)
-tx = ctx["transaction"]
-rpc = {"eip155:8453": "https://mainnet.base.org"}.get(ctx["chain_id"])
-if not rpc:
-    json.dump({"allow": False, "reason": f"No RPC for {ctx['chain_id']}"}, sys.stdout)
+config = ctx.get("policy_config") or {}
+owned = set(config.get("addresses", []))
+limit = int(config.get("max_lovelace_out", "0"))
+
+tx = ctx.get("transaction")
+if tx is None:
+    # No transaction context: this is a sign_typed_data request, which this policy
+    # has nothing to say about. Denying is the safe default for a spending cap.
+    json.dump({"allow": False, "reason": "no transaction context to evaluate"}, sys.stdout)
     sys.exit(0)
 
-payload = json.dumps({
-    "jsonrpc": "2.0", "id": 1, "method": "eth_call",
-    "params": [{"to": tx["to"], "value": hex(int(tx["value"])), "data": tx["data"]}, "latest"]
-}).encode()
-try:
-    resp = json.load(urllib.request.urlopen(
-        urllib.request.Request(rpc, data=payload, headers={"Content-Type": "application/json"}), timeout=4))
-    if "error" in resp:
-        json.dump({"allow": False, "reason": f"Reverted: {resp['error']['message']}"}, sys.stdout)
-    else:
-        json.dump({"allow": True}, sys.stdout)
-except Exception as e:
-    json.dump({"allow": False, "reason": str(e)}, sys.stdout)
+def outflow(effects):
+    total = 0
+    for effect in effects:
+        if effect["address"] not in owned:
+            continue
+        for asset, amount in effect["diff"]:
+            # amount is a signed decimal string, not a number
+            if asset == "lovelace" and int(amount) < 0:
+                total -= int(amount)
+    return total
+
+spent = outflow(tx["effects"])
+# Collateral is consumed only if the transaction's scripts fail, and it never reduces
+# the change output, so effects does not account for it. Count it against the cap.
+at_risk = outflow((tx.get("chain_extra") or {}).get("collateral_effects", []))
+
+if spent + at_risk > limit:
+    json.dump({"allow": False,
+               "reason": f"{spent + at_risk} lovelace out, cap is {limit}"}, sys.stdout)
+else:
+    json.dump({"allow": True}, sys.stdout)
 ```
 
 The corresponding policy file:
 
 ```json
 {
-  "id": "simulate-tx",
-  "name": "EVM Transaction Simulation",
+  "id": "ada-spend-cap",
+  "name": "Max 5 ADA out per transaction",
   "version": 1,
   "created_at": "2026-03-22T10:00:00Z",
   "rules": [
-    { "type": "allowed_chains", "chain_ids": ["eip155:8453"] }
+    { "type": "allowed_chains", "chain_ids": ["cip34:1-764824073"] }
   ],
-  "executable": "/home/user/.ows/plugins/policies/simulate.py",
+  "executable": "/home/user/.ows/plugins/policies/ada-spend-cap.py",
+  "config": {
+    "addresses": ["addr1qx2f..."],
+    "max_lovelace_out": "5000000"
+  },
   "action": "deny"
 }
 ```
+
+On a chain whose signer does not fill `effects`, the same policy has to decode `transaction.raw_hex` itself before it can decide anything about value.
 
 ## References
 

--- a/docs/03-policy-engine.md
+++ b/docs/03-policy-engine.md
@@ -225,6 +225,7 @@ The base JSON object available to policy evaluation:
   "chain_id": "cip34:1-764824073",
   "wallet_id": "3198bc9c-6672-5ab3-d995-4942343ae5b6",
   "api_key_id": "7a2f1b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c",
+  "request_type": "sign_transaction",
   "transaction": {
     "effects": [
       { "address": "addr1qx2f...", "diff": [["lovelace", "-4200000"]] },
@@ -245,6 +246,7 @@ The base JSON object available to policy evaluation:
 | `chain_id` | string | yes | CAIP-2 chain identifier |
 | `wallet_id` | string | yes | Wallet ID in scope for this request |
 | `api_key_id` | string | yes | The ID of the API key making this request |
+| `request_type` | string | yes | Which operation is being authorized: `sign_transaction`, `sign_message`, `sign_hash`, or `sign_typed_data`. **Branch on this**, not on which optional fields are populated. |
 | `transaction` | object | no | The signing payload. Present for `sign_transaction`, `sign_message`, and `sign_hash`; omitted for `sign_typed_data`, which exposes its payload via `typed_data.raw_json` instead. See below. |
 | `spending` | object | yes | Lightweight spending metadata currently exposed by the engine |
 | `timestamp` | string | yes | ISO 8601 timestamp of the signing request |
@@ -265,6 +267,28 @@ For executable policies, the engine injects `policy_config` into the JSON payloa
 Only chains whose signer overrides `make_transaction_context` fill `effects`; today that is Cardano. Everywhere else — EVM included — `effects` is empty and `raw_hex` is the whole payload, so a policy that needs parsed transaction fields has to decode `raw_hex` itself.
 
 > **Earlier versions documented `transaction.to` and `transaction.value`.** Both fields existed on the struct but were never populated by any chain, on any code path, so a policy reading them always saw `null`. They are removed in favour of `effects`; nothing that worked has stopped working.
+
+### Migrating a policy that detects typed data
+
+`transaction` used to be present on every request, with `raw_hex` set to `""` for `sign_typed_data`. It is now omitted for that operation, and **the direction in which an existing policy breaks depends on how it was written**:
+
+| Policy style | Before | After |
+|---|---|---|
+| `payload["transaction"]["raw_hex"] == ""` | deny | `KeyError`, non-zero exit, **deny** |
+| `payload.get("transaction", {}).get("raw_hex", "")` | deny | deny |
+| `tx = payload.get("transaction") or {}` | deny | `None == ""` is False, **allow** |
+| `const tx = ctx.transaction \|\| {}` | deny | `undefined === ""` is False, **allow** |
+
+The defensively written script is the one that fails **open**. It does not raise, so the engine has nothing to catch, and a policy that blocks typed data signing today silently stops blocking it — with no error and no log entry.
+
+Check `request_type` instead. It is always present, it names the operation directly, and a policy that reads it cannot be fooled by an optional field's absence:
+
+```python
+if ctx["request_type"] == "sign_typed_data":
+    json.dump({"allow": False, "reason": "typed data signing is not permitted"}, sys.stdout)
+```
+
+Rust consumers are unaffected: the type change breaks at compile time.
 
 ### `typed_data` (optional)
 
@@ -350,12 +374,12 @@ config = ctx.get("policy_config") or {}
 owned = set(config.get("addresses", []))
 limit = int(config.get("max_lovelace_out", "0"))
 
-tx = ctx.get("transaction")
-if tx is None:
-    # No transaction context: this is a sign_typed_data request, which this policy
-    # has nothing to say about. Denying is the safe default for a spending cap.
-    json.dump({"allow": False, "reason": "no transaction context to evaluate"}, sys.stdout)
+if ctx["request_type"] == "sign_typed_data":
+    # Typed data carries no transaction context, so a spending cap cannot bound it.
+    json.dump({"allow": False, "reason": "typed data signing is not permitted"}, sys.stdout)
     sys.exit(0)
+
+tx = ctx["transaction"]
 
 def outflow(effects):
     total = 0

--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -40,7 +40,7 @@ OWS groups chains into families that share a cryptographic curve and address der
 | Spark | secp256k1 | 8797555 | `m/84'/0'/0'/0/{index}` | `spark:` + compressed pubkey hex | `spark` |
 | Filecoin | secp256k1 | 461 | `m/44'/461'/0'/0/{index}` | `f1` + base32(blake2b-160) | `fil` |
 | NEAR | ed25519 | 397 | `m/44'/397'/{index}'` | 64-char lowercase hex of pubkey (implicit account) | `near` |
-| Cardano | Ed25519-BIP32 (CIP-1852) | 1815 | Payment `m/1852'/1815'/{index}'/0/0` + stake `m/1852'/1815'/0'/2/0` | Shelley Bech32 base (`addr1…` mainnet; `addr_test1…` testnets) | `cip34` |
+| Cardano | Ed25519-BIP32 (CIP-1852) | 1815 | Payment `m/1852'/1815'/{index}'/0/0` + stake `m/1852'/1815'/{index}'/2/0` | Shelley Bech32 base (`addr1…` mainnet; `addr_test1…` testnets) | `cip34` |
 
 
 ## Known Networks

--- a/docs/07-supported-chains.md
+++ b/docs/07-supported-chains.md
@@ -21,7 +21,7 @@ type AssetId = `${ChainId}:${string}`;
 // e.g. "eip155:8453:native" (ETH on Base)
 ```
 
-The `native` token refers to the chain's native currency (ETH, SOL, SUI, XRP, BTC, ATOM, TRX, TON, etc.).
+The `native` token refers to the chain's native currency (ETH, SOL, SUI, XRP, BTC, ATOM, TRX, TON, ADA, etc.).
 
 ## Chain Families
 
@@ -40,6 +40,8 @@ OWS groups chains into families that share a cryptographic curve and address der
 | Spark | secp256k1 | 8797555 | `m/84'/0'/0'/0/{index}` | `spark:` + compressed pubkey hex | `spark` |
 | Filecoin | secp256k1 | 461 | `m/44'/461'/0'/0/{index}` | `f1` + base32(blake2b-160) | `fil` |
 | NEAR | ed25519 | 397 | `m/44'/397'/{index}'` | 64-char lowercase hex of pubkey (implicit account) | `near` |
+| Cardano | Ed25519-BIP32 (CIP-1852) | 1815 | Payment `m/1852'/1815'/{index}'/0/0` + stake `m/1852'/1815'/0'/2/0` | Shelley Bech32 base (`addr1…` mainnet; `addr_test1…` testnets) | `cip34` |
+
 
 ## Known Networks
 
@@ -76,6 +78,9 @@ Each network has a canonical chain identifier. Endpoint discovery and transport 
 | Filecoin | `fil:mainnet` |
 | NEAR | `near:mainnet` |
 | NEAR (testnet) | `near:testnet` |
+| Cardano (mainnet) | `cip34:1-764824073` |
+| Cardano Pre-production | `cip34:0-1` |
+| Cardano Preview | `cip34:0-2` |
 
 Implementations MAY ship convenience endpoint defaults, but those defaults are deployment choices rather than OWS interoperability requirements.
 
@@ -109,6 +114,9 @@ spark     → spark:mainnet
 filecoin  → fil:mainnet
 near          → near:mainnet
 near-testnet  → near:testnet
+cardano          → cip34:1-764824073
+cardano-preprod  → cip34:0-1
+cardano-preview  → cip34:0-2
 ```
 
 Aliases MUST be resolved to full CAIP-2 identifiers before any processing. They MUST NOT appear in wallet files, policy files, or audit logs.
@@ -133,7 +141,8 @@ Master Seed (512 bits via PBKDF2)
     ├── m/44'/144'/0'/0/0   → XRPL Account 0
     ├── m/84'/0'/0'/0/0     → Spark Account 0
     ├── m/44'/461'/0'/0/0   → Filecoin Account 0
-    └── m/44'/397'/0'       → NEAR Account 0
+    ├── m/44'/397'/0'       → NEAR Account 0
+    └── m/1852'/1815'/0'/0/0 → Cardano payment key 0 (base address combines stake key `m/1852'/1815'/0'/2/0`)
 ```
 
 For mnemonic-based wallets, a single mnemonic derives accounts across all supported chains. Those wallet files store the encrypted mnemonic, and the signer derives the appropriate private key using each chain's coin type and derivation path. Wallets imported from raw private keys instead store encrypted curve-key material directly.

--- a/docs/cardano.md
+++ b/docs/cardano.md
@@ -1,0 +1,1072 @@
+# Cardano Support — Technical Specification
+
+> Status: work in progress. This document specifies the Cardano integration parts
+> that are **implemented** in this fork, and flags the parts that are still
+> **planned**. The implemented surface is:
+>
+> 1. **Analysis, architecture, and setup** — codebase familiarization, build/test
+>    pipeline, and a map of where Cardano fits into the existing abstractions (see
+>    [Analysis, Architecture, and Setup](#analysis-architecture-and-setup)).
+> 2. **CAIP-2 / CAIP-10 addressing abstraction**
+> 3. **Key derivation and cryptography — Ed25519-BIP32**
+> 4. **Implementing the chain plugin interface** — Shelley address encoding
+>    (base/enterprise/reward), CIP-8 (COSE) message signing, and transaction
+>    signing/witness encoding, all via `cardano-serialization-lib` and its
+>    `cardano-message-signing` companion (see
+>    [Transaction and Message Signing](#3-transaction-and-message-signing-chain-plugin-interface)).
+> 5. **Policy engine support** — parsing an unsigned Cardano transaction (CBOR) into
+>    the chain-agnostic `TransactionContext` that the OWS Policy Engine evaluates,
+>    resolving input UTxO values via the configured Koios RPC provider so that ADA
+>    and native-asset flows can be computed per address (see
+>    [Policy Engine Support](#4-policy-engine-support)).
+> 6. **Address balance fetching** — ADA and native-asset balances for a Cardano
+>    address, fetched from Koios (see
+>    [Address balance fetching](#5-address-balance-fetching)).
+> 7. **Documentation and bindings** — this document, plus the optional `address`
+>    argument exposed through the CLI and the Node/Python bindings (see
+>    [§3.6](#36-address-aware-sign_message-across-all-chains)).
+>
+> Transaction *building* (input selection, fee/change calculation) remains out of
+> scope and is tracked separately; the signer operates on an already-assembled
+> unsigned transaction (CBOR).
+
+## Abstract
+
+This specification adds Cardano mainnet support to the Open Wallet Standard (OWS)
+reference implementation while preserving OWS's chain-agnostic, local-first design.
+It introduces the `cip34` CAIP-2 namespace and registers Cardano mainnet, preprod,
+and preview networks with canonical chain identifiers, a coin type, and default
+(keyless) Koios RPC endpoints. On the cryptographic side, it adds a new
+`Ed25519Bip32` curve (Ed25519-V2 / BIP32-Ed25519) implemented generically via the
+`ed25519-bip32` crate, together with the Cardano Icarus master-key scheme and
+CIP-1852 hierarchical derivation. Cardano accounts are derived from two credentials
+— a payment credential (`role = 0`) and a stake credential (`role = 2`) — which
+diverges from OWS's prior assumption that one account maps to a single derivation
+path; the key-storage and derivation layers were extended to carry the two
+96-byte extended private keys required to assemble a Shelley base address. On top
+of this foundation, the chain plugin interface (`ChainSigner`) is fully
+implemented: Shelley **base**, **enterprise**, and **reward** address encoding;
+raw Ed25519 signing; CIP-8 message signing (COSE `COSE_Sign1` structures); and
+transaction signing that produces and CBOR-encodes the `Vkeywitness`es required to
+make a transaction submittable. Address encoding, transaction (de)serialization,
+and witness construction use `cardano-serialization-lib` (CSL), while the COSE
+message structures use Emurgo's `cardano-message-signing` companion library.
+Finally, it wires Cardano into the OWS Policy Engine: `make_transaction_context`
+parses an unsigned transaction (CBOR) and, because UTxO inputs carry no value,
+resolves them through the configured Koios RPC provider to compute per-address ADA
+and native-asset flows (`TransactionEffect`s) that built-in and executable policies
+can evaluate before a key is used.
+
+## Motivation
+
+OWS already supports Ed25519 chains (Solana, TON, NEAR) using SLIP-10 derivation,
+and secp256k1 chains using BIP-32. Cardano cannot reuse either path:
+
+- **Curve / derivation scheme.** Cardano uses BIP32-Ed25519 ("Ed25519-V2"),
+  which extends a 64-byte Ed25519 extended secret key with a 32-byte chain code
+  (96 bytes total) and supports both hardened and **non-hardened** child
+  derivation. SLIP-10 ed25519 (used by Solana et al.) is hardened-only and is not
+  compatible with Cardano wallets.
+- **Master key generation.** Cardano (Icarus) derives the root key from the raw
+  BIP-39 **entropy** via PBKDF2-HMAC-SHA512, not from the BIP-39 _seed_ used by
+  BIP-32 / SLIP-10.
+- **Multi-credential addresses.** A Cardano Shelley address is built from two
+  independent credentials at two different CIP-1852 derivation paths (payment and
+  stake). OWS previously assumed a single derivation path produces a single
+  address.
+- **Identifier namespace.** Cardano is not an EVM/`eip155`, `solana`, `cosmos`,
+  etc. chain; it needs its own CAIP-2 namespace and a deterministic chain
+  identifier.
+
+The existing abstractions (`Curve`, `HdDeriver`, `ChainType`, `Chain`,
+`ChainSigner`) therefore had to be extended rather than reused as-is.
+
+## Analysis, Architecture, and Setup
+
+### Cryptographic stack
+
+OWS already ships a broad cryptographic toolkit in `ows-signer`. The relevant
+existing primitives and the libraries that provide them:
+
+| Concern                       | Library (crate)                          | Used by / notes                                   |
+| ----------------------------- | ---------------------------------------- | ------------------------------------------------- |
+| secp256k1 ECDSA               | `k256`                                   | EVM, Bitcoin, Cosmos, Tron, XRPL, Spark, Filecoin |
+| BIP-32 derivation (secp256k1) | `coins-bip32`                            | all secp256k1 families                            |
+| Ed25519 signatures            | `ed25519-dalek`                          | Solana, TON, Sui, NEAR                            |
+| SLIP-10 ed25519 derivation    | in-house (HMAC-SHA512 over `hmac`/`sha2`)| hardened-only ed25519 families                    |
+| BIP-39 mnemonics              | `coins-bip39`                            | seed + entropy extraction                         |
+| Hashing                       | `sha2`, `sha3`, `ripemd`, `blake2`       | address + tx hashing across families              |
+| Address encodings             | `bech32`, `bs58` (+check), `base64`      | segwit/bech32, base58check, etc.                  |
+| At-rest encryption            | `aes-gcm` + `scrypt`/`hkdf` (`CryptoEnvelope`) | encrypted wallet files                      |
+| Secret hygiene                | `zeroize` (`SecretBytes`)                | all key material is zeroized on drop              |
+
+Cardano introduces two additional, Cardano-specific dependencies:
+
+- **`ed25519-bip32` (0.4.1)** — BIP32-Ed25519 ("Ed25519-V2") key derivation:
+  96-byte extended private keys (`XPRV_SIZE`), `DerivationScheme::V2`, hardened
+  **and** non-hardened children, and `normalize_bytes_force3rd` for valid root
+  keys. Chosen so derivation stays in the generic `HdDeriver`, rather than pulling
+  a full chain SDK into the key path.
+- **`cardano-serialization-lib` (CSL, 14.1.1)** — the canonical Cardano library
+  for network parameters (`NetworkInfo`), address construction
+  (`BaseAddress`/`EnterpriseAddress`/`RewardAddress`, `Credential`), extended-key
+  helpers (`Bip32PrivateKey`), and CBOR transaction (de)serialization
+  (`FixedTransaction`, `make_vkey_witness`, `Vkeywitness`). It is used for network
+  parameters, Shelley address encoding, and transaction signing/witness encoding.
+  Note CSL also pulls in `pbkdf2`, which we use directly for the Icarus master-key
+  step.
+- **`emurgo-cardano-message-signing` (1.1.0)** — Emurgo's COSE companion to CSL,
+  used exclusively for CIP-8 message signing. It provides the `COSESign1Builder`,
+  `HeaderMap`/`Headers`/`ProtectedHeaderMap`/`Label`, `AlgorithmId::EdDSA`, and
+  `SignedMessage`/CBOR helpers needed to build and serialize the COSE `Sig_structure`
+  and `COSE_Sign1` payload that Cardano wallets expect.
+
+### Peculiarities of Cardano vs. other OWS chains
+
+Several ways Cardano departs from chains already supported in OWS, each of which
+drove a specific design decision later in this document:
+
+1. **Extended-key derivation (96 bytes, V2).** Unlike SLIP-10 ed25519
+   (32-byte keys, hardened-only) or BIP-32 secp256k1, Cardano uses BIP32-Ed25519
+   with 64-byte extended secret keys + a 32-byte chain code, and allows
+   **non-hardened** derivation. This is a new `Curve`, not a tweak to an existing
+   one.
+2. **Master key from entropy, not seed.** Most chains derive from the BIP-39
+   *seed* (PBKDF2 over the mnemonic phrase). Cardano's Icarus scheme derives the
+   root key from the raw BIP-39 **entropy** (PBKDF2-HMAC-SHA512, empty password,
+   entropy as salt, 4096 iterations). Reusing the seed would yield addresses no
+   other Cardano wallet could reproduce.
+3. **Two credentials per address.** A Shelley **base** address combines a payment
+   credential (CIP-1852 `role = 0`) and a stake credential (`role = 2`), each at
+   its own derivation path. OWS's "one path → one address" assumption does not
+   hold; the key-storage layer carries 192 bytes (payment ‖ stake).
+4. **CIP-1852 purpose, not BIP-44.** Cardano uses purpose `1852'` (not `44'`)
+   with coin type `1815'`, and a `role` segment between account and index.
+5. **CAIP-2 via CIP-34.** The chain identifier encodes both a network id and a
+   network magic (`cip34:<networkId>-<networkMagic>`), rather than a single
+   numeric/string reference.
+6. **CBOR transactions + keyless RPC.** Transactions are CBOR (parsed and
+   witness-encoded by CSL's `FixedTransaction`); the default RPC provider is
+   keyless Koios, with submission via a binary `POST /submittx`.
+7. **COSE message signing (CIP-8).** Unlike most OWS chains, which sign a hashed
+   or prefixed byte string, Cardano message signing follows CIP-8: the message is
+   wrapped in a COSE `COSE_Sign1` structure whose protected headers carry the
+   signing address, and the signature is over the COSE `Sig_structure`, not the
+   raw message.
+
+General specifications worth reading alongside this section:
+[CIP-1852](https://cips.cardano.org/cip/CIP-1852),
+[CIP-3 (Icarus master key)](https://cips.cardano.org/cip/CIP-3),
+[CIP-19 (addresses)](https://cips.cardano.org/cip/CIP-19),
+[CIP-34 (chain identification)](https://cips.cardano.org/cip/CIP-34),
+the [BIP32-Ed25519 paper](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf),
+and the in-repo [`docs/07-supported-chains.md`](07-supported-chains.md).
+
+## Specification
+
+### 1. CAIP-2 / CAIP-10 addressing
+
+#### 1.1 Namespace and chain identifiers
+
+Cardano is identified with the **`cip34`** CAIP-2 namespace, following
+[CIP-34](https://cips.cardano.org/cip/CIP-34). The CIP-34 reference encodes the
+network as `<networkId>-<networkMagic>`:
+
+| Network | OWS name          | CAIP-2 chain id     | networkId | networkMagic |
+| ------- | ----------------- | ------------------- | --------- | ------------ |
+| Mainnet | `cardano`         | `cip34:1-764824073` | 1         | 764824073    |
+| Preprod | `cardano-preprod` | `cip34:0-1`         | 0         | 1            |
+| Preview | `cardano-preview` | `cip34:0-2`         | 0         | 2            |
+
+A new `ChainType::Cardano` variant is added to the chain-family enum
+(`ows/crates/ows-core/src/chain.rs`). The namespace mapping is wired in both directions:
+
+- `ChainType::Cardano.namespace()` → `"cip34"`
+- `ChainType::from_namespace("cip34")` → `Some(ChainType::Cardano)`
+- `ChainType::Cardano.default_coin_type()` → `1815` (SLIP-44 coin type for ADA)
+
+The three networks above are registered in `KNOWN_CHAINS`, so `parse_chain`
+resolves both friendly names (`cardano`, `cardano-preprod`, `cardano-preview`) and
+raw CAIP-2 ids (`cip34:1-764824073`, `cip34:0-1`, `cip34:0-2`). `cardano` is the
+first Cardano entry in the registry, so it is the default for the family
+(`default_chain_for_type(ChainType::Cardano)` → mainnet).
+
+#### 1.2 CAIP-10 accounts
+
+CAIP-10 account identifiers follow the existing OWS convention
+`chain_id:address`, e.g.
+
+```
+cip34:1-764824073:addr1...
+```
+
+The account id is assembled in `derive_all_accounts` as
+`format!("{}:{}", chain.chain_id, address)`, identical to every other family.
+
+#### 1.3 Universal wallet membership
+
+`ChainType::Cardano` is appended to `ALL_CHAIN_TYPES`. Because a
+universal wallet derives one account per family plus the explicitly listed
+testnet extras, Cardano contributes three rows:
+
+- `UNIVERSAL_WALLET_EXTRA_CHAIN_NAMES = ["cardano-preprod", "cardano-preview"]`
+- `universal_wallet_chains()` therefore yields mainnet (via the family default)
+  plus the two testnets, in a stable order.
+
+#### 1.4 RPC configuration (Koios, keyless)
+
+OWS does not currently support authenticated RPC providers, so the default
+provider is **Koios**, which offers a keyless free tier. Default endpoints are
+registered in `Config::default_rpc()`:
+
+| Chain id            | Default RPC                         |
+| ------------------- | ----------------------------------- |
+| `cip34:1-764824073` | `https://api.koios.rest/api/v1`     |
+| `cip34:0-1`         | `https://preprod.koios.rest/api/v1` |
+| `cip34:0-2`         | `https://preview.koios.rest/api/v1` |
+
+RPC resolution reuses the generic precedence already in place: explicit override
+→ user config exact `chain_id` → user config namespace match → built-in default.
+
+#### 1.5 Signer resolution
+
+`signer_for_chain` constructs `CardanoSigner::from_chain_id(chain.chain_id)`, which
+selects network parameters from the CAIP-2 id (`cip34:0-1` → preprod, `cip34:0-2`
+→ preview, anything else → mainnet). Network parameters come from
+`cardano-serialization-lib`'s `NetworkInfo`.
+
+### 2. Key derivation and cryptography
+
+#### 2.1 New curve
+
+A third `Curve` variant, `Ed25519Bip32`, is added (`ows/crates/ows-signer/src/curve.rs`):
+
+- `private_key_len()` → `ed25519_bip32::XPRV_SIZE` (96 bytes: 64-byte extended
+  secret key + 32-byte chain code)
+- `public_key_len()` → 32 bytes
+
+#### 2.2 Master key generation (Icarus)
+
+For `Curve::Ed25519Bip32`, `HdDeriver::derive_from_mnemonic` does **not** use the
+BIP-39 seed. Instead it follows the Cardano Icarus scheme
+(`ed25519_bip32_master_xprv_from_entropy`):
+
+1. Extract the raw BIP-39 **entropy** (checksum bits excluded) from the mnemonic.
+   `Mnemonic::entropy()` was added for this purpose.
+2. `PBKDF2-HMAC-SHA512` with an **empty password**, the entropy as the **salt**,
+   `4096` iterations, producing a 96-byte output. The password slot is left empty
+   on purpose: Cardano software wallets (Eternl, Yoroi, …) pass no
+   spending password into this step, so filling it — for example with the BIP-39
+   passphrase — would derive a different root key and produce addresses no other
+   Cardano wallet could reproduce from the same mnemonic.
+3. Normalize the result with `XPrv::normalize_bytes_force3rd` to obtain a valid
+   master extended private key.
+
+This is verified against published Icarus test vectors (including the all-zero
+"abandon … about" mnemonic).
+
+#### 2.3 Child derivation
+
+`HdDeriver::derive` accepts a 96-byte master `XPrv` for `Ed25519Bip32`
+(seed-length validation requires exactly `XPRV_SIZE`; the 16–64 byte rule that
+applies to secp256k1/ed25519 is bypassed). Path components are walked with the
+`ed25519-bip32` crate using **`DerivationScheme::V2`**, supporting both hardened
+(`'`) and non-hardened indices. The result is the 96-byte child `XPrv`.
+
+All curves share a single path parser (`parse_path_components`), so
+`validate_path` and every per-curve derivation branch agree on what a path means:
+each component is `<index>` or `<index>'`, and the bare index must be **below
+2³¹** (`0x80000000`). The bound matters most for Cardano, the only curve that also
+accepts non-hardened components: without it `m/2147483648` and `m/0'` would derive
+the same child index and be two spellings of one path. On the hardened-only
+SLIP-10 branch the same parser additionally rejects any non-hardened component
+(`Ed25519NonHardened`).
+
+The deriver continues to expose the same surface for all curves:
+`derive`, `derive_from_mnemonic`, and the cached `derive_from_mnemonic_cached`
+(the cache key incorporates the `ed25519_bip32` curve tag so it cannot collide
+with secp256k1/ed25519 keys for the same path).
+
+#### 2.4 CIP-1852 paths
+
+`CardanoSigner` exposes the CIP-1852 hierarchy
+`m / 1852' / 1815' / account' / role / index`, where `role` is
+`0` = external/payment, `1` = internal/change, `2` = stake:
+
+| Helper                            | Path                          |
+| --------------------------------- | ----------------------------- |
+| `payment_derivation_path(index)`  | `m/1852'/1815'/{index}'/0/0`  |
+| `stake_derivation_path(index)`    | `m/1852'/1815'/{index}'/2/0`  |
+
+Per the agreed scope, only **one base address per account at address index 0** is
+supported initially, so the generic `index` that OWS threads through derivation is
+used as the CIP-1852 **account** index and the address index stays `0`.
+`default_derivation_path(index)` returns the payment leaf
+(`m/1852'/1815'/{index}'/0/0`). Generic single-path key resolution no
+longer derives this leaf directly; instead generic call sites use
+`default_derivation_paths` and `encode_keys` (see
+[§3.5](#35-key-material-abstraction-default_derivation_paths-and-encode_keys)),
+which for Cardano materialize both the payment leaf and the stake key
+(`m/1852'/1815'/{index}'/2/0`) as a single 192-byte buffer.
+
+#### 2.5 `ChainSigner` integration
+
+`CardanoSigner` implements `ChainSigner`:
+
+- `chain_type()` → `ChainType::Cardano`
+- `curve()` → `Curve::Ed25519Bip32`
+- `coin_type()` → `1815`
+- `default_derivation_path(index)` → payment leaf (see above)
+
+`derive_address`, `sign`, `sign_message`, `sign_transaction`, and
+`encode_signed_transaction` are now fully implemented; mnemonic key resolution uses
+`default_derivation_paths` and `encode_keys` (see [§3.5](#35-key-material-abstraction-default_derivation_paths-and-encode_keys));
+they are specified in [§3](#3-transaction-and-message-signing-chain-plugin-interface).
+The key material these methods consume is a 192-byte buffer = payment `XPrv` (96) ‖
+stake `XPrv` (96) at matching CIP-1852 indices (or a bare 96-byte payment `XPrv`,
+which yields an enterprise address with no staking component).
+
+#### 2.6 Multi-credential key storage
+
+Because a Cardano account needs two credentials, the multi-curve key material was
+extended (`ows/crates/ows-lib/src/ops.rs`):
+
+- The `KeyPair` struct (used for raw-private-key imports) gains an
+  `ed25519_bip32` field, serialized as
+  `{"secp256k1":"…","ed25519":"…","ed25519_bip32":"…"}`. The `KeyType::PrivateKey`
+  doc comment in `wallet_file.rs` is updated accordingly. The wallet-file schema
+  version (`ows_version`) is unchanged at `2`; the new field is additive.
+- For imported private-key wallets, `random_ed25519_bip32()` generates **two**
+  normalized 96-byte `XPrv`s (payment ‖ stake = 192 bytes) so the layout matches
+  the base-address encoding.
+- `KeyPair::key_for_curve(Curve::Ed25519Bip32)` returns this material; empty
+  material yields a clear "private key for chain is empty" error for wallets
+  imported before Cardano support existed.
+- An explicitly supplied `ed25519_bip32` key is validated at import time
+  (`validate_ed25519_bip32_key` in `import_wallet_private_key`): the blob must be
+  exactly 96 or 192 bytes, and each 96-byte half must pass
+  `XPrv::from_slice_verified`, i.e. satisfy the Ed25519-BIP32 scalar clamping
+  rules. A malformed key is rejected with an `InvalidInput` error naming the
+  offending half (`payment` / `stake`) instead of being stored and failing later
+  at signing time.
+- Mnemonic wallets reach the same 192-byte layout through `default_derivation_paths`
+  and `encode_keys` (see
+  [§3.5](#35-key-material-abstraction-default_derivation_paths-and-encode_keys)) rather than through
+  `KeyPair`, so both wallet kinds present an identical payment ‖ stake buffer to the
+  signer.
+
+#### 2.7 Broadcast plumbing
+
+`broadcast` dispatches `ChainType::Cardano` to `broadcast_cardano`, which POSTs the
+raw CBOR transaction to Koios `{rpc}/submittx` (`Content-Type: application/cbor`),
+expects HTTP `202`, and returns the 64-hex-character transaction hash. The fully
+signed CBOR produced by `encode_signed_transaction` (see [§3.4](#34-transaction-signing)) is
+what feeds this path.
+
+### 3. Transaction and message signing (Chain Plugin Interface)
+
+This deliverable implements the `ChainSigner` plugin surface for Cardano:
+address encoding, raw signing, CIP-8 message signing, and transaction
+signing/witness encoding. Address construction, transaction (de)serialization, and
+witness encoding use `cardano-serialization-lib` (CSL); COSE message structures use
+Emurgo's `cardano-message-signing` companion crate.
+
+All signer methods accept the **key material** layout described in
+[§2.5](#25-chainsigner-integration): either a 192-byte payment `XPrv` ‖ stake
+`XPrv`, or a bare 96-byte payment `XPrv`. Two small private helpers slice this
+buffer:
+
+- `payment_bip32(key_material)` → payment `Bip32PrivateKey` (accepts 96 or 192
+  bytes; anything else is a clear `InvalidPrivateKey` error).
+- `stake_bip32(key_material)` → `Some(stake)` when 192 bytes are supplied, `None`
+  for the 96-byte payment-only case.
+
+#### 3.1 Shelley address encoding
+
+`derive_address` chooses the address kind from whether a stake key is present:
+
+| Key material            | Address kind | Helper                          | Example prefix |
+| ----------------------- | ------------ | ------------------------------- | -------------- |
+| payment ‖ stake (192 B) | base         | `base_address_bech32`           | `addr1q…`      |
+| payment only (96 B)     | enterprise   | `enterprise_address_bech32`     | `addr1v…`      |
+| stake only (signing)    | reward       | `reward_address_bech32`         | `stake1…`      |
+
+Each helper hashes the relevant public key (`to_public().to_raw_key().hash()`),
+wraps it in a `Credential::from_keyhash`, builds the matching CSL address type
+(`BaseAddress` / `EnterpriseAddress` / `RewardAddress`) bound to the signer's
+`network_id`, and bech32-encodes it. The reward address is not produced by
+`derive_address` directly; it is used during message signing when a stake/reward
+address is the requested signer.
+
+#### 3.2 Raw signing (`sign`)
+
+`sign` produces a bare 64-byte Ed25519 signature over the supplied bytes using the
+**payment** key, returning the signature plus the payment public key. It performs
+no hashing or prefixing (the caller decides what to sign) and is the low-level
+primitive used by transaction witnessing.
+
+#### 3.3 CIP-8 message signing (`sign_message`)
+
+`sign_message` follows [CIP-8](https://cips.cardano.org/cip/CIP-8): the message is
+embedded in a COSE `COSE_Sign1` structure and the signature is computed over the
+COSE `Sig_structure`, not the raw message. The flow:
+
+1. **Select the signing credential from the optional `address`.** The address (a
+   bech32 string) determines which key signs and is embedded in the protected
+   headers:
+   - `Reward` (`stake1…`) → sign with the **stake** key; requires 192-byte
+     material, else `InvalidPrivateKey`.
+   - `Base` (`addr1q…`) → sign with the **payment** key; also requires the stake
+     key so the base address can be reconstructed and verified.
+   - `Enterprise` (`addr1v…`) → sign with the **payment** key.
+   - Any other address kind → `AddressMismatch`.
+   In each case the signer **re-derives** the address from the key material and
+   compares it to the requested one, returning `AddressMismatch` on any
+   discrepancy. This guarantees the embedded `address` header is one the key
+   actually controls.
+2. **No `address` supplied** → sign with the payment key and embed the address
+   derived from the key material (base if a stake key is present, else
+   enterprise).
+3. **Build the COSE structure.** A `HeaderMap` of protected headers is populated
+   with `AlgorithmId::EdDSA` and an `"address"` label whose value is the **raw
+   address bytes** (CBOR byte string). A `COSESign1Builder` is constructed over
+   these headers and the message payload; `make_data_to_sign()` yields the
+   `Sig_structure`, which is signed with the selected raw Ed25519 key.
+4. **Serialize.** The signature is folded back into the builder, wrapped as a
+   `SignedMessage::new_cose_sign1`, and serialized to CBOR. `SignOutput.signature`
+   is the serialized `COSE_Sign1`; `public_key` is the signing key's public key
+   wrapped in a serialized **`COSE_Key`** (`EdDSA25519Key::new(raw_pubkey).build()`,
+   CBOR-encoded — `kty: OKP`, `alg: EdDSA`, `crv: Ed25519`, `x: <32-byte key>`),
+   not the bare 32 raw bytes. This is the `key` half of the `(signature, key)`
+   pair CIP-30's `signData` returns, so a CIP-8 verifier can consume the output
+   directly.
+
+#### 3.4 Transaction signing
+
+`sign_transaction` consumes the unsigned transaction CBOR (it does **not** build
+transactions — input selection, fees, and change are the caller's responsibility):
+
+1. Parse the bytes into a CSL `FixedTransaction` (`InvalidTransaction` on failure).
+2. Always create a payment witness with `make_vkey_witness(tx_hash, payment_raw_key)`.
+3. Determine whether the body needs a **stake** signature. Two independent sources
+   are consulted:
+   - **Structural requirements** (`stake_key_hashes_required_by_body`) — the key
+     hashes the ledger will demand regardless of what the builder declared:
+     - **certificate stake credentials** (`add_cert_key_hashes`), covering the
+       Conway `reg_cert` (a legacy `stake_registration` with no explicit deposit
+       needs no witness, so it is skipped), stake deregistration, stake/vote
+       delegation and the combined registration+delegation certificates, and vote
+       delegation — mirroring the stake-credential arms of the ledger's
+       `witsVKeyNeeded`. Script credentials are witnessed by the script, not a
+       vkey, so only key-hash credentials are collected. Pool **owners** on a pool
+       registration are stake key hashes and are collected; the pool operator's
+       cold key, genesis delegates, committee credentials, and DRep credentials
+       can never be a CIP-1852 stake key and are not.
+     - **withdrawals** — the reward account of every withdrawal in the body.
+   - **`required_signers`** — consulted only to decide whether *this* wallet's
+     stake key should sign, never to decide that a stake key is missing: a hash
+     listed there routinely belongs to a co-signer.
+4. If stake key material is present and its hash is in either set, a stake witness
+   is appended. If **no** stake key is available but the body structurally requires
+   a stake signature for anything other than the payment credential,
+   `sign_transaction` fails with `InvalidTransaction` rather than returning a
+   transaction that would fail phase-1 validation on submission.
+5. `SignOutput.signature` is the CBOR-encoded **`Vkeywitnesses` set** (payment,
+   optionally followed by stake); `public_key` is the payment witness's public key.
+
+`encode_signed_transaction` assembles the submittable transaction: it re-parses the
+unsigned CBOR into a `FixedTransaction`, decodes the signature buffer back into a
+`Vkeywitnesses` set (`Vkeywitnesses::from_bytes`), adds each witness with
+`add_vkey_witness`, and returns the CBOR of the now-witnessed transaction.
+This is the byte string handed to `broadcast_cardano` ([§2.7](#27-broadcast-plumbing)).
+
+#### 3.5 Key-material abstraction (`default_derivation_paths` and `encode_keys`)
+
+To let a chain decide how mnemonic-derived key material is shaped, `ChainSigner`
+exposes two overridable hooks:
+
+- `default_derivation_paths(index)` — all BIP paths bound to one account. The
+  default returns a single-element vector containing `default_derivation_path(index)`,
+  so every other chain is unaffected.
+- `encode_keys(keys)` — packs the resolved key bundle into the single opaque blob
+  that signing methods consume. The default returns the primary (first) key
+  unchanged.
+
+`CardanoSigner` overrides both: `default_derivation_paths` returns the payment leaf
+`m/1852'/1815'/{index}'/0/0` and the stake key `m/1852'/1815'/{index}'/2/0`;
+`encode_keys` concatenates the two 96-byte `XPrv`s into the 192-byte payment ‖
+stake buffer the address and signing methods expect. Generic call sites were
+migrated to this pattern — `derive_all_accounts`, `secret_to_signing_key`,
+`derive_address` (the public lib function), the CLI `derive` command, and the
+signer integration test now call `signer.default_derivation_paths(index)`, derive
+keys via `HdDeriver`, then `signer.encode_keys(&keys)` instead of deriving a single
+path inline. This is what lets Cardano transparently carry two credentials through
+code that still assumes "one account → one key blob".
+
+#### 3.6 Address-aware `sign_message` across all chains
+
+CIP-8 needs to know *which* of a wallet's Cardano addresses a signature is for, so
+the `sign_message` signature gained an `address: Option<&str>` parameter across the
+whole `ChainSigner` trait, every chain implementation, the `ows-lib` entry points
+(`sign_message`, `sign_typed_data`, and their API-key variants), the CLI (a new
+`--address` flag on `sign message`), and the Node/Python bindings.
+
+For non-Cardano chains the parameter is an optional safety check: a new default
+trait method `verify_sign_message_address` re-derives the address from the private
+key and compares it (case-insensitively, ignoring a `0x` prefix) to the requested
+one, returning the new `SignerError::AddressMismatch` on a mismatch. Each chain
+calls it at the top of `sign_message` (and EVM's typed-data path calls it too), so
+passing an `address` that the key does not control is rejected everywhere, while
+passing `None` keeps the prior behavior. Cardano does not use the default check —
+it performs richer, address-kind-aware selection and verification inline (see
+[§3.3](#33-cip-8-message-signing-sign_message)).
+
+### 4. Policy engine support
+
+OWS gates every signing request through a **Policy Engine**: before a key is
+decrypted and used, the request is turned into a chain-agnostic
+`PolicyContext` (`ows/crates/ows-core/src/policy.rs`) that built-in rules and custom
+**executable** policies evaluate and can veto. The core of that context is a
+`TransactionContext`, whose `effects` field is a list of per-address asset
+deltas:
+
+```rust
+pub struct TransactionEffect {
+    pub address: String,
+    pub diff: Vec<(String, i64)>, // (asset_id, signed change)
+}
+
+pub struct TransactionContext {
+    pub effects: Vec<TransactionEffect>,
+    pub raw_hex: String,          // the raw unsigned transaction
+    pub data: Option<String>,     // calldata (EVM only)
+}
+```
+
+Each `ChainSigner` produces this context from raw transaction bytes via
+`make_transaction_context(tx_bytes, rpc_url)`. The trait's default implementation
+returns empty `effects` (just the `raw_hex`), which suffices for chains where the
+transaction already carries enough information — or where flow analysis is not yet
+implemented. This deliverable overrides it for Cardano so that a policy can reason
+about the **actual ADA and native-asset movement** a transaction causes, per
+address.
+
+#### 4.1 Why Cardano needs the RPC provider
+
+Cardano is UTxO-based. A transaction body lists its inputs only as
+`(transaction_hash, index)` references — it does **not** carry the value or assets
+locked at those UTxOs. To compute how much each address gains or loses, the signer
+must resolve every referenced input to its underlying UTxO. This is the
+architectural consequence flagged in the scope: unlike the account-based effects on
+other chains, building a Cardano `TransactionContext` **depends on network access**
+to the configured RPC provider (Koios).
+
+Accordingly, `make_transaction_context` takes an `Option<&str>` RPC URL, and the
+`ows-lib` call sites that build the policy context — `sign_and_send`
+(`ops.rs`) and `sign_with_api_key` (`key_ops.rs`) — now resolve the Koios endpoint
+for Cardano and pass it through. Resolution reuses the generic precedence
+(explicit override → config exact `chain_id` → config namespace → built-in
+default; see [§1.4](#14-rpc-configuration-koios-keyless)); `resolve_rpc_url` was
+made `pub(crate)`-visible for this. For every non-Cardano chain the URL stays
+`None`, so no network call is introduced anywhere else.
+
+#### 4.2 Parsing and input resolution (Koios `tx_cbor`)
+
+`CardanoSigner::make_transaction_context` (`ows/crates/ows-signer/src/chains/cardano.rs`):
+
+1. Parse the bytes into a CSL `FixedTransaction` (`InvalidTransaction` on failure),
+   and record the raw hex for `TransactionContext.raw_hex`.
+2. Collect input references as `(tx_hash_hex, index)` pairs from `tx.body().inputs()`.
+3. If there are inputs, an RPC URL is **required** (else `InvalidMessage`). Inputs are
+   resolved *not* by asking Koios for UTxO values, but by fetching the **CBOR of each
+   referenced transaction** (`fetch_txs_cbor`, one request set per unique tx hash) and
+   reading the referenced output out of it: `POST {rpc}/tx_cbor` with
+   `{"_tx_hashes": [...]}`.
+   - Requests are **chunked** at 10 hashes per call and use a blocking `reqwest`
+     client with a `45s` timeout.
+   - Non-2xx responses become `SignerError::RpcError`.
+4. Each returned CBOR is decoded into a `FixedTransaction` and its
+   `transaction_hash()` is compared against the hash it was requested under; a
+   mismatch is a hard `RpcError`. A hash missing from the response is likewise an
+   `RpcError`, and an input whose index is past the end of the source transaction's
+   outputs is an `InvalidTransaction` (a missing input would silently understate the
+   flow, so it is rejected rather than ignored).
+
+Each resolved `Utxo` carries the input's `address`, its lovelace amount, and a list
+of native assets keyed by `policy_id ‖ asset_name` (hex), all read from the source
+transaction's output.
+
+#### 4.3 Computing per-address effects
+
+The signer builds two `address → (asset_id → amount)` maps and diffs them:
+
+- **Inputs** map is populated from the resolved input UTxOs (value → `lovelace`,
+  each native asset → `policy_id ‖ asset_name`).
+- **Outputs** map is read directly from `tx.body().outputs()`: the `coin` becomes
+  `lovelace`, and each `multiasset` entry becomes `policy_id_hex ‖ asset_name_hex`.
+- **Withdrawals** (`tx.body().withdrawals()`) are folded into the **inputs** map:
+  lovelace leaves the reward account and enters the transaction, so each
+  withdrawal counts as an input from the bech32 **reward address**
+  (`stake1…`) it is drawn from.
+- **Certificate deposits and refunds** (`cert_deposit_or_refund`) are attributed to
+  the reward address of the certificate's credential, built from that credential
+  and the signer's `network_id`. A **deposit** locks lovelace under the credential
+  and is therefore counted as an *output* to that reward address; a **refund**
+  unlocks it and is counted as an *input*. Covered certificates are the Conway
+  `reg_cert`/`unreg_cert` (only when they carry an explicit `coin` on the wire),
+  stake registration-and-delegation, stake-vote registration-and-delegation, vote
+  registration-and-delegation, and DRep registration/deregistration. Legacy
+  Shelley certificates without an on-wire amount are skipped, because their
+  deposit comes from protocol parameters that the transaction bytes do not carry.
+- ADA is represented by the reserved asset id **`"lovelace"`**; every native asset
+  is keyed by the concatenation of its (hex) policy id and (hex) asset name, so the
+  same token nets out across inputs and outputs.
+
+For every address touched by either side, and every asset id it involves, the
+effect is `output_balance − input_balance` as a signed `i64`. Zero-diff assets and
+zero-diff addresses are dropped; the remaining `diff` entries are sorted by asset
+id and the `effects` list is sorted by address, so the context is deterministic
+(important for reproducible policy decisions and stable test vectors). A pure
+self-transfer, for example, yields a single effect on the sender with only the
+negative fee.
+
+The result is returned as `TransactionContext { effects, raw_hex, data: None }` and
+handed to the policy engine, which passes it (as part of `PolicyContext`) to
+built-in rules and to executable policies over stdin.
+
+### 5. Address balance fetching
+
+`get_cardano_balances` (`ows/crates/ows-pay/src/cardano.rs`) queries the
+configured Koios RPC URL (`ows-pay`'s `get_balances` requires an explicit RPC
+URL for Cardano — a missing one is `PayErrorCode::InvalidInput`) and returns the
+generic `TokenBalance` list that every other chain in `ows-pay` produces:
+
+- ADA is reported with `address: "lovelace"`, symbol `ADA`, and 6 decimals; the
+  amount is the lovelace total scaled by `10^-6`.
+- Each native asset is reported with `address` set to its **asset fingerprint**
+  (`asset1…`), `name` set to `policy_id.asset_name`, and `symbol`/`decimals`
+  taken from the token-registry metadata — falling back to the first 10
+  characters of the asset name and `0` decimals when no metadata exists.
+  Zero-quantity entries are dropped, and the list is sorted by descending
+  amount.
+- **Koios** reads `POST {rpc}/address_info` (summing `asset_list` across the
+  UTxO set) and resolves metadata via `POST {rpc}/asset_info`, chunked.
+
+Errors are mapped onto `PayErrorCode`: transport → `HttpTransport`, non-success
+status → `HttpStatus`, and an undecodable response body or amount → the new
+`InvalidData`.
+
+## Rationale
+
+- **`cip34` namespace.** CIP-34 is the Cardano-native CAIP-2 registration and
+  encodes network id + network magic deterministically, which lets a single
+  identifier disambiguate mainnet/preprod/preview without inventing OWS-specific
+  aliases. CIP-34 is still in _Proposed_ status, which is a known risk we accept
+  and monitor.
+- **Generic `ed25519-bip32` instead of `cardano-serialization-lib` for
+  derivation.** The simplest route would be to derive keys with
+  `cardano-serialization-lib` (CSL). OWS deliberately keeps derivation
+  chain-agnostic and generic (a single `HdDeriver` across all families), so we
+  implement BIP32-Ed25519 with the lightweight `ed25519-bip32` crate and only use
+  CSL for Cardano-specific concerns (network parameters, address encoding, and
+  transaction/witness encoding). This avoids leaking a chain-specific library into
+  the generic key path while still using the canonical library for the parts that
+  must match the ecosystem byte-for-byte.
+- **CSL + `cardano-message-signing` for the chain plugin, per IOHK.** As recorded
+  in the deliverable description (IOHK agreed on 8.4.2026 to use
+  `cardano-serialization-lib`), address encoding and transaction signing go through
+  CSL, and CIP-8 message signing uses Emurgo's `cardano-message-signing` COSE
+  helpers rather than a hand-rolled COSE encoder. This keeps the produced
+  addresses, witnesses, and signed messages compatible with mainstream Cardano
+  wallets and tooling.
+- **Base address with payment + stake.** Per agreement with IOHK, the initial
+  implementation targets exactly one base address per account at address index 0,
+  combining a payment credential (role 0) and a stake credential (role 2). This
+  keeps the scope bounded while still producing a normal, stake-delegatable
+  Shelley address rather than an enterprise (payment-only) address.
+- **Two 96-byte keys in `KeyPair`.** Storing payment ‖ stake (192 bytes) up front
+  makes the imported-key representation forward-compatible with base-address
+  assembly without another schema change.
+- **`default_derivation_paths` + `encode_keys` instead of widening the signer
+  surface.** Rather than special-casing Cardano in every generic call site,
+  overridable `ChainSigner::default_derivation_paths` and `encode_keys` let a chain
+  declare how many keys per account it needs and how to pack them into one blob.
+  The defaults keep single-path behavior for all other chains; only Cardano returns
+  the 192-byte payment ‖ stake buffer. This localizes the "two credentials per
+  account" peculiarity to the Cardano signer.
+- **`address`-driven message signing.** CIP-8 embeds the signing address in the
+  COSE protected headers, so `sign_message` must know which address the caller
+  intends. Threading an optional `address` through the trait (rather than a
+  Cardano-only API) also gave every other chain a cheap opt-in guard against
+  signing with the wrong key (`verify_sign_message_address` →
+  `AddressMismatch`).
+- **A CBOR witness set as the signature.** `sign_transaction` returns the CBOR
+  encoding of the whole `Vkeywitnesses` set, and `encode_signed_transaction`
+  decodes it back with `Vkeywitnesses::from_bytes`. This keeps
+  `SignOutput.signature` a flat byte string (consistent with other chains) while
+  supporting the multi-witness (payment + stake) case without the caller having to
+  know a fixed per-witness length.
+- **Stake witnessing driven by the transaction body, not by `required_signers`.**
+  A builder is not obliged to list the stake key in `required_signers`, so keying
+  the decision off that field alone silently produced unsubmittable delegation and
+  withdrawal transactions. `sign_transaction` therefore derives the required stake
+  key hashes from the certificates and withdrawals themselves (mirroring the
+  ledger's `witsVKeyNeeded`) and keeps `required_signers` only as an additional
+  trigger — never as the reason to declare a stake key missing, since a hash listed
+  there frequently belongs to a co-signer. When a stake signature is structurally
+  required and no stake key is available, failing early is preferable to handing
+  back a transaction that dies in phase-1 validation.
+- **`COSE_Key` as the message-signing public key.** CIP-30's `signData` returns a
+  `(signature, key)` pair where `key` is a COSE key, not raw bytes. Returning the
+  serialized `COSE_Key` in `SignOutput.public_key` lets wallet/dApp verifiers use
+  the output as-is instead of re-wrapping the raw Ed25519 key themselves.
+- **Deposits, refunds, and withdrawals attributed to the reward address.** Staking
+  lovelace is locked under a *credential*, not at a payment address, so the only
+  faithful place to book it is the credential's reward address. Treating deposits
+  as outputs and refunds/withdrawals as inputs keeps the netting arithmetic
+  identical to the UTxO side, so a policy sees "2 ADA left this payment address and
+  2 ADA is now locked at this `stake1…`" instead of an unexplained outflow.
+- **RPC-resolved transaction effects for policy.** Cardano inputs carry no value,
+  so a meaningful `TransactionContext` cannot be built from the transaction bytes
+  alone. Rather than inventing a Cardano-only policy path, the existing
+  `make_transaction_context` hook is overridden to resolve inputs via Koios and emit
+  the same chain-agnostic `TransactionEffect` shape every other chain uses — so
+  executable policies see uniform per-address asset deltas regardless of chain. The
+  RPC dependency is threaded only for Cardano; all other chains keep passing `None`.
+- **Reject missing input UTxOs.** If Koios omits a referenced transaction, returns
+  CBOR whose hash does not match, or the referenced output index does not exist,
+  `make_transaction_context` errors instead of proceeding. An unresolved input would
+  silently understate the ADA/asset outflow and could let a spending policy pass a
+  transaction it should have denied, so a partial resolution is treated as a hard
+  failure.
+
+  > **⚠️ Warning — chained/unconfirmed transactions.** This same strictness breaks
+  > transaction *chaining*. If a transaction spends an input that was created by an
+  > earlier transaction which has **not yet been confirmed in a block**, Koios does
+  > not know that transaction yet and omits it from the `tx_cbor` response. Because
+  > the returned data is then incomplete,
+  > `make_transaction_context` fails (surfaced as `RpcError` —
+  > "missing transaction CBOR") and the signing request is rejected, even though
+  > the transaction itself is well-formed. In other words, a transaction cannot be
+  > signed through the policy engine until every input it references has been
+  > confirmed and indexed by Koios. Building and submitting a chain of dependent
+  > transactions back-to-back (before the parents confirm) is therefore not currently
+  > supported.
+- **Deterministic effect ordering.** Effects are sorted by address and each `diff`
+  by asset id, and ADA is normalized to the single `"lovelace"` key. This makes the
+  context stable across runs, so policy decisions are reproducible and reference
+  vectors are exact.
+
+### Acceptance Criteria
+
+These deliverables are considered complete when:
+
+1. `ChainType::Cardano` exists and round-trips through serde, `namespace()`,
+   `from_namespace()`, `default_coin_type()`, and `Display`/`FromStr`.
+2. `parse_chain` resolves `cardano`, `cardano-preprod`, `cardano-preview`, and the
+   corresponding `cip34:*` ids; `default_chain_for_type(Cardano)` is mainnet.
+3. Default Koios RPC endpoints are registered for all three networks and resolved
+   by the generic RPC lookup.
+4. `Curve::Ed25519Bip32` reports correct key lengths (96 / 32).
+5. `HdDeriver` produces the correct Icarus master `XPrv` from entropy (matches
+   published vectors) and performs V2 child derivation, including the CIP-1852
+   payment/stake/account paths.
+6. `CardanoSigner` reports curve `Ed25519Bip32`, coin type `1815`, and the
+   CIP-1852 payment leaf as its default path.
+7. Multi-curve key storage carries an `ed25519_bip32` entry (192 bytes for
+   imported keys) without changing the wallet schema version, and an explicitly
+   supplied key is accepted only in the 96/192-byte shapes with valid
+   Ed25519-BIP32 clamping.
+8. `derive_address` produces the correct mainnet Shelley **base** address from
+   192-byte key material and the correct **enterprise** address from 96-byte
+   payment-only material (verified against fixed vectors for 12- and 24-word
+   mnemonics).
+9. `sign_message` produces a CIP-8 `COSE_Sign1` matching reference vectors for the
+   no-address, base, enterprise, and reward-address cases, returns the signing
+   key as a serialized `COSE_Key`, and rejects an address the key does not control
+   with `AddressMismatch`.
+10. `sign_transaction` produces correct `Vkeywitness`(es) — payment only, and
+    payment + stake when the transaction's certificates, withdrawals, or
+    `required_signers` demand it — and `encode_signed_transaction` round-trips the
+    witness set into a submittable transaction matching reference CBOR vectors.
+11. `default_derivation_paths` returns both CIP-1852 paths for Cardano, and
+    `encode_keys` returns the 192-byte payment ‖ stake buffer; all other chains
+    remain on their single-path defaults.
+12. `make_transaction_context` parses an unsigned Cardano transaction, resolves its
+    inputs via Koios `tx_cbor`, and produces per-address `TransactionEffect`s with
+    correct signed ADA and native-asset diffs (verified against mocked Koios
+    responses for self-transfer, external+change, asset-carrying, and
+    multi-input/multi-output cases); withdrawals and certificate deposits/refunds
+    are booked against the corresponding reward address; it errors when the RPC URL
+    is missing for a transaction with inputs, or when Koios returns incomplete
+    transaction data.
+13. Address balance fetching returns ADA under `lovelace` plus one entry per
+    native asset (fingerprint, `policy_id.asset_name`, token-registry
+    symbol/decimals), and an amount that cannot be decoded
+    fails with `PayErrorCode::InvalidData` instead of reporting `0`.
+
+### Implementation Plan
+
+Everything specified above is landed and covered by unit/integration tests (see
+[Testing](#testing)): the chain-registry/addressing layer, Ed25519-BIP32 key
+derivation, the chain plugin interface (Shelley base/enterprise/reward address
+encoding, raw signing, CIP-8 message signing, and transaction signing/witness
+encoding), policy-engine support (`make_transaction_context` with Koios input
+resolution), address balance fetching, and the CLI/binding surface for the
+optional `address` argument. Remaining Cardano work (separate deliverables)
+proceeds as: transaction *building* (input selection, fee/change), persisting
+both payment and stake paths per `WalletAccount`, and optional alternative RPC
+providers (e.g. Blockfrost).
+
+## Backwards Compatibility Assessment
+
+- **Wallet file schema unchanged.** `ows_version` stays at `2`. The new
+  `ed25519_bip32` key field is additive; existing mnemonic wallets need no
+  migration (Cardano keys are derived on demand). Private-key wallets imported
+  before Cardano support simply have no `ed25519_bip32` material and surface a
+  clear error if used for Cardano, rather than silently degrading.
+- **Existing families untouched.** secp256k1 and SLIP-10 ed25519 derivation paths
+  are unchanged; the `Ed25519Bip32` branch is additive in `Curve`, `HdDeriver`,
+  and `KeyPair`. Characterization tests on EVM/Solana derivation continue to pass.
+- **`sign_message` signature changed (binding-level).** Adding `address:
+  Option<&str>` to `ChainSigner::sign_message` and to the `ows-lib`/binding entry
+  points is a source-breaking change for direct callers, mitigated by making the
+  parameter optional: passing `None` reproduces the prior behavior exactly, and
+  every chain's non-Cardano message signing is unchanged when no address is given.
+  `default_derivation_paths` and `encode_keys` are purely additive (defaults mirror
+  the old inline single-path derivation).
+- **Policy context is additive.** `make_transaction_context` already existed on
+  `ChainSigner` with a default-empty implementation; Cardano overrides it and the new
+  `SignerError::RpcError` variant is additive, so no other chain's behavior changes.
+  The lib call sites resolve an RPC URL only for Cardano (all other chains keep
+  passing `None`), so no new network call is introduced for existing chains.
+- **New network dependency for Cardano signing requests.** Building a Cardano
+  policy context now performs a Koios call when the transaction has inputs; a Cardano
+  signing request that previously would have proceeded with empty effects now
+  requires provider reachability (and errors if none is configured/available). This
+  is intended — the policy engine needs the flow to make a decision — but it is a
+  behavioral change for Cardano relative to the prior default-empty context.
+- **Known abstraction gap.** `WalletAccount` still stores a single
+  `derivation_path`, so the stored Cardano account currently records only the
+  payment leaf even though the signer now derives both payment and stake keys at
+  runtime via `default_derivation_paths` and `encode_keys`. Persisting both paths
+  per account is a noted
+  follow-up (`TODO` in `derive_all_accounts`).
+
+## Security Considerations
+
+- **Key material handling.** All derived keys are wrapped in `SecretBytes`
+  (zeroized on drop). Intermediate buffers in HD derivation are explicitly
+  zeroized. The 96-byte extended private keys are treated as secrets identical to
+  other curve keys. Every buffer that transiently holds an Ed25519-BIP32 secret is
+  covered: the PBKDF2 output and normalized master `XPrv`
+  (`ed25519_bip32_master_xprv_from_entropy`), the randomly generated import keys,
+  the decoded hex of an explicitly supplied key, the `KeyPair` fields and the JSON
+  blob they are serialized into, and the bit accumulator and phrase copy inside
+  `Mnemonic::entropy()` — all are `Zeroizing`/explicitly wiped rather than left to
+  the allocator.
+- **Malformed imported keys are rejected.** A user-supplied `ed25519_bip32` key is
+  shape- and clamping-checked at import (see
+  [§2.6](#26-multi-credential-key-storage)), so an unusable key surfaces at import
+  time rather than as an opaque failure on first use.
+- **Icarus master key.** Uses the standard PBKDF2-HMAC-SHA512 (4096 iterations,
+  empty password, entropy as salt) and `normalize_bytes_force3rd`, matching
+  ecosystem wallets; deviating would produce incompatible (and potentially
+  unrecoverable-by-other-wallets) addresses.
+- **Non-hardened derivation.** BIP32-Ed25519 V2 permits non-hardened child keys.
+  This is required for Cardano interoperability, but callers should remain aware
+  that a non-hardened branch's xpub + a single child xprv can expose sibling keys;
+  the default account/payment/stake paths use hardened account-level segments.
+  Path components at or above 2³¹ are rejected on every curve, so a bare
+  `m/2147483648` cannot be used as an alias for the hardened `m/0'` (see
+  [§2.3](#23-child-derivation)) — two spellings of one path would otherwise let the
+  same key be reached under a path a policy or an account record does not
+  recognize.
+- **Key cache isolation.** The derivation cache key includes the curve tag, so
+  Ed25519-BIP32 keys cannot be confused with secp256k1/ed25519 keys derived at the
+  same BIP path string.
+- **Keyless RPC.** Koios needs no API key, avoiding credential storage. Broadcast
+  is performed over HTTPS; transaction submission and input resolution will rely on
+  this provider, so provider availability/trust is a deployment consideration.
+- **Address-bound message signing.** `sign_message` always re-derives the address
+  from the supplied key material and refuses to sign for an `address` the key does
+  not control (`AddressMismatch`). The signing address is embedded in the CIP-8
+  COSE protected headers, so a verifier can confirm which credential signed. Across
+  other chains the same `verify_sign_message_address` guard prevents signing a
+  message under an address the wallet did not derive.
+- **Selective stake witnessing.** `sign_transaction` only attaches a stake witness
+  when the transaction body actually calls for one — a certificate stake
+  credential, a pool-owner hash, a withdrawal reward account, or an explicit
+  `required_signers` entry matching the stake key hash — so a routine payment
+  transaction is never signed with the stake key. Conversely, when the body
+  structurally requires a stake signature the wallet cannot provide, signing fails
+  instead of emitting a transaction that would be rejected on submission.
+  Transaction *content* is not otherwise inspected or policy-checked here —
+  the signer trusts the caller-provided unsigned CBOR — so transaction building and
+  vetting remain the responsibility of upstream layers.
+- **Trust in the RPC-derived context.** Cardano input values come from Koios, so the
+  `TransactionContext` a policy evaluates is only as trustworthy as the RPC
+  provider. Fetching whole source transactions rather than endpoint-computed UTxO
+  values narrows that trust: each returned CBOR is re-hashed and must match the hash
+  it was requested under, so the endpoint cannot fabricate input values under a tx
+  hash the transaction actually references (it can still withhold a transaction,
+  which fails closed). The keyless Koios default trades authentication for
+  operational simplicity; deployments with stronger requirements should point RPC
+  config at a trusted provider. To limit silent under-reporting, a transaction with
+  inputs and no RPC URL is rejected, and any input Koios fails to return aborts
+  context construction rather than degrading to a partial view. On the balance path
+  the same strictness applies: an unparseable lovelace balance or asset quantity is
+  a hard `PayErrorCode::InvalidData` error rather than a silent `0`, so a
+  malformed response cannot understate holdings. Nullable Koios fields
+  (`asset_list`, `asset_name`, token-registry `decimals`) are modelled as optional
+  and default to empty/`0`, because their absence is a normal response shape rather
+  than corrupt data.
+
+## Implementation
+
+Components modified or added:
+
+- `ows/crates/ows-core/src/chain.rs` — `ChainType::Cardano`; `cip34` namespace mapping;
+  coin type `1815`; mainnet/preprod/preview registry entries;
+  `UNIVERSAL_WALLET_EXTRA_CHAIN_NAMES`; `parse_chain` support.
+- `ows/crates/ows-core/src/config.rs` — default Koios RPC endpoints for the three networks.
+- `ows/crates/ows-core/src/wallet_file.rs` — `KeyType::PrivateKey` doc updated to include
+  `ed25519_bip32`.
+- `ows/crates/ows-signer/src/curve.rs` — `Curve::Ed25519Bip32` and key lengths.
+- `ows/crates/ows-signer/src/mnemonic.rs` — `Mnemonic::entropy()` (raw BIP-39 entropy).
+- `ows/crates/ows-signer/src/hd.rs` — Icarus master-key generation and V2 child derivation;
+  a single shared path parser (`parse_path_components`) that bounds every index
+  below 2³¹.
+- `ows/crates/ows-signer/src/chains/cardano.rs` — `CardanoSigner`, CIP-1852 path helpers,
+  network selection, and the full `ChainSigner` impl: base/enterprise/reward
+  address encoding, `sign`, CIP-8 `sign_message`, `sign_transaction`,
+  `encode_signed_transaction`, the `default_derivation_paths` / `encode_keys`
+  overrides, and the `make_transaction_context` override plus its Koios `tx_cbor`
+  client (`fetch_txs_cbor`), which also books withdrawals and certificate
+  deposits/refunds against the reward address.
+- `ows/crates/ows-signer/src/traits.rs` — `sign_message` gains `address: Option<&str>`; new
+  default methods `verify_sign_message_address`, `default_derivation_paths`, and
+  `encode_keys`; new `SignerError::AddressMismatch` and `SignerError::RpcError`.
+  (`make_transaction_context` already existed as a default-empty hook; Cardano now
+  overrides it.)
+- `ows/crates/ows-lib/src/ops.rs` & `ows/crates/ows-lib/src/key_ops.rs` — `sign_and_send` and
+  `sign_with_api_key` resolve the Koios RPC URL for Cardano and pass it into
+  `make_transaction_context`; `resolve_rpc_url` is exposed for reuse.
+- `ows/crates/ows-pay/src/cardano.rs` & `ows/crates/ows-pay/src/error.rs` — address balance fetching via
+  Koios `address_info` / `asset_info`; new `PayErrorCode::InvalidData` for a
+  response whose amounts cannot be decoded.
+- `ows/crates/ows-signer/src/chains/*.rs` — every chain's `sign_message` updated to the new
+  signature and calls `verify_sign_message_address`.
+- `ows/crates/ows-signer/src/chains/mod.rs` & `lib.rs` — register `CardanoSigner` in
+  `signer_for_chain`; integration test uses `default_derivation_paths` and
+  `encode_keys`.
+- `ows/crates/ows-lib/src/ops.rs` — `KeyPair.ed25519_bip32`, random 192-byte generation,
+  `validate_ed25519_bip32_key` on private-key import,
+  curve dispatch, `broadcast_cardano`; `sign_message`/`sign_typed_data` thread the
+  `address` argument; mnemonic derivation routes through `default_derivation_paths`
+  and `encode_keys`.
+- `ows/crates/ows-lib/src/key_ops.rs` — API-key `sign_message`/`sign_typed_data` thread
+  `address` and call `verify_sign_message_address`.
+- `ows/crates/ows-cli` — `sign message --address` flag; `derive` uses
+  `default_derivation_paths` and `encode_keys`.
+- `bindings/node` & `bindings/python` — `sign_message`/`sign_typed_data` expose
+  the optional `address` argument.
+
+Dependencies added:
+
+- `ed25519-bip32 = "0.4.1"` — generic BIP32-Ed25519 derivation
+  (`ows/crates/ows-signer/Cargo.toml`, `ows/crates/ows-lib/Cargo.toml`).
+- `pbkdf2 = "0.12"` — Icarus master-key derivation
+  (`ows/crates/ows-signer/Cargo.toml`).
+- `cardano-serialization-lib = "14.1.1"` — Cardano network parameters
+  (`NetworkInfo`), Shelley address encoding, and transaction/witness encoding
+  (`ows/crates/ows-signer/Cargo.toml`).
+- `emurgo-cardano-message-signing = "1.1.0"` — CIP-8 COSE message-signing helpers
+  (`ows/crates/ows-signer/Cargo.toml`).
+- `reqwest = "0.12"` (blocking, `json`, `rustls-tls`, no default features) — Koios
+  `tx_cbor` HTTP client used to resolve transaction inputs for the policy context
+  (`ows/crates/ows-signer/Cargo.toml`).
+- `mockito = "1"` (dev-dependency) — mocks the Koios endpoints in the
+  `make_transaction_context` and balance tests
+  (`ows/crates/ows-signer/Cargo.toml`, `ows/crates/ows-pay/Cargo.toml`).
+
+## Testing
+
+Implemented and passing for these deliverables:
+
+- **Curve** (`curve.rs`): key-length and equality tests for `Ed25519Bip32`.
+- **Master key / derivation** (`hd.rs`): Icarus master `XPrv` vectors (named and
+  all-zero "abandon" mnemonic); V2 hardened child derivation against
+  `ed25519-bip32` crate vectors; rejection of a 64-byte BIP-39 seed for the
+  Ed25519-BIP32 curve; equivalence of mnemonic-based vs master-`XPrv`-based
+  derivation for `m/1852'/1815'/0'/0/0`.
+- **Path validation** (`hd.rs`): indices at or above 2³¹ are rejected by
+  `validate_path` and by `derive` on all three curves, while `2147483647`(`'`) is
+  still accepted; repeated hardened markers (`m/44''`) are rejected; and
+  `m/2147483648` no longer aliases `m/0'` on the Ed25519-BIP32 curve.
+- **Mnemonic** (`mnemonic.rs`): `entropy()` returns all-zero entropy for the
+  "abandon" vector, and matches the Trezor BIP-39 vectors for 12- and 24-word
+  phrases (the 24-word cases pin the checksum-byte truncation, since 24 words
+  carry 264 bits).
+- **Chain registry** (`chain.rs`): serde round-trip including Cardano; namespace,
+  coin type, and `from_namespace("cip34")` mappings; `parse_chain` for friendly
+  names and `cip34:*` ids; universal-wallet order/count (mainnet + preprod +
+  preview).
+- **Config** (`config.rs`): default RPC lookups for all three Koios endpoints.
+- **Signer** (`cardano.rs`): CIP-1852 path construction; chain type/curve/coin
+  type; default path equals payment leaf.
+- **Address encoding** (`cardano.rs`): mainnet **base** address from 12- and
+  24-word mnemonics (via `default_derivation_paths` and `encode_keys`) against fixed
+  `addr1q…` vectors;
+  **enterprise** address from a payment-only key against fixed `addr1v…` vectors.
+- **Message signing** (`cardano.rs`): CIP-8 `COSE_Sign1` output against reference
+  vectors for the no-address, base, enterprise, and reward-address cases
+  (including the expected serialized `COSE_Key` per signing credential).
+- **Transaction signing** (`cardano.rs`): a CBOR test-transaction builder takes a
+  body-customization closure and exercises the payment-only witness path, the
+  payment + `required_signers` stake path, a stake-delegation certificate, and a
+  withdrawal; `sign_transaction` signatures and the `encode_signed_transaction`
+  output are asserted against reference CBOR, and the certificate/withdrawal cases
+  assert that the witness set carries exactly the payment and stake public keys.
+- **Key import** (`ows/crates/ows-lib/src/ops.rs`): a private-key wallet imports both the
+  96-byte payment and the 192-byte payment ‖ stake Ed25519-BIP32 shapes and
+  exports them unchanged; a 64-byte key and a 96-byte key with invalid scalar
+  clamping are both rejected at import.
+- **Cross-chain `sign_message`** (`evm.rs`, etc.): `AddressMismatch` is returned
+  for a wrong `address`, and signing succeeds when the derived address is passed;
+  `None` reproduces prior signatures (`solana.rs`, `bitcoin.rs`).
+- **Integration** (`lib.rs`): `signer_for_chain` derives a mainnet `addr1…` base
+  address via `default_derivation_paths`, `encode_keys`, and `derive_address`, now
+  passing end-to-end.
+- **Policy context** (`cardano.rs`): `make_transaction_context` is exercised with a
+  mocked Koios `tx_cbor` endpoint (`mockito`, serving real CBOR for the source
+  transactions) across the flow shapes that matter
+  for policy evaluation — a self-transfer (only the negative fee shows up), a single
+  input with an external payment plus change, the same with a native asset split
+  between external and change outputs, and multi-input/multi-output transactions
+  that rebalance across the wallet's own addresses and to a third party. Three
+  staking shapes are covered on top of those: a **withdrawal** (reward address
+  debited, payment address credited with the withdrawal minus the fee), a **stake
+  registration deposit** (payment address debited by deposit + fee, reward address
+  credited with the locked deposit), and a **stake deregistration refund** (the
+  mirror image). Each asserts
+  the exact sorted `effects` (per-address signed lovelace and asset diffs) and that
+  the mock endpoint was hit. Balance fetching (`ows-pay/src/cardano.rs`) is covered
+  by tests against mocked Koios `address_info` / `asset_info` endpoints.
+
+## References
+
+- [CIP-34: Cardano Blockchain identification](https://cips.cardano.org/cip/CIP-34) (status: Proposed)
+- [CIP-1852: HD Wallets for Cardano](https://cips.cardano.org/cip/CIP-1852)
+- [CIP-3: Wallet key generation (Icarus master key)](https://cips.cardano.org/cip/CIP-3)
+- [CIP-8: Message signing](https://cips.cardano.org/cip/CIP-8)
+- [CIP-30: Cardano dApp-Wallet Web Bridge (`signData`)](https://cips.cardano.org/cip/CIP-30)
+- [CIP-19: Cardano addresses](https://cips.cardano.org/cip/CIP-19)
+- [BIP32-Ed25519 (Khovratovich & Law)](https://input-output-hk.github.io/adrestia/static/Ed25519_BIP.pdf)
+- [`ed25519-bip32` crate](https://docs.rs/ed25519-bip32/0.4.1/)
+- [`cardano-serialization-lib`](https://github.com/Emurgo/cardano-serialization-lib)
+- [`cardano-message-signing`](https://github.com/Emurgo/message-signing)
+- [RFC 8152: CBOR Object Signing and Encryption (COSE)](https://www.rfc-editor.org/rfc/rfc8152)
+- [Koios API](https://api.koios.rest/)
+- [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) and [CAIP-10](https://chainagnostic.org/CAIPs/caip-10)
+- [SLIP-44: Registered coin types](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) (ADA = 1815)

--- a/docs/cardano.md
+++ b/docs/cardano.md
@@ -540,6 +540,7 @@ pub struct TransactionContext {
     pub effects: Vec<TransactionEffect>,
     pub raw_hex: String,          // the raw unsigned transaction
     pub data: Option<String>,     // calldata (EVM only)
+    pub chain_extra: Option<serde_json::Value>, // chain-specific detail effects cannot carry
 }
 ```
 
@@ -576,8 +577,11 @@ made `pub(crate)`-visible for this. For every non-Cardano chain the URL stays
 
 1. Parse the bytes into a CSL `FixedTransaction` (`InvalidTransaction` on failure),
    and record the raw hex for `TransactionContext.raw_hex`.
-2. Collect input references as `(tx_hash_hex, index)` pairs from `tx.body().inputs()`.
-3. If there are inputs, an RPC URL is **required** (else `InvalidMessage`). Inputs are
+2. Collect input references as `(tx_hash_hex, index)` pairs from `tx.body().inputs()`,
+   and the declared collateral references the same way from `tx.body().collateral()`.
+   Both sets are resolved in one batch and split apart afterwards
+   (see [section 4.4](#44-collateral-chain_extracollateral_effects)).
+3. If there is anything to resolve, an RPC URL is **required** (else `InvalidMessage`). Inputs are
    resolved *not* by asking Koios for UTxO values, but by fetching the **CBOR of each
    referenced transaction** (`fetch_txs_cbor`, one request set per unique tx hash) and
    reading the referenced output out of it: `POST {rpc}/tx_cbor` with
@@ -624,18 +628,54 @@ The signer builds two `address → (asset_id → amount)` maps and diffs them:
 
 For every address touched by either side, and every asset id it involves, the
 effect is `output_balance − input_balance`, computed in `i128` and rendered as a
-signed decimal string (see [§4.4](#44-why-amounts-are-strings)). Zero-diff assets and
+signed decimal string (see [§4.5](#45-why-amounts-are-strings)). Zero-diff assets and
 zero-diff addresses are dropped; the remaining `diff` entries are sorted by asset
 id and the `effects` list is sorted by address, so the context is deterministic
 (important for reproducible policy decisions and stable test vectors). A pure
 self-transfer, for example, yields a single effect on the sender with only the
 negative fee.
 
-The result is returned as `TransactionContext { effects, raw_hex, data: None }` and
-handed to the policy engine, which passes it (as part of `PolicyContext`) to
-built-in rules and to executable policies over stdin.
+The result is returned as `TransactionContext { effects, raw_hex, data: None,
+chain_extra }` and handed to the policy engine, which passes it (as part of
+`PolicyContext`) to built-in rules and to executable policies over stdin.
 
-#### 4.4 Why amounts are strings
+#### 4.4 Collateral (`chain_extra.collateral_effects`)
+
+Collateral is the one value-consuming part of a Cardano transaction that `effects`
+cannot describe honestly. Every other such field — a certificate deposit, a fee, a
+donation — reduces the change output, so it shows up in `effects` whether or not the
+signer models the cause. Collateral does not: it is consumed through a separate path
+and **only when phase-2 (script) validation fails**. Folding it into `effects` would
+report a loss on the success path that never happens; leaving it out entirely would
+let an executable policy that caps outflow miss it.
+
+So it is reported separately, in the generic `chain_extra` slot:
+
+```json
+"chain_extra": {
+  "collateral_effects": [
+    { "address": "addr1…", "diff": [["lovelace", "-2000000"]] }
+  ]
+}
+```
+
+The entries have the same shape as `effects`, and the same diffing code produces
+them (`effects_from_balances`): the resolved `collateral` inputs on one side,
+`collateral_return` on the other, so what is reported is the **worst-case loss** if
+the scripts fail. `total_collateral` is not read — it is a declared figure the ledger
+already checks against the same inputs, and deriving the number from resolved UTxOs
+keeps the one trust model (see [§4.2](#42-parsing-and-input-resolution-koios-tx_cbor)).
+
+Collateral inputs are resolved in the **same** Koios batch as the spent inputs, so
+exposing them costs no extra request, and they are subject to the same fail-closed
+rule: a collateral input Koios cannot return aborts context construction. `chain_extra`
+is omitted entirely when a transaction declares no collateral, which is every
+non-script transaction.
+
+A policy that caps outflow therefore has to read both lists and decide for itself
+whether to count the contingent one.
+
+#### 4.5 Why amounts are strings
 
 `TransactionEffect.diff` carries each amount as a signed decimal **string**, not an
 integer. `TransactionEffect` lives in `ows-core` and is shared by every chain, so
@@ -772,6 +812,15 @@ status → `HttpStatus`, and an undecodable response body or amount → the new
   by asset id, and ADA is normalized to the single `"lovelace"` key. This makes the
   context stable across runs, so policy decisions are reproducible and reference
   vectors are exact.
+- **Collateral is contingent, and reported as such.** Collateral is consumed only on
+  phase-2 validation failure, so it is reported under
+  `chain_extra.collateral_effects` rather than folded into `effects`, which would
+  overstate every script transaction's cost on the success path
+  (see [section 4.4](#44-collateral-chain_extracollateral_effects)). The consequence
+  for policy authors is explicit: a spend cap that reads only `effects` does not
+  bound the collateral at risk, because collateral does not reduce the change
+  output. Declarative rules read neither list, so capping spend needs an executable
+  policy, and that policy has to add the two together itself.
 
 ### Acceptance Criteria
 
@@ -813,9 +862,11 @@ These deliverables are considered complete when:
     correct signed ADA and native-asset diffs (verified against mocked Koios
     responses for self-transfer, external+change, asset-carrying, and
     multi-input/multi-output cases); withdrawals and certificate deposits/refunds
-    are booked against the corresponding reward address; it errors when the RPC URL
-    is missing for a transaction with inputs, or when Koios returns incomplete
-    transaction data.
+    are booked against the corresponding reward address; declared collateral is
+    resolved in the same batch and reported under `chain_extra.collateral_effects`,
+    net of `collateral_return`, and is absent for a transaction without collateral;
+    it errors when the RPC URL is missing for a transaction with inputs, or when
+    Koios returns incomplete transaction data.
 13. Address balance fetching returns ADA under `lovelace` plus one entry per
     native asset (fingerprint, `policy_id.asset_name`, token-registry
     symbol/decimals), and an amount that cannot be decoded
@@ -959,7 +1010,8 @@ Components modified or added:
   `encode_signed_transaction`, the `default_derivation_paths` / `encode_keys`
   overrides, and the `make_transaction_context` override plus its Koios `tx_cbor`
   client (`fetch_txs_cbor`), which also books withdrawals and certificate
-  deposits/refunds against the reward address.
+  deposits/refunds against the reward address and reports declared collateral under
+  `chain_extra.collateral_effects`.
 - `ows/crates/ows-signer/src/traits.rs` — `sign_message` gains `address: Option<&str>`; new
   default methods `verify_sign_message_address`, `default_derivation_paths`, and
   `encode_keys`; new `SignerError::AddressMismatch` and `SignerError::RpcError`.
@@ -1061,6 +1113,10 @@ Implemented and passing for these deliverables:
   input with an external payment plus change, the same with a native asset split
   between external and change outputs, and multi-input/multi-output transactions
   that rebalance across the wallet's own addresses and to a third party. Three
+  collateral shapes are covered too: collateral with no `collateral_return` (the
+  whole collateral input is at risk, and none of it appears in `effects`), collateral
+  with a partial return (only the remainder is at risk), and a transaction with no
+  collateral at all (`chain_extra` is absent). Three
   staking shapes are covered on top of those: a **withdrawal** (reward address
   debited, payment address credited with the withdrawal minus the fee), a **stake
   registration deposit** (payment address debited by deposit + fee, reward address

--- a/docs/cardano.md
+++ b/docs/cardano.md
@@ -1003,6 +1003,53 @@ providers (e.g. Blockfrost).
   (`asset_list`, `asset_name`, token-registry `decimals`) are modelled as optional
   and default to empty/`0`, because their absence is a normal response shape rather
   than corrupt data.
+- **What the RPC provider learns.** Building the policy context is the first thing in
+  OWS that makes a network call from `ows-signer`, so it is worth being exact about
+  what leaves the machine. **The transaction being signed is never sent.**
+  `make_transaction_context` asks Koios for the CBOR of transactions that are
+  *already on chain*, by hash — the hashes the unsigned transaction's inputs and
+  collateral reference (`POST {rpc}/tx_cbor`). Signing itself is local; no key
+  material, and no part of the transaction under construction, is transmitted.
+  What the provider (and anything on the network path) can observe is the set of
+  source transaction hashes and the requester's IP, from which it can infer which
+  UTxOs the wallet is about to spend and correlate requests over time. Broadcast is
+  the separate step that does transmit the finished transaction
+  (`POST {rpc}/submittx`), as any submission path must. A deployment that treats
+  that inference as sensitive should point `rpc` config at a provider it operates
+  (see [§1.4](#14-rpc-configuration-koios-keyless)); the keyless Koios default
+  trades this for needing no account and storing no credential.
+- **Unmaintained transitive dependencies.** The two Emurgo crates bring in five
+  crates carrying RUSTSEC *unmaintained* advisories. Four come from
+  `cardano-serialization-lib`: `clear_on_drop`, and `rand_os` with `cloudabi` and
+  `fuchsia-cprng` under it. The fifth, `nodrop`, comes from
+  `emurgo-cardano-message-signing` instead, four levels down
+  (`pruefung` → `digest 0.6` → `generic-array 0.8` → `nodrop`); CSL does not depend
+  on `generic-array` at all. These are warn-level "no longer maintained" notices,
+  not known vulnerabilities, and OWS accepts them knowingly rather than silently,
+  since CSL is the only maintained Rust implementation of Cardano's wire formats.
+  None of the five is reachable from OWS:
+  - `rand_os`, and `cloudabi`/`fuchsia-cprng` under it, back CSL's *key generation*
+    (`Bip32PrivateKey::generate_ed25519_bip32`, `PrivateKey::generate_*`), which OWS
+    never calls — the signer only ever uses `Bip32PrivateKey::from_bytes`, and every
+    OWS key comes from `ed25519-bip32` and `rand` in `ows-signer` (see
+    [§2.2](#22-master-key-generation-icarus)). `cloudabi` and `fuchsia-cprng` are in
+    the lockfile but do not build on any target OWS ships: they are `rand_os`'s
+    per-OS backends for CloudABI and Fuchsia.
+  - `clear_on_drop` is declared by CSL but never referenced anywhere in its source,
+    so it is compiled and never runs. The consequence is worth stating plainly, since
+    it is the opposite of what the dependency name suggests: CSL does **not** zeroize
+    the `Bip32PrivateKey` it holds, so the copy `Bip32PrivateKey::from_bytes` makes of
+    the key material outlives its buffer. OWS zeroizes what it owns — the
+    `SecretBytes`/`Zeroizing` buffer it decodes from is wiped on drop (see
+    [§2.6](#26-multi-credential-key-storage)) — but it cannot reach inside CSL's copy.
+  - `nodrop` is a pre-1.0 `ManuallyDrop` polyfill under `generic-array 0.8`, which
+    `pruefung` needs for the FNV-32a checksum in `emurgo-cardano-message-signing`.
+    That checksum only serves `SignedMessage::{to,from}_user_facing_encoding` (the
+    `cms_…` string format); OWS signs through `COSESign1Builder` and never calls
+    either, so the code path is not reached.
+
+  The revisit trigger is a CSL or message-signing release that drops them, or a
+  maintained fork; that would be a dependency bump with no change to OWS code.
 
 ## Implementation
 
@@ -1069,7 +1116,9 @@ Dependencies added:
   (`ows/crates/ows-signer/Cargo.toml`).
 - `reqwest = "0.12"` (blocking, `json`, `rustls-tls`, no default features) — Koios
   `tx_cbor` HTTP client used to resolve transaction inputs for the policy context
-  (`ows/crates/ows-signer/Cargo.toml`).
+  (`ows/crates/ows-signer/Cargo.toml`). This is the first network dependency in
+  `ows-signer`, the crate that holds key material; what it does and does not send is
+  spelled out under "What the RPC provider learns" in Security considerations.
 - `mockito = "1"` (dev-dependency) — mocks the Koios endpoints in the
   `make_transaction_context` and balance tests
   (`ows/crates/ows-signer/Cargo.toml`, `ows/crates/ows-pay/Cargo.toml`).

--- a/docs/cardano.md
+++ b/docs/cardano.md
@@ -133,9 +133,10 @@ drove a specific design decision later in this document:
    one.
 2. **Master key from entropy, not seed.** Most chains derive from the BIP-39
    *seed* (PBKDF2 over the mnemonic phrase). Cardano's Icarus scheme derives the
-   root key from the raw BIP-39 **entropy** (PBKDF2-HMAC-SHA512, empty password,
-   entropy as salt, 4096 iterations). Reusing the seed would yield addresses no
-   other Cardano wallet could reproduce.
+   root key from the raw BIP-39 **entropy** (PBKDF2-HMAC-SHA512, entropy as salt,
+   4096 iterations, and a password slot that OWS leaves empty — see
+   [§2.2](#22-master-key-generation-icarus)). Reusing the seed would yield
+   addresses no Icarus-scheme wallet could reproduce.
 3. **Two credentials per address.** A Shelley **base** address combines a payment
    credential (CIP-1852 `role = 0`) and a stake credential (`role = 2`), each at
    its own derivation path. OWS's "one path → one address" assumption does not
@@ -254,11 +255,17 @@ BIP-39 seed. Instead it follows the Cardano Icarus scheme
 1. Extract the raw BIP-39 **entropy** (checksum bits excluded) from the mnemonic.
    `Mnemonic::entropy()` was added for this purpose.
 2. `PBKDF2-HMAC-SHA512` with an **empty password**, the entropy as the **salt**,
-   `4096` iterations, producing a 96-byte output. The password slot is left empty
-   on purpose: Cardano software wallets (Eternl, Yoroi, …) pass no
-   spending password into this step, so filling it — for example with the BIP-39
-   passphrase — would derive a different root key and produce addresses no other
-   Cardano wallet could reproduce from the same mnemonic.
+   `4096` iterations, producing a 96-byte output. CIP-3 specifies the step as
+   `generateMasterKey(seed, password)` and publishes vectors for the same recovery
+   phrase both with no passphrase and with the passphrase `foo`, so the empty slot
+   is a choice rather than something the spec requires. OWS has nothing to put
+   there: it never accepts a BIP-39 passphrase (the `passphrase` it exposes is the
+   vault's encryption passphrase), and every derivation call site passes `""`. The
+   empty-password form is the one the published CIP-3 vector in the tests uses and
+   the one a wallet holding only the mnemonic reproduces. A non-empty password
+   derives a different root key and therefore a different set of addresses, so
+   supporting one would mean adding a parameter here and surfacing it as an
+   explicit choice — not changing this step.
 3. Normalize the result with `XPrv::normalize_bytes_force3rd` to obtain a valid
    master extended private key.
 
@@ -936,10 +943,14 @@ providers (e.g. Blockfrost).
   shape- and clamping-checked at import (see
   [§2.6](#26-multi-credential-key-storage)), so an unusable key surfaces at import
   time rather than as an opaque failure on first use.
-- **Icarus master key.** Uses the standard PBKDF2-HMAC-SHA512 (4096 iterations,
-  empty password, entropy as salt) and `normalize_bytes_force3rd`, matching
-  ecosystem wallets; deviating would produce incompatible (and potentially
-  unrecoverable-by-other-wallets) addresses.
+- **Icarus master key.** Uses PBKDF2-HMAC-SHA512 (4096 iterations, entropy as
+  salt) with an empty password, and `normalize_bytes_force3rd`. CIP-3 permits a
+  non-empty password and publishes a vector for one; OWS has no BIP-39 passphrase
+  to supply, so it uses the empty form — the one the published vector in the tests
+  pins, and the one a wallet holding only the mnemonic can reproduce. Any other
+  password, or deriving from the BIP-39 seed instead of the entropy, yields a
+  different root key and a different set of addresses, so it would have to be an
+  explicit and visible choice rather than a silent one.
 - **Non-hardened derivation.** BIP32-Ed25519 V2 permits non-hardened child keys.
   This is required for Cardano interoperability, but callers should remain aware
   that a non-hardened branch's xpub + a single child xprv can expose sibling keys;

--- a/docs/cardano.md
+++ b/docs/cardano.md
@@ -680,10 +680,12 @@ already checks against the same inputs, and deriving the number from resolved UT
 keeps the one trust model (see [§4.2](#42-parsing-and-input-resolution-koios-tx_cbor)).
 
 Collateral inputs are resolved in the **same** Koios batch as the spent inputs, so
-exposing them costs no extra request, and they are subject to the same fail-closed
-rule: a collateral input Koios cannot return aborts context construction. `chain_extra`
-is omitted entirely when a transaction declares no collateral, which is every
-non-script transaction.
+exposing them usually costs no extra request — the batch is deduplicated and chunked
+at ten hashes per `tx_cbor` call, so collateral adds a call only when its own unique
+hashes push the total past a multiple of ten — and they are subject to the same
+fail-closed rule: a collateral input Koios cannot return aborts context construction.
+`chain_extra` is omitted entirely when a transaction declares no collateral, which is
+every non-script transaction.
 
 A policy that caps outflow therefore has to read both lists and decide for itself
 whether to count the contingent one.

--- a/docs/cardano.md
+++ b/docs/cardano.md
@@ -571,12 +571,16 @@ to the configured RPC provider (Koios).
 
 Accordingly, `make_transaction_context` takes an `Option<&str>` RPC URL, and the
 `ows-lib` call sites that build the policy context — `sign_and_send`
-(`ops.rs`) and `sign_with_api_key` (`key_ops.rs`) — now resolve the Koios endpoint
-for Cardano and pass it through. Resolution reuses the generic precedence
+(`ops.rs`) and `sign_with_api_key` (`key_ops.rs`) — resolve the endpoint and pass
+it through. Which chains need one is a property of the signer,
+`ChainSigner::transaction_context_needs_rpc` (default `false`, `true` for
+`CardanoSigner`), rather than a `ChainType` match at each call site: the next chain
+whose context depends on network access overrides the method instead of extending
+two conditions. Resolution reuses the generic precedence
 (explicit override → config exact `chain_id` → config namespace → built-in
 default; see [§1.4](#14-rpc-configuration-koios-keyless)); `resolve_rpc_url` was
-made `pub(crate)`-visible for this. For every non-Cardano chain the URL stays
-`None`, so no network call is introduced anywhere else.
+made `pub(crate)`-visible for this. For every chain that does not ask for a URL it
+stays `None`, so no network call is introduced anywhere else.
 
 #### 4.2 Parsing and input resolution (Koios `tx_cbor`)
 
@@ -1024,7 +1028,8 @@ Components modified or added:
   deposits/refunds against the reward address and reports declared collateral under
   `chain_extra.collateral_effects`.
 - `ows/crates/ows-signer/src/traits.rs` — `sign_message` gains `address: Option<&str>`; new
-  default methods `verify_sign_message_address`, `default_derivation_paths`, and
+  default methods `verify_sign_message_address`, `transaction_context_needs_rpc`,
+  `default_derivation_paths`, and
   `encode_keys`; new `SignerError::AddressMismatch` and `SignerError::RpcError`.
   (`make_transaction_context` already existed as a default-empty hook; Cardano now
   overrides it.)

--- a/docs/cardano.md
+++ b/docs/cardano.md
@@ -533,7 +533,7 @@ deltas:
 ```rust
 pub struct TransactionEffect {
     pub address: String,
-    pub diff: Vec<(String, i64)>, // (asset_id, signed change)
+    pub diff: Vec<(String, String)>, // (asset_id, signed decimal change)
 }
 
 pub struct TransactionContext {
@@ -623,7 +623,8 @@ The signer builds two `address → (asset_id → amount)` maps and diffs them:
   same token nets out across inputs and outputs.
 
 For every address touched by either side, and every asset id it involves, the
-effect is `output_balance − input_balance` as a signed `i64`. Zero-diff assets and
+effect is `output_balance − input_balance`, computed in `i128` and rendered as a
+signed decimal string (see [§4.4](#44-why-amounts-are-strings)). Zero-diff assets and
 zero-diff addresses are dropped; the remaining `diff` entries are sorted by asset
 id and the `effects` list is sorted by address, so the context is deterministic
 (important for reproducible policy decisions and stable test vectors). A pure
@@ -633,6 +634,21 @@ negative fee.
 The result is returned as `TransactionContext { effects, raw_hex, data: None }` and
 handed to the policy engine, which passes it (as part of `PolicyContext`) to
 built-in rules and to executable policies over stdin.
+
+#### 4.4 Why amounts are strings
+
+`TransactionEffect.diff` carries each amount as a signed decimal **string**, not an
+integer. `TransactionEffect` lives in `ows-core` and is shared by every chain, so
+the type has to hold the widest smallest-unit any chain uses: lovelace fits an
+`i64` with room to spare, but wei overflows one above roughly 9.22 ETH, and a JSON
+integer above 2^53 does not survive `JSON.parse` in a policy written in
+JavaScript. A string has no ceiling in either place, and it matches the
+`String`-typed amounts already in the context (`spending.daily_total`, and the
+`value` field this replaced).
+
+Consumers parse it themselves: `int(...)` in Python, `BigInt(...)` in JavaScript.
+The subtraction that produces it runs in `i128`, so a native-asset quantity at the
+top of `u64` cannot wrap on the way out.
 
 ### 5. Address balance fetching
 

--- a/docs/cardano.md
+++ b/docs/cardano.md
@@ -109,10 +109,13 @@ Cardano introduces two additional, Cardano-specific dependencies:
   a full chain SDK into the key path.
 - **`cardano-serialization-lib` (CSL, 14.1.1)** — the canonical Cardano library
   for network parameters (`NetworkInfo`), address construction
-  (`BaseAddress`/`EnterpriseAddress`/`RewardAddress`, `Credential`), extended-key
-  helpers (`Bip32PrivateKey`), and CBOR transaction (de)serialization
-  (`FixedTransaction`, `make_vkey_witness`, `Vkeywitness`). It is used for network
-  parameters, Shelley address encoding, and transaction signing/witness encoding.
+  (`BaseAddress`/`EnterpriseAddress`/`RewardAddress`, `Credential`), public-key
+  hashing (`PublicKey`), witness construction (`Vkey`, `Ed25519Signature`,
+  `Vkeywitness`), and CBOR transaction (de)serialization (`FixedTransaction`). It
+  is used for network parameters, Shelley address encoding, and transaction
+  signing/witness encoding. Only public halves are handed to CSL: the secret stays
+  in `ed25519-bip32`'s `XPrv`, so CSL's private-key types are not used at all (see
+  [Security Considerations](#security-considerations)).
   Note CSL also pulls in `pbkdf2`, which we use directly for the Icarus master-key
   step.
 - **`emurgo-cardano-message-signing` (1.1.0)** — Emurgo's COSE companion to CSL,
@@ -380,13 +383,12 @@ Emurgo's `cardano-message-signing` companion crate.
 
 All signer methods accept the **key material** layout described in
 [§2.5](#25-chainsigner-integration): either a 192-byte payment `XPrv` ‖ stake
-`XPrv`, or a bare 96-byte payment `XPrv`. Two small private helpers slice this
+`XPrv`, or a bare 96-byte payment `XPrv`. One small private helper slices this
 buffer:
 
-- `payment_bip32(key_material)` → payment `Bip32PrivateKey` (accepts 96 or 192
-  bytes; anything else is a clear `InvalidPrivateKey` error).
-- `stake_bip32(key_material)` → `Some(stake)` when 192 bytes are supplied, `None`
-  for the 96-byte payment-only case.
+- `decode_keys(key_material)` → `(payment XPrv, Option<stake XPrv>)`. It accepts 96
+  or 192 bytes — anything else is a clear `InvalidPrivateKey` error — and yields
+  `Some(stake)` only for the 192-byte layout.
 
 #### 3.1 Shelley address encoding
 
@@ -398,7 +400,7 @@ buffer:
 | payment only (96 B)     | enterprise   | `enterprise_address_bech32`     | `addr1v…`      |
 | stake only (signing)    | reward       | `reward_address_bech32`         | `stake1…`      |
 
-Each helper hashes the relevant public key (`to_public().to_raw_key().hash()`),
+Each helper hashes the relevant public key (`public_key(xprv)?.hash()`),
 wraps it in a `Credential::from_keyhash`, builds the matching CSL address type
 (`BaseAddress` / `EnterpriseAddress` / `RewardAddress`) bound to the signer's
 `network_id`, and bech32-encodes it. The reward address is not produced by
@@ -454,7 +456,7 @@ COSE `Sig_structure`, not the raw message. The flow:
 transactions — input selection, fees, and change are the caller's responsibility):
 
 1. Parse the bytes into a CSL `FixedTransaction` (`InvalidTransaction` on failure).
-2. Always create a payment witness with `make_vkey_witness(tx_hash, payment_raw_key)`.
+2. Always create a payment witness with `vkey_witness(tx_hash, payment_xprv)`.
 3. Determine whether the body needs a **stake** signature. Two independent sources
    are consulted:
    - **Structural requirements** (`stake_key_hashes_required_by_body`) — the key
@@ -942,7 +944,20 @@ providers (e.g. Blockfrost).
   the decoded hex of an explicitly supplied key, the `KeyPair` fields and the JSON
   blob they are serialized into, and the bit accumulator and phrase copy inside
   `Mnemonic::entropy()` — all are `Zeroizing`/explicitly wiped rather than left to
-  the allocator.
+  the allocator. The Cardano signer also keeps the secret out of CSL entirely: it
+  holds an `ed25519-bip32` `XPrv`, which zeroizes in its own `Drop` and signs out of
+  that buffer, because CSL's `PrivateKey` would copy the extended secret into an
+  allocation nothing wipes (see the `clear_on_drop` note under *Unmaintained
+  transitive dependencies* below). What the `XPrv` does not wipe is the stack: the
+  copies `from_slice_verified` makes on the way in, and the moved-from slot left
+  when an `XPrv` is returned by value, run no `Drop`. Wiping those would take a
+  by-reference constructor `ed25519-bip32` does not offer.
+- **Never format an `XPrv`.** Unlike CSL's key types — `Bip32PrivateKey` has no
+  `Debug`, and `chain_crypto::SecretKey`'s is `#[cfg(test)]`-gated — `XPrv`
+  implements both `Debug` and `Display` unconditionally, and both `hex::encode` the
+  full 96 bytes into a `String` nothing zeroizes. No code formats one today; a
+  `{:?}` added to a log line or an error message later is all it would take, so
+  treat the two impls as unusable.
 - **Malformed imported keys are rejected.** A user-supplied `ed25519_bip32` key is
   shape- and clamping-checked at import (see
   [§2.6](#26-multi-credential-key-storage)), so an unusable key surfaces at import
@@ -1030,18 +1045,27 @@ providers (e.g. Blockfrost).
   None of the five is reachable from OWS:
   - `rand_os`, and `cloudabi`/`fuchsia-cprng` under it, back CSL's *key generation*
     (`Bip32PrivateKey::generate_ed25519_bip32`, `PrivateKey::generate_*`), which OWS
-    never calls — the signer only ever uses `Bip32PrivateKey::from_bytes`, and every
+    never calls — the signer constructs no CSL private key at all, and every
     OWS key comes from `ed25519-bip32` and `rand` in `ows-signer` (see
     [§2.2](#22-master-key-generation-icarus)). `cloudabi` and `fuchsia-cprng` are in
     the lockfile but do not build on any target OWS ships: they are `rand_os`'s
     per-OS backends for CloudABI and Fuchsia.
   - `clear_on_drop` is declared by CSL but never referenced anywhere in its source,
     so it is compiled and never runs. The consequence is worth stating plainly, since
-    it is the opposite of what the dependency name suggests: CSL does **not** zeroize
-    the `Bip32PrivateKey` it holds, so the copy `Bip32PrivateKey::from_bytes` makes of
-    the key material outlives its buffer. OWS zeroizes what it owns — the
+    it is the opposite of what the dependency name suggests: CSL zeroizes none of its
+    own key types. `Bip32PrivateKey` escapes the consequence only because the `XPrv`
+    it wraps wipes itself (`ed25519-bip32`'s `Drop` calls `securemem::zero`), but
+    `PrivateKey` — what `Bip32PrivateKey::to_raw_key` returns, and what CSL's signing
+    helpers take — holds an `ExtendedPriv([u8; 64])` with no `Drop` at all. Signing
+    through CSL would therefore leave a copy of the 64-byte extended secret in freed
+    memory on every call. Key *hashing* never had this problem: it goes through
+    `Bip32PublicKey::to_raw_key`, which yields a `PublicKey` and touches no secret.
+    OWS never constructs a CSL private key: `decode_keys` keeps the secret in an
+    `XPrv`, `XPrv::sign` signs out of that buffer, and only the 32-byte public key is
+    handed to CSL (see
+    [§3](#3-transaction-and-message-signing-chain-plugin-interface)). The
     `SecretBytes`/`Zeroizing` buffer it decodes from is wiped on drop (see
-    [§2.6](#26-multi-credential-key-storage)) — but it cannot reach inside CSL's copy.
+    [§2.6](#26-multi-credential-key-storage)).
   - `nodrop` is a pre-1.0 `ManuallyDrop` polyfill under `generic-array 0.8`, which
     `pruefung` needs for the FNV-32a checksum in `emurgo-cardano-message-signing`.
     That checksum only serves `SignedMessage::{to,from}_user_facing_encoding` (the

--- a/docs/cardano.md
+++ b/docs/cardano.md
@@ -235,9 +235,25 @@ RPC resolution reuses the generic precedence already in place: explicit override
 #### 1.5 Signer resolution
 
 `signer_for_chain` constructs `CardanoSigner::from_chain_id(chain.chain_id)`, which
-selects network parameters from the CAIP-2 id (`cip34:0-1` → preprod, `cip34:0-2`
-→ preview, anything else → mainnet). Network parameters come from
+selects network parameters from the CAIP-2 id — `cip34:1-764824073` → mainnet,
+`cip34:0-1` → preprod, `cip34:0-2` → preview — and **rejects any other reference**
+with `SignerError::UnsupportedChain`. Network parameters come from
 `cardano-serialization-lib`'s `NetworkInfo`.
+
+Rejecting is not a formality: `parse_chain` accepts any reference under a known
+namespace (`cip34:0-999` parses), so an unsupported network does reach this
+constructor. On EVM the chain id is signed into the transaction, so a wrong network
+cannot yield a signature that is valid elsewhere; on Cardano the network lives in the
+address header byte and is chosen here, so a fallback to mainnet would derive mainnet
+addresses and produce real mainnet signatures for a caller who asked for a testnet.
+A rejected reference is never signed with, transmitted or turned into an address. How
+early it fails depends on the path: the paths that build a transaction context
+(`sign_with_api_key`, `sign_and_send` in agent mode, `sign_encode_and_broadcast`,
+`sign_hash_with_credential`) construct the signer before resolving an RPC URL, before
+the policy context and before the key; the owner-mode signing paths and the api-key
+message and hash paths derive the key first and reject after it.
+This is why `signer_for_chain` and `signer_for_chain_type` return
+`Result<Box<dyn ChainSigner>, SignerError>`.
 
 ### 2. Key derivation and cryptography
 
@@ -1173,7 +1189,10 @@ Implemented and passing for these deliverables:
   preview).
 - **Config** (`config.rs`): default RPC lookups for all three Koios endpoints.
 - **Signer** (`cardano.rs`): CIP-1852 path construction; chain type/curve/coin
-  type; default path equals payment leaf.
+  type; default path equals payment leaf; `from_chain_id` maps the three known
+  references to their network ids and rejects every other one, with
+  `signer_for_chain` propagating that rejection for a `cip34:` id `parse_chain`
+  accepted.
 - **Address encoding** (`cardano.rs`): mainnet **base** address from 12- and
   24-word mnemonics (via `default_derivation_paths` and `encode_keys`) against fixed
   `addr1q…` vectors;

--- a/docs/policy-engine-implementation.md
+++ b/docs/policy-engine-implementation.md
@@ -71,11 +71,11 @@ addresses:
 
     import json, sys
     ctx = json.load(sys.stdin)
-    tx = ctx.get("transaction")
-    if tx is None:  # sign_typed_data: no transaction to cap
-        json.dump({"allow": False, "reason": "no transaction context"}, sys.stdout)
+    if ctx["request_type"] == "sign_typed_data":  # no transaction to cap
+        json.dump({"allow": False, "reason": "typed data not permitted"}, sys.stdout)
         sys.exit(0)
 
+    tx = ctx["transaction"]
     owned = {"addr1qx2f..."}
     limit = 5_000_000  # 5 ADA
     out = -sum(int(amount)
@@ -106,7 +106,8 @@ Reference it in the policy file:
 | chain_id | CAIP-2 chain ID (e.g. eip155:8453) |
 | wallet_id | Wallet UUID |
 | api_key_id | API key UUID |
-| transaction | Absent for sign_typed_data; see 03-policy-engine.md |
+| request_type | sign_transaction, sign_message, sign_hash or sign_typed_data; always present |
+| transaction | Absent for sign_typed_data; branch on request_type, not on this field's absence |
 | transaction.effects | Per-address asset movement; empty unless the chain's signer implements flow analysis (Cardano today) |
 | transaction.effects[].diff | [asset, amount] pairs; amount is a signed decimal string in the smallest unit |
 | transaction.chain_extra | Chain-specific detail effects cannot carry; present only when a chain fills it |
@@ -123,6 +124,7 @@ replaces them.
 Test executable policies without real signing:
 
     echo '{"chain_id": "cip34:1-764824073", "wallet_id": "test", "api_key_id": "test",
+      "request_type": "sign_transaction",
       "transaction": {"raw_hex": "84a4",
         "effects": [{"address": "addr1qx2f...", "diff": [["lovelace", "-6000000"]]}]},
       "spending": {"daily_total": "0", "date": "2026-01-01"},

--- a/docs/policy-engine-implementation.md
+++ b/docs/policy-engine-implementation.md
@@ -66,13 +66,23 @@ All attached policies must allow (AND semantics):
 Use executables for spending limits, on-chain simulation, or external API calls.
 The executable receives PolicyContext JSON on stdin and must write PolicyResult to stdout.
 
-Minimal Python example:
+Minimal Python example — cap the ADA one transaction moves out of the wallet's own
+addresses:
 
     import json, sys
     ctx = json.load(sys.stdin)
-    value = int(ctx["transaction"].get("value", "0"))
-    limit = 10_000_000_000_000_000  # 0.01 ETH
-    if value > limit:
+    tx = ctx.get("transaction")
+    if tx is None:  # sign_typed_data: no transaction to cap
+        json.dump({"allow": False, "reason": "no transaction context"}, sys.stdout)
+        sys.exit(0)
+
+    owned = {"addr1qx2f..."}
+    limit = 5_000_000  # 5 ADA
+    out = -sum(int(amount)
+               for effect in tx["effects"] if effect["address"] in owned
+               for asset, amount in effect["diff"]
+               if asset == "lovelace" and int(amount) < 0)
+    if out > limit:
         json.dump({"allow": False, "reason": "Value exceeds limit"}, sys.stdout)
     else:
         json.dump({"allow": True}, sys.stdout)
@@ -81,10 +91,10 @@ Reference it in the policy file:
 
     {
       "id": "value-limit",
-      "name": "Max 0.01 ETH per transaction",
+      "name": "Max 5 ADA per transaction",
       "version": 1,
       "created_at": "2026-01-01T00:00:00Z",
-      "rules": [{ "type": "allowed_chains", "chain_ids": ["eip155:8453"] }],
+      "rules": [{ "type": "allowed_chains", "chain_ids": ["cip34:1-764824073"] }],
       "executable": "/home/user/.ows/plugins/policies/value-limit.py",
       "action": "deny"
     }
@@ -96,20 +106,25 @@ Reference it in the policy file:
 | chain_id | CAIP-2 chain ID (e.g. eip155:8453) |
 | wallet_id | Wallet UUID |
 | api_key_id | API key UUID |
-| transaction.to | Recipient address (EVM) |
-| transaction.value | Value in wei as string |
-| transaction.data | Calldata hex |
-| transaction.raw_hex | Raw unsigned transaction hex |
+| transaction | Absent for sign_typed_data; see 03-policy-engine.md |
+| transaction.effects | Per-address asset movement; empty unless the chain's signer implements flow analysis (Cardano today) |
+| transaction.effects[].diff | [asset, amount] pairs; amount is a signed decimal string in the smallest unit |
+| transaction.chain_extra | Chain-specific detail effects cannot carry; present only when a chain fills it |
+| transaction.raw_hex | Raw unsigned payload hex |
 | spending.daily_total | Cumulative value signed today (wei) |
 | timestamp | ISO-8601 signing request time |
+
+`transaction.to` and `transaction.value` were documented here previously. Neither was
+ever populated by any chain, so a policy reading them always saw `null`; `effects`
+replaces them.
 
 ## 6. Testing Policies
 
 Test executable policies without real signing:
 
-    echo '{"chain_id": "eip155:8453", "wallet_id": "test", "api_key_id": "test",
-      "transaction": {"to": "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C",
-        "value": "5000000000000000", "raw_hex": "0x", "data": "0x"},
+    echo '{"chain_id": "cip34:1-764824073", "wallet_id": "test", "api_key_id": "test",
+      "transaction": {"raw_hex": "84a4",
+        "effects": [{"address": "addr1qx2f...", "diff": [["lovelace", "-6000000"]]}]},
       "spending": {"daily_total": "0", "date": "2026-01-01"},
       "timestamp": "2026-01-01T00:00:00Z"}' | python3 value-limit.py
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,7 +20,7 @@ pip install open-wallet-standard           # Python
 
 ## Create a wallet
 
-A single command derives addresses for every supported chain — EVM, Solana, Sui, Bitcoin, Cosmos, Tron, and TON.
+A single command derives addresses for every chain family the implementation registers (15 accounts in the reference build — EVM through Cardano).
 
 ```bash
 ows wallet create --name "agent-treasury"
@@ -35,6 +35,9 @@ Created wallet 3198bc9c-...
   tron:mainnet    TKLm...    m/44'/195'/0'/0/0
   ton:mainnet     UQ...      m/44'/607'/0'
   sui:mainnet     0x...      m/44'/784'/0'/0'/0'
+  cip34:1-764824073 addr1...       payment m/1852'/1815'/0'/0/0 + stake m/1852'/1815'/0'/2/0
+  cip34:0-1         addr_test1...  same paths; Pre-production testnet
+  cip34:0-2         addr_test1...  same paths; Preview testnet
 ```
 
 ## Fund the wallet

--- a/docs/sdk-cli.md
+++ b/docs/sdk-cli.md
@@ -270,7 +270,9 @@ ows sign message --wallet "my-wallet" --chain 8453 --message "hello world"
 | `--chain <CHAIN>` | Chain name (`ethereum`, `base`, `arbitrum`, …), CAIP-2 ID (`eip155:8453`), or bare EVM chain ID (`8453`) |
 | `--message <MSG>` | Message to sign |
 | `--encoding <ENC>` | Message encoding: `utf8` (default) or `hex` |
+| `--address <ADDR>` | Address that will be used to sign the message (e.g. stake/base/enterprise address on Cardano) |
 | `--typed-data <JSON>` | EIP-712 typed data JSON (EVM only) |
+| `--index <N>` | Account index (HD derivation; default `0`) |
 | `--json` | Output structured JSON |
 
 ### `ows sign tx`

--- a/docs/sdk-cli.md
+++ b/docs/sdk-cli.md
@@ -61,10 +61,11 @@ echo "4c0883a691..." | ows wallet import --name "from-evm" --private-key
 # Import an Ed25519 key (e.g. from Solana)
 echo "9d61b19d..." | ows wallet import --name "from-sol" --private-key --chain solana
 
-# Import explicit keys for both curves via environment variables
+# Import explicit keys for all three curves via environment variables
 OWS_SECP256K1_KEY="4c0883a691..." \
 OWS_ED25519_KEY="9d61b19d..." \
-  ows wallet import --name "both"
+OWS_ED25519_BIP32_KEY="cafe..." \
+  ows wallet import --name "all-curves"
 ```
 
 | Flag | Description |
@@ -76,8 +77,9 @@ OWS_ED25519_KEY="9d61b19d..." \
 | `--index <N>` | Account index for HD derivation (mnemonic only, default: 0) |
 | `OWS_SECP256K1_KEY` | Explicit secp256k1 private key via environment variable |
 | `OWS_ED25519_KEY` | Explicit Ed25519 private key via environment variable |
+| `OWS_ED25519_BIP32_KEY` | Explicit Ed25519-BIP32 extended private key (hex) via environment variable |
 
-Private key imports generate all 9 chain accounts: the provided key is used for its curve's chains, and a random key is generated for the other curve. Use `OWS_SECP256K1_KEY` and `OWS_ED25519_KEY` together to supply both keys explicitly.
+Private key imports generate all 13 chain-family accounts: the provided key is used for its curve's chains, and random keys fill the other curves (secp256k1, Ed25519, Ed25519-BIP32). Use `OWS_SECP256K1_KEY`, `OWS_ED25519_KEY`, and `OWS_ED25519_BIP32_KEY` together to supply all three curves explicitly.
 
 ### `ows wallet export`
 
@@ -88,7 +90,7 @@ ows wallet export --wallet "my-wallet"
 ```
 
 - Mnemonic wallets output the phrase.
-- Private key wallets output JSON: `{"secp256k1":"hex...","ed25519":"hex..."}`.
+- Private key wallets output JSON: `{"secp256k1":"hex...","ed25519":"hex...","ed25519_bip32":"hex..."}`.
 
 If the wallet is passphrase-protected, you will be prompted.
 
@@ -373,6 +375,8 @@ ows fund balance --wallet "my-wallet" --chain base
 |------|-------------|
 | `--wallet <NAME>` | Wallet name (required) |
 | `--chain <CHAIN>` | Chain to query (required) |
+
+For **Cardano**, balances use the RPC URL from config
 
 ## System Commands
 

--- a/docs/sdk-node.md
+++ b/docs/sdk-node.md
@@ -243,7 +243,7 @@ console.log(wallet3.accounts.length); // => 8
 
 ### Signing
 
-#### `signMessage(wallet, chain, message, passphrase?, encoding?, index?, vaultPath?)`
+#### `signMessage(wallet, chain, message, passphrase?, encoding?, index?, address?, vaultPath?)`
 
 Sign a message with chain-specific formatting.
 
@@ -261,6 +261,7 @@ console.log(result.recoveryId); // 0 or 1
 | `passphrase` | `string` | `undefined` | Decryption passphrase |
 | `encoding` | `string` | `"utf8"` | `"utf8"` or `"hex"` |
 | `index` | `number` | `0` | Account index |
+| `address` | `string` | `undefined` | Optional address that will be used to sign the message (e.g. stake/base/enterprise address on Cardano) |
 | `vaultPath` | `string` | `~/.ows` | Custom vault directory root |
 
 **Returns:** `SignResult`
@@ -300,7 +301,7 @@ console.log(result.signature);
 console.log(result.recoveryId); // 0 or 1
 ```
 
-#### `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, vaultPath?)`
+#### `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, address?, vaultPath?)`
 
 Sign EIP-712 typed structured data (EVM only).
 
@@ -333,6 +334,7 @@ console.log(result.recoveryId); // 27 or 28
 | `typedDataJson` | `string` | &mdash; | JSON string of EIP-712 typed data |
 | `passphrase` | `string` | `undefined` | Decryption passphrase |
 | `index` | `number` | `0` | Account index |
+| `address` | `string` | `undefined` | Optional address that will be used to sign the message (e.g. stake/base/enterprise address on Cardano) |
 | `vaultPath` | `string` | `~/.ows` | Custom vault directory root |
 
 **Returns:** `SignResult`

--- a/docs/sdk-node.md
+++ b/docs/sdk-node.md
@@ -96,7 +96,7 @@ const solAddr = deriveAddress(mnemonic, "solana");
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mnemonic` | `string` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `string` | &mdash; | `"evm"`, `"solana"`, `"xrpl"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` |
+| `chain` | `string` | &mdash; | `"evm"`, `"solana"`, `"xrpl"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"`, `"cardano"` |
 | `index` | `number` | `0` | Account index in derivation path |
 
 **Returns:** `string`
@@ -120,6 +120,9 @@ console.log(wallet.accounts);
 //   { chainId: "sui:mainnet", address: "0x...", derivationPath: "m/44'/784'/0'/0'/0'" },
 //   { chainId: "xrpl:mainnet", address: "r...", derivationPath: "m/44'/144'/0'/0/0" },
 //   { chainId: "fil:mainnet", address: "f1...", derivationPath: "m/44'/461'/0'/0/0" },
+//   { chainId: "cip34:1-764824073", address: "addr1...", derivationPath: "m/1852'/1815'/0'/0/0" }, // payment; stake m/1852'/1815'/0'/2/0
+//   { chainId: "cip34:0-1", address: "addr_test1...", derivationPath: "m/1852'/1815'/0'/0/0" }, // Cardano Pre-production
+//   { chainId: "cip34:0-2", address: "addr_test1...", derivationPath: "m/1852'/1815'/0'/0/0" }, // Cardano Preview
 // ]
 ```
 
@@ -174,7 +177,7 @@ renameWallet("old-name", "new-name");
 Export a wallet's secret.
 
 - **Mnemonic wallets** return the phrase string.
-- **Private key wallets** return a JSON string with both curve keys:
+- **Private key wallets** return a JSON string with per-curve key material:
 
 ```javascript
 // Mnemonic wallet
@@ -184,7 +187,7 @@ const phrase = exportWallet("mn-wallet");
 // Private key wallet
 const keysJson = exportWallet("pk-wallet");
 const keys = JSON.parse(keysJson);
-// => { secp256k1: "4c0883a6...", ed25519: "9d61b19d..." }
+// => { secp256k1: "4c0883a6...", ed25519: "9d61b19d...", ed25519_bip32: "..." }
 ```
 
 **Returns:** `string`
@@ -193,7 +196,7 @@ const keys = JSON.parse(keysJson);
 
 #### `importWalletMnemonic(name, mnemonic, passphrase?, index?, vaultPath?)`
 
-Import a wallet from a BIP-39 mnemonic. Derives all 9 chain accounts via HD paths.
+Import a wallet from a BIP-39 mnemonic. Derives all 13 chain-family accounts via HD paths.
 
 ```javascript
 const wallet = importWalletMnemonic("imported", "goose puzzle decorate ...");
@@ -201,43 +204,45 @@ const wallet = importWalletMnemonic("imported", "goose puzzle decorate ...");
 
 **Returns:** `WalletInfo`
 
-#### `importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?)`
+#### `importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?, ed25519Bip32Key?)`
 
-Import a wallet from a hex-encoded private key. All 9 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
+Import a wallet from a hex-encoded private key. All registered chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curves.
 
 The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
 
-Alternatively, provide explicit keys for each curve via `secp256k1Key` and `ed25519Key`. When both are given, `privateKeyHex` and `chain` are ignored.
+Alternatively, provide explicit keys for each curve via `secp256k1Key`, `ed25519Key`, and `ed25519Bip32Key`. When all are given, `privateKeyHex` and `chain` are ignored.
 
 ```javascript
-// Import an EVM private key — generates a random Ed25519 key for Solana/Sui/TON
+// Import an EVM private key — generates a random Ed25519 key for Solana/Sui/TON and a random Ed25519Bip32 key for Cardano
 const wallet = importWalletPrivateKey("from-evm", "4c0883a691...");
-console.log(wallet.accounts.length); // => 9
+console.log(wallet.accounts.length); // => 15
 
-// Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
+// Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc and a random Ed25519Bip32 for Cardano.
 const wallet2 = importWalletPrivateKey(
   "from-solana", "9d61b19d...", undefined, undefined, "solana"
 );
-console.log(wallet2.accounts.length); // => 8
+console.log(wallet2.accounts.length); // => 15
 
-// Import explicit keys for both curves
+// Import explicit keys for all curves
 const wallet3 = importWalletPrivateKey(
-  "both-keys", "", undefined, undefined, undefined,
+  "all-keys", "", undefined, undefined, undefined,
   "4c0883a691...",  // secp256k1 key
-  "9d61b19d..."     // ed25519 key
+  "9d61b19d...",    // ed25519 key
+  "cafe..."         // ed25519Bip32 key
 );
-console.log(wallet3.accounts.length); // => 8
+console.log(wallet3.accounts.length); // => 15
 ```
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `name` | `string` | &mdash; | Wallet name |
-| `privateKeyHex` | `string` | &mdash; | Hex-encoded private key (with or without `0x` prefix). Ignored when both curve keys are provided. |
+| `privateKeyHex` | `string` | &mdash; | Hex-encoded private key (with or without `0x` prefix). Ignored when all three curve keys (`secp256k1Key`, `ed25519Key`, and `ed25519Bip32Key`) are provided. |
 | `passphrase` | `string` | `undefined` | Encryption passphrase |
 | `vaultPath` | `string` | `~/.ows` | Custom vault directory root |
-| `chain` | `string` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"` (Ed25519) |
-| `secp256k1Key` | `string` | `undefined` | Explicit secp256k1 private key (hex). Overrides random generation for secp256k1 chains. |
-| `ed25519Key` | `string` | `undefined` | Explicit Ed25519 private key (hex). Overrides random generation for Ed25519 chains. |
+| `chain` | `string` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"` (Ed25519) or `"cardano"` (Ed25519-BIP32) |
+| `secp256k1Key` | `string` | `undefined` | Explicit secp256k1 private key (hex). With `ed25519Key`, fills that curve; otherwise overrides random secp256k1 when using a primary `privateKeyHex`. |
+| `ed25519Key` | `string` | `undefined` | Explicit Ed25519 private key (hex). Same pairing rules as `secp256k1Key`. |
+| `ed25519Bip32Key` | `string` | `undefined` | Explicit Ed25519-BIP32 extended private key, 96/192 bytes as hex. Random if omitted. |
 
 **Returns:** `WalletInfo`
 

--- a/docs/sdk-node.md
+++ b/docs/sdk-node.md
@@ -248,7 +248,7 @@ console.log(wallet3.accounts.length); // => 15
 
 ### Signing
 
-#### `signMessage(wallet, chain, message, passphrase?, encoding?, index?, address?, vaultPath?)`
+#### `signMessage(wallet, chain, message, passphrase?, encoding?, index?, vaultPath?, address?)`
 
 Sign a message with chain-specific formatting.
 
@@ -266,8 +266,8 @@ console.log(result.recoveryId); // 0 or 1
 | `passphrase` | `string` | `undefined` | Decryption passphrase |
 | `encoding` | `string` | `"utf8"` | `"utf8"` or `"hex"` |
 | `index` | `number` | `0` | Account index |
-| `address` | `string` | `undefined` | Optional address that will be used to sign the message (e.g. stake/base/enterprise address on Cardano) |
 | `vaultPath` | `string` | `~/.ows` | Custom vault directory root |
+| `address` | `string` | `undefined` | Optional address that will be used to sign the message (e.g. stake/base/enterprise address on Cardano) |
 
 **Returns:** `SignResult`
 
@@ -306,7 +306,7 @@ console.log(result.signature);
 console.log(result.recoveryId); // 0 or 1
 ```
 
-#### `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, address?, vaultPath?)`
+#### `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, vaultPath?, address?)`
 
 Sign EIP-712 typed structured data (EVM only).
 
@@ -339,8 +339,8 @@ console.log(result.recoveryId); // 27 or 28
 | `typedDataJson` | `string` | &mdash; | JSON string of EIP-712 typed data |
 | `passphrase` | `string` | `undefined` | Decryption passphrase |
 | `index` | `number` | `0` | Account index |
-| `address` | `string` | `undefined` | Optional address that will be used to sign the message (e.g. stake/base/enterprise address on Cardano) |
 | `vaultPath` | `string` | `~/.ows` | Custom vault directory root |
+| `address` | `string` | `undefined` | Optional address that will be used to sign the message (e.g. stake/base/enterprise address on Cardano) |
 
 **Returns:** `SignResult`
 

--- a/docs/sdk-python.md
+++ b/docs/sdk-python.md
@@ -210,7 +210,7 @@ print(len(wallet["accounts"]))  # => 9
 
 ### Signing
 
-#### `sign_message(wallet, chain, message, passphrase=None, encoding=None, index=None, vault_path=None)`
+#### `sign_message(wallet, chain, message, passphrase=None, encoding=None, index=None, address=None, vault_path=None)`
 
 Sign a message with chain-specific formatting.
 
@@ -251,7 +251,7 @@ print(result["signature"])
 print(result["recovery_id"])  # 0 or 1
 ```
 
-#### `sign_typed_data(wallet, chain, typed_data_json, passphrase=None, index=None, vault_path=None)`
+#### `sign_typed_data(wallet, chain, typed_data_json, passphrase=None, index=None, address=None, vault_path=None)`
 
 Sign EIP-712 typed structured data (EVM only).
 

--- a/docs/sdk-python.md
+++ b/docs/sdk-python.md
@@ -94,7 +94,7 @@ sol_addr = derive_address(mnemonic, "solana")
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mnemonic` | `str` | &mdash; | BIP-39 mnemonic phrase |
-| `chain` | `str` | &mdash; | `"evm"`, `"solana"`, `"xrpl"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"ton"`, `"spark"`, `"filecoin"` |
+| `chain` | `str` | &mdash; | `"evm"`, `"solana"`, `"xrpl"`, `"sui"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"ton"`, `"spark"`, `"filecoin"`, `"cardano"` |
 | `index` | `int` | `0` | Account index in derivation path |
 
 ### Wallet Management
@@ -147,7 +147,7 @@ rename_wallet("old-name", "new-name")
 Export a wallet's secret.
 
 - **Mnemonic wallets** return the phrase string.
-- **Private key wallets** return a JSON string with both curve keys.
+- **Private key wallets** return a JSON string with per-curve key material (`secp256k1`, `ed25519`, `ed25519_bip32`).
 
 ```python
 # Mnemonic wallet
@@ -157,56 +157,58 @@ phrase = export_wallet("mn-wallet")
 # Private key wallet
 import json
 keys = json.loads(export_wallet("pk-wallet"))
-# => {"secp256k1": "4c0883a6...", "ed25519": "9d61b19d..."}
+# => {"secp256k1": "4c0883a6...", "ed25519": "9d61b19d...", "ed25519_bip32": "..."}
 ```
 
 ### Import
 
 #### `import_wallet_mnemonic(name, mnemonic, passphrase=None, index=None, vault_path=None)`
 
-Import a wallet from a BIP-39 mnemonic. Derives all 9 chain accounts via HD paths.
+Import a wallet from a BIP-39 mnemonic. Derives all universal-wallet accounts via HD paths (13 chain families plus Cardano Preprod and Preview).
 
 ```python
 wallet = import_wallet_mnemonic("imported", "goose puzzle decorate ...")
 ```
 
-#### `import_wallet_private_key(name, private_key_hex, chain=None, passphrase=None, vault_path=None, secp256k1_key=None, ed25519_key=None)`
+#### `import_wallet_private_key(name, private_key_hex, chain=None, passphrase=None, vault_path=None, secp256k1_key=None, ed25519_key=None, ed25519_bip32_key=None)`
 
-Import a wallet from a hex-encoded private key. All 9 chains are supported: the provided key is used for its curve's chains, and a random key is generated for the other curve.
+Import a wallet from a hex-encoded private key. All chain families are supported (15 accounts, including Cardano Preprod and Preview): the provided key is used for its curve's chains, and random keys are generated for the other curves.
 
 The optional `chain` parameter specifies which chain the key originates from to determine the curve. Defaults to `"evm"` (secp256k1).
 
-Alternatively, provide explicit keys for each curve via `secp256k1_key` and `ed25519_key`. When both are given, `private_key_hex` and `chain` are ignored.
+Alternatively, provide explicit keys for each curve via `secp256k1_key`, `ed25519_key`, and `ed25519_bip32_key`. When all are given, `private_key_hex` and `chain` are ignored.
 
 ```python
-# Import an EVM private key — generates a random Ed25519 key for Solana/Sui/TON
+# Import an EVM private key — generates random Ed25519 and Ed25519-BIP32 keys for other curves
 wallet = import_wallet_private_key("from-evm", "4c0883a691...")
-print(len(wallet["accounts"]))  # => 9
+print(len(wallet["accounts"]))  # => 15
 
-# Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc.
+# Import a Solana private key — generates a random secp256k1 key for EVM/BTC/etc and Ed25519-BIP32 for Cardano.
 wallet = import_wallet_private_key(
     "from-solana", "9d61b19d...", chain="solana"
 )
-print(len(wallet["accounts"]))  # => 9
+print(len(wallet["accounts"]))  # => 15
 
-# Import explicit keys for both curves
+# Import explicit keys for all curves
 wallet = import_wallet_private_key(
-    "both-keys", "",
+    "all-keys", "",
     secp256k1_key="4c0883a691...",
-    ed25519_key="9d61b19d..."
+    ed25519_key="9d61b19d...",
+    ed25519_bip32_key="cafe..."
 )
-print(len(wallet["accounts"]))  # => 9
+print(len(wallet["accounts"]))  # => 15
 ```
 
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `name` | `str` | &mdash; | Wallet name |
-| `private_key_hex` | `str` | &mdash; | Hex-encoded private key. Ignored when both curve keys are provided. |
-| `chain` | `str` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"` (Ed25519) |
+| `private_key_hex` | `str` | &mdash; | Hex-encoded private key. Ignored when all three curve keys (`secp256k1Key`, `ed25519Key`, and `ed25519Bip32Key`) are provided. |
+| `chain` | `str` | `"evm"` | Source chain: `"evm"`, `"bitcoin"`, `"cosmos"`, `"tron"`, `"filecoin"` (secp256k1) or `"solana"`, `"sui"`, `"ton"` (Ed25519) or `"cardano"` (Ed25519-BIP32) |
 | `passphrase` | `str` | `None` | Encryption passphrase |
 | `vault_path` | `str` | `None` | Custom vault directory |
 | `secp256k1_key` | `str` | `None` | Explicit secp256k1 private key (hex) |
 | `ed25519_key` | `str` | `None` | Explicit Ed25519 private key (hex) |
+| `ed25519_bip32_key` | `str` | `None` | Explicit Ed25519-BIP32 private key (hex) |
 
 ### Signing
 

--- a/docs/sdk-python.md
+++ b/docs/sdk-python.md
@@ -212,7 +212,7 @@ print(len(wallet["accounts"]))  # => 15
 
 ### Signing
 
-#### `sign_message(wallet, chain, message, passphrase=None, encoding=None, index=None, address=None, vault_path=None)`
+#### `sign_message(wallet, chain, message, passphrase=None, encoding=None, index=None, vault_path=None, address=None)`
 
 Sign a message with chain-specific formatting.
 
@@ -253,7 +253,7 @@ print(result["signature"])
 print(result["recovery_id"])  # 0 or 1
 ```
 
-#### `sign_typed_data(wallet, chain, typed_data_json, passphrase=None, index=None, address=None, vault_path=None)`
+#### `sign_typed_data(wallet, chain, typed_data_json, passphrase=None, index=None, vault_path=None, address=None)`
 
 Sign EIP-712 typed structured data (EVM only).
 

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -38,6 +38,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +254,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+
+[[package]]
+name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
@@ -318,6 +336,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -340,7 +364,16 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -358,7 +391,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -379,6 +412,46 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cardano-serialization-lib"
+version = "14.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a894086cb078655b52a9478ae50e1f7b11f3a16fb02e2f11fe63b63644462c"
+dependencies = [
+ "bech32 0.7.3",
+ "cbor_event",
+ "cfg-if",
+ "clear_on_drop",
+ "cryptoxide",
+ "digest 0.9.0",
+ "ed25519-bip32",
+ "getrandom 0.2.17",
+ "hashlink",
+ "hex",
+ "itertools 0.10.5",
+ "js-sys",
+ "noop_proc_macro",
+ "num",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_os",
+ "schemars 0.8.22",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "sha2 0.9.9",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "cbor_event"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "089a0261d1bc59e54e8e11860031efd88593f0e61b921172c474f1f38c2f2d3c"
 
 [[package]]
 name = "cc"
@@ -467,6 +540,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "coins-bip32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,11 +565,11 @@ checksum = "66c43ff7fd9ff522219058808a259e61423335767b1071d5b346de60d9219657"
 dependencies = [
  "bs58",
  "coins-core",
- "digest",
+ "digest 0.10.7",
  "hmac",
  "k256",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -494,7 +585,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -508,11 +599,11 @@ dependencies = [
  "bech32 0.9.1",
  "bs58",
  "const-hex",
- "digest",
+ "digest 0.10.7",
  "generic-array",
  "ripemd",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -609,7 +700,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -694,11 +785,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -728,7 +828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -763,7 +863,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -782,7 +882,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -894,6 +994,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,11 +1075,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1046,6 +1150,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1061,6 +1174,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heapless"
@@ -1114,7 +1236,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1199,7 +1321,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1221,16 +1343,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
  "tokio",
@@ -1415,20 +1534,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1447,13 +1565,10 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
- "cfg-if",
- "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1467,7 +1582,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -1523,12 +1638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1667,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,10 +1697,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -1579,6 +1728,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1660,7 +1831,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "tempfile",
  "thiserror 2.0.18",
@@ -1695,9 +1866,10 @@ dependencies = [
  "bitcoin",
  "blake2",
  "bs58",
+ "cardano-serialization-lib",
  "coins-bip32",
  "coins-bip39",
- "digest",
+ "digest 0.10.7",
  "ed25519-bip32",
  "ed25519-dalek",
  "hex",
@@ -1712,7 +1884,7 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "signal-hook",
  "thiserror 2.0.18",
@@ -1737,7 +1909,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
  "password-hash",
 ]
@@ -1851,7 +2023,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -1877,7 +2049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1885,34 +2057,31 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
- "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.2",
+ "getrandom 0.2.17",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2008,6 +2177,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -2034,12 +2218,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2089,25 +2297,30 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "ipnet",
  "js-sys",
  "log",
+ "mime",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2116,13 +2329,13 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower 0.5.3",
- "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.11",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2155,7 +2368,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2212,7 +2425,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2231,6 +2444,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2277,6 +2499,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -2300,6 +2534,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scrypt"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,7 +2554,7 @@ dependencies = [
  "password-hash",
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2370,6 +2616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2640,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2458,13 +2726,26 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2473,7 +2754,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -2509,7 +2790,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2895,24 +3176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,13 +3290,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "wasm-bindgen",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3077,45 +3338,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
- "once_cell",
- "rustversion",
  "serde",
  "wasm-bindgen-macro",
- "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.65"
+name = "wasm-bindgen-backend"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
+ "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3123,13 +3363,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.115"
+name = "wasm-bindgen-futures"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
- "unicode-ident",
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
@@ -3159,7 +3431,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -3167,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3187,12 +3459,43 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3203,8 +3506,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -3236,12 +3539,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3476,7 +3809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap 2.13.0",
  "log",
  "serde",
@@ -3550,7 +3883,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "strum",
  "strum_macros",
  "thiserror-no-std",

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -236,6 +236,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -245,6 +251,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-url"
+version = "1.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
+dependencies = [
+ "base64 0.13.1",
+]
 
 [[package]]
 name = "base64ct"
@@ -373,7 +388,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -382,7 +397,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -423,7 +438,7 @@ dependencies = [
  "cbor_event",
  "cfg-if",
  "clear_on_drop",
- "cryptoxide",
+ "cryptoxide 0.4.4",
  "digest 0.9.0",
  "ed25519-bip32",
  "getrandom 0.2.17",
@@ -441,7 +456,7 @@ dependencies = [
  "rand_os",
  "schemars 0.8.22",
  "serde",
- "serde-wasm-bindgen",
+ "serde-wasm-bindgen 0.4.5",
  "serde_json",
  "sha2 0.9.9",
  "wasm-bindgen",
@@ -600,7 +615,7 @@ dependencies = [
  "bs58",
  "const-hex",
  "digest 0.10.7",
- "generic-array",
+ "generic-array 0.14.7",
  "ripemd",
  "serde",
  "sha2 0.10.9",
@@ -659,7 +674,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -671,10 +686,16 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
+
+[[package]]
+name = "cryptoxide"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42014d4c82e74bc17aaccc4bd75d3615d2b8236198de81c51bed5ddefaae6435"
 
 [[package]]
 name = "cryptoxide"
@@ -785,11 +806,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecae1c064e29fcabb6c2e9939e53dc7da72ed90234ae36ebfe03a478742efbd1"
+dependencies = [
+ "generic-array 0.8.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -851,7 +881,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
 dependencies = [
- "cryptoxide",
+ "cryptoxide 0.4.4",
 ]
 
 [[package]]
@@ -884,7 +914,7 @@ dependencies = [
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "pkcs8",
  "rand_core 0.6.4",
@@ -926,6 +956,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
  "embedded-io",
+]
+
+[[package]]
+name = "emurgo-cardano-message-signing"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2136c6e1d3b4ef3f6ca14aef5677c7e480b3eaa38f63da30275655dbf7f866f"
+dependencies = [
+ "base64-url",
+ "byteorder",
+ "cbor_event",
+ "cryptoxide 0.3.6",
+ "hex",
+ "linked-hash-map",
+ "noop_proc_macro",
+ "pruefung",
+ "serde-wasm-bindgen 0.6.5",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1042,6 +1090,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2297fb0e3ea512e380da24b52dca3924028f59df5e3a17a18f81d8349ca7ebe"
+dependencies = [
+ "nodrop",
+ "typenum",
 ]
 
 [[package]]
@@ -1524,7 +1582,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1620,6 +1678,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1729,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "noop_proc_macro"
@@ -1872,6 +1942,7 @@ dependencies = [
  "digest 0.10.7",
  "ed25519-bip32",
  "ed25519-dalek",
+ "emurgo-cardano-message-signing",
  "hex",
  "hkdf",
  "hmac",
@@ -2053,6 +2124,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "pruefung"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734d1fcf58d4e4aa4118926d4d44b1ea8921e4064c30a0415ae273552ebdd784"
+dependencies = [
+ "digest 0.6.1",
+ "generic-array 0.8.4",
 ]
 
 [[package]]
@@ -2565,7 +2646,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -2620,6 +2701,17 @@ name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
 dependencies = [
  "js-sys",
  "serde",

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -586,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptoxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +743,15 @@ checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
  "signature",
+]
+
+[[package]]
+name = "ed25519-bip32"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
+dependencies = [
+ "cryptoxide",
 ]
 
 [[package]]
@@ -1634,6 +1649,7 @@ dependencies = [
  "base64 0.22.1",
  "bs58",
  "chrono",
+ "ed25519-bip32",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hex",
@@ -1682,6 +1698,7 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "digest",
+ "ed25519-bip32",
  "ed25519-dalek",
  "hex",
  "hkdf",
@@ -1689,6 +1706,7 @@ dependencies = [
  "k256",
  "libc",
  "ows-core",
+ "pbkdf2",
  "rand 0.8.5",
  "ripemd",
  "scrypt",
@@ -1721,6 +1739,7 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+ "password-hash",
 ]
 
 [[package]]

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -1990,6 +1990,7 @@ dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
  "hex",
+ "mockito",
  "ows-core",
  "reqwest",
  "serde",

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -50,6 +50,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +134,16 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "async-stream"
@@ -630,6 +649,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1067,6 +1096,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -1087,7 +1122,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1696,6 +1734,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1775,31 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -1948,9 +2020,11 @@ dependencies = [
  "hmac",
  "k256",
  "libc",
+ "mockito",
  "ows-core",
  "pbkdf2",
  "rand 0.8.5",
+ "reqwest",
  "ripemd",
  "scrypt",
  "serde",
@@ -1961,6 +2035,29 @@ dependencies = [
  "thiserror 2.0.18",
  "xrpl-rust",
  "zeroize",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -2332,6 +2429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,6 +2463,8 @@ version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-automata",
  "regex-syntax",
 ]
@@ -2367,6 +2475,8 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -2384,6 +2494,7 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -2625,6 +2736,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
@@ -2885,6 +3002,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -3151,6 +3274,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "socket2 0.6.3",
  "tokio-macros",

--- a/ows/Cargo.lock
+++ b/ows/Cargo.lock
@@ -4190,6 +4190,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/ows/crates/ows-cli/src/commands/derive.rs
+++ b/ows/crates/ows-cli/src/commands/derive.rs
@@ -1,5 +1,5 @@
-use ows_core::{default_chain_for_type, ALL_CHAIN_TYPES};
-use ows_signer::{signer_for_chain, signer_for_chain_type, HdDeriver, Mnemonic};
+use ows_core::universal_wallet_chains;
+use ows_signer::{signer_for_chain, HdDeriver, Mnemonic};
 use zeroize::Zeroize;
 
 use crate::{parse_chain, CliError};
@@ -22,10 +22,9 @@ pub fn run(chain_str: Option<&str>, index: u32) -> Result<(), CliError> {
 
         println!("{address}");
     } else {
-        // Derive for all chains
-        for ct in &ALL_CHAIN_TYPES {
-            let chain = default_chain_for_type(*ct);
-            let signer = signer_for_chain_type(*ct);
+        // Derive for all universal-wallet networks (see `ows_core::universal_wallet_chains`)
+        for chain in universal_wallet_chains() {
+            let signer = signer_for_chain(&chain);
             let paths = signer.default_derivation_paths(index);
             let curve = signer.curve();
 

--- a/ows/crates/ows-cli/src/commands/derive.rs
+++ b/ows/crates/ows-cli/src/commands/derive.rs
@@ -13,11 +13,12 @@ pub fn run(chain_str: Option<&str>, index: u32) -> Result<(), CliError> {
         // Derive for a single chain
         let chain = parse_chain(cs)?;
         let signer = signer_for_chain(chain.chain_type);
-        let path = signer.default_derivation_path(index);
+        let paths = signer.default_derivation_paths(index);
         let curve = signer.curve();
 
-        let key = HdDeriver::derive_from_mnemonic_cached(&mnemonic, "", &path, curve)?;
-        let address = signer.derive_address(key.expose())?;
+        let keys = HdDeriver::derive_keys_from_mnemonic_cached(&mnemonic, "", paths, curve)?;
+        let signing_key = signer.encode_keys(&keys)?;
+        let address = signer.derive_address(signing_key.expose())?;
 
         println!("{address}");
     } else {
@@ -25,11 +26,12 @@ pub fn run(chain_str: Option<&str>, index: u32) -> Result<(), CliError> {
         for ct in &ALL_CHAIN_TYPES {
             let chain = default_chain_for_type(*ct);
             let signer = signer_for_chain(*ct);
-            let path = signer.default_derivation_path(index);
+            let paths = signer.default_derivation_paths(index);
             let curve = signer.curve();
 
-            let key = HdDeriver::derive_from_mnemonic_cached(&mnemonic, "", &path, curve)?;
-            let address = signer.derive_address(key.expose())?;
+            let keys = HdDeriver::derive_keys_from_mnemonic_cached(&mnemonic, "", paths, curve)?;
+            let signing_key = signer.encode_keys(&keys)?;
+            let address = signer.derive_address(signing_key.expose())?;
 
             println!("{} → {}", chain.chain_id, address);
         }

--- a/ows/crates/ows-cli/src/commands/derive.rs
+++ b/ows/crates/ows-cli/src/commands/derive.rs
@@ -1,5 +1,5 @@
 use ows_core::{default_chain_for_type, ALL_CHAIN_TYPES};
-use ows_signer::{signer_for_chain, HdDeriver, Mnemonic};
+use ows_signer::{signer_for_chain, signer_for_chain_type, HdDeriver, Mnemonic};
 use zeroize::Zeroize;
 
 use crate::{parse_chain, CliError};
@@ -12,7 +12,7 @@ pub fn run(chain_str: Option<&str>, index: u32) -> Result<(), CliError> {
     if let Some(cs) = chain_str {
         // Derive for a single chain
         let chain = parse_chain(cs)?;
-        let signer = signer_for_chain(chain.chain_type);
+        let signer = signer_for_chain(&chain);
         let paths = signer.default_derivation_paths(index);
         let curve = signer.curve();
 
@@ -25,7 +25,7 @@ pub fn run(chain_str: Option<&str>, index: u32) -> Result<(), CliError> {
         // Derive for all chains
         for ct in &ALL_CHAIN_TYPES {
             let chain = default_chain_for_type(*ct);
-            let signer = signer_for_chain(*ct);
+            let signer = signer_for_chain_type(*ct);
             let paths = signer.default_derivation_paths(index);
             let curve = signer.curve();
 

--- a/ows/crates/ows-cli/src/commands/derive.rs
+++ b/ows/crates/ows-cli/src/commands/derive.rs
@@ -12,7 +12,7 @@ pub fn run(chain_str: Option<&str>, index: u32) -> Result<(), CliError> {
     if let Some(cs) = chain_str {
         // Derive for a single chain
         let chain = parse_chain(cs)?;
-        let signer = signer_for_chain(&chain);
+        let signer = signer_for_chain(&chain)?;
         let paths = signer.default_derivation_paths(index);
         let curve = signer.curve();
 
@@ -24,7 +24,7 @@ pub fn run(chain_str: Option<&str>, index: u32) -> Result<(), CliError> {
     } else {
         // Derive for all universal-wallet networks (see `ows_core::universal_wallet_chains`)
         for chain in universal_wallet_chains() {
-            let signer = signer_for_chain(&chain);
+            let signer = signer_for_chain(&chain)?;
             let paths = signer.default_derivation_paths(index);
             let curve = signer.curve();
 

--- a/ows/crates/ows-cli/src/commands/fund.rs
+++ b/ows/crates/ows-cli/src/commands/fund.rs
@@ -1,4 +1,6 @@
 use crate::CliError;
+use ows_core::parse_chain;
+use ows_lib::ops::resolve_rpc_url;
 use ows_lib::types::AccountInfo;
 
 /// Returns the wallet account matching the target funding chain.
@@ -6,14 +8,12 @@ fn find_account_for_chain<'a>(
     accounts: &'a [AccountInfo],
     chain: &str,
 ) -> Result<&'a AccountInfo, CliError> {
-    let chain_prefix = match chain {
-        "solana" => "solana:",
-        _ => "eip155:",
-    };
+    let parsed_chain =
+        parse_chain(chain).map_err(|e| CliError::InvalidArgs(format!("unknown chain: {e}")))?;
 
     accounts
         .iter()
-        .find(|a| a.chain_id.starts_with(chain_prefix))
+        .find(|a| a.chain_id == parsed_chain.chain_id)
         .ok_or_else(|| {
             CliError::InvalidArgs(format!("wallet has no account for chain \"{chain}\""))
         })
@@ -92,7 +92,15 @@ pub fn balance(wallet_name: &str, chain: Option<&str>) -> Result<(), CliError> {
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| CliError::InvalidArgs(format!("tokio: {e}")))?;
 
-    let balances = rt.block_on(ows_pay::fund::get_balances(address, Some(chain_name)))?;
+    let chain = parse_chain(chain_name)
+        .map_err(|e| CliError::InvalidArgs(format!("unknown chain: {e}")))?;
+
+    let rpc_url = resolve_rpc_url(chain.chain_id, chain.chain_type, None).ok();
+    let balances = rt.block_on(ows_pay::fund::get_balances(
+        address,
+        Some(chain_name),
+        rpc_url.as_deref(),
+    ))?;
 
     if balances.is_empty() {
         eprintln!("No tokens found for {address} on {chain_name}");
@@ -101,11 +109,13 @@ pub fn balance(wallet_name: &str, chain: Option<&str>) -> Result<(), CliError> {
 
     for token in &balances {
         let amount = token.balance.amount;
-        let value = token.balance.value;
-        println!(
-            "{:>12.6} {:6} ${:<10.2}  {}",
-            amount, token.symbol, value, token.name
-        );
+        match token.balance.value {
+            Some(value) => println!(
+                "{:>12.6} {:6} ${:<10.2}  {}",
+                amount, token.symbol, value, token.name
+            ),
+            None => println!("{:>12} {:<10} {}", amount, token.symbol, token.name),
+        }
     }
 
     Ok(())

--- a/ows/crates/ows-cli/src/commands/info.rs
+++ b/ows/crates/ows-cli/src/commands/info.rs
@@ -8,17 +8,21 @@ pub fn run() -> Result<(), CliError> {
     println!("Vault path: {}", config.vault_path.display());
     println!();
     println!("Supported chains:");
-    println!("{:<12} {:<10} {:<10}", "Chain", "Namespace", "Coin Type");
-    println!("{:<12} {:<10} {:<10}", "-----", "---------", "---------");
+    println!(
+        "{:<22} {:<12} {:<10}",
+        "Chain name", "Namespace", "Coin Type"
+    );
+    println!(
+        "{:<22} {:<12} {:<10}",
+        "----------", "---------", "---------"
+    );
 
-    let chains = ows_core::ALL_CHAIN_TYPES;
-
-    for chain in chains {
+    for chain in ows_core::universal_wallet_chains() {
         println!(
-            "{:<12} {:<10} {:<10}",
-            chain,
-            chain.namespace(),
-            chain.default_coin_type()
+            "{:<22} {:<12} {:<10}",
+            chain.name,
+            chain.chain_type.namespace(),
+            chain.chain_type.default_coin_type()
         );
     }
 

--- a/ows/crates/ows-cli/src/commands/pay.rs
+++ b/ows/crates/ows-cli/src/commands/pay.rs
@@ -67,6 +67,7 @@ impl ows_pay::WalletAccess for OwsLibWallet {
                     Some(&self.passphrase),
                     None,
                     None,
+                    None,
                 )
                 .map_err(|e| {
                     ows_pay::PayError::new(ows_pay::PayErrorCode::SigningFailed, e.to_string())

--- a/ows/crates/ows-cli/src/commands/sign_message.rs
+++ b/ows/crates/ows-cli/src/commands/sign_message.rs
@@ -45,7 +45,7 @@ pub fn run(
     let chain = parse_chain(chain_str)?;
     let key = super::resolve_signing_key(wallet_name, chain.chain_type, index)?;
 
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
 
     let output = if let Some(td_json) = typed_data {
         if chain.chain_type != ows_core::ChainType::Evm {

--- a/ows/crates/ows-cli/src/commands/sign_message.rs
+++ b/ows/crates/ows-cli/src/commands/sign_message.rs
@@ -1,8 +1,10 @@
 use ows_signer::chains::EvmSigner;
 use ows_signer::signer_for_chain;
+use ows_signer::ChainSigner;
 
 use crate::{parse_chain, CliError};
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     chain_str: &str,
     wallet_name: &str,
@@ -11,6 +13,7 @@ pub fn run(
     typed_data: Option<&str>,
     index: u32,
     json_output: bool,
+    address: Option<&str>,
 ) -> Result<(), CliError> {
     // Check for API token in passphrase — route through library for policy enforcement
     let passphrase = super::peek_passphrase();
@@ -25,6 +28,7 @@ pub fn run(
                 td_json,
                 passphrase.as_deref(),
                 Some(index),
+                address,
                 None,
             )?;
             return print_result(&result.signature, result.recovery_id, json_output);
@@ -36,6 +40,7 @@ pub fn run(
             passphrase.as_deref(),
             Some(encoding),
             Some(index),
+            address,
             None,
         )?;
         return print_result(&result.signature, result.recovery_id, json_output);
@@ -53,6 +58,7 @@ pub fn run(
                 "--typed-data is only supported for EVM chains".into(),
             ));
         }
+        ChainSigner::verify_sign_message_address(&*signer, key.expose(), address)?;
         EvmSigner.sign_typed_data(key.expose(), td_json)?
     } else {
         let msg_bytes = match encoding {
@@ -65,7 +71,7 @@ pub fn run(
                 )))
             }
         };
-        signer.sign_message(key.expose(), &msg_bytes)?
+        signer.sign_message(key.expose(), &msg_bytes, address)?
     };
 
     print_result(

--- a/ows/crates/ows-cli/src/commands/sign_message.rs
+++ b/ows/crates/ows-cli/src/commands/sign_message.rs
@@ -50,7 +50,7 @@ pub fn run(
     let chain = parse_chain(chain_str)?;
     let key = super::resolve_signing_key(wallet_name, chain.chain_type, index)?;
 
-    let signer = signer_for_chain(&chain);
+    let signer = signer_for_chain(&chain)?;
 
     let output = if let Some(td_json) = typed_data {
         if chain.chain_type != ows_core::ChainType::Evm {

--- a/ows/crates/ows-cli/src/commands/sign_transaction.rs
+++ b/ows/crates/ows-cli/src/commands/sign_transaction.rs
@@ -34,7 +34,7 @@ pub fn run(
     let tx_bytes = hex::decode(tx_hex_clean)
         .map_err(|e| CliError::InvalidArgs(format!("invalid hex transaction: {e}")))?;
 
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
     let signable = signer.extract_signable_bytes(&tx_bytes)?;
     let output = signer.sign_transaction(key.expose(), signable)?;
 

--- a/ows/crates/ows-cli/src/commands/sign_transaction.rs
+++ b/ows/crates/ows-cli/src/commands/sign_transaction.rs
@@ -34,7 +34,7 @@ pub fn run(
     let tx_bytes = hex::decode(tx_hex_clean)
         .map_err(|e| CliError::InvalidArgs(format!("invalid hex transaction: {e}")))?;
 
-    let signer = signer_for_chain(&chain);
+    let signer = signer_for_chain(&chain)?;
     let signable = signer.extract_signable_bytes(&tx_bytes)?;
     let output = signer.sign_transaction(key.expose(), signable)?;
 

--- a/ows/crates/ows-cli/src/commands/wallet.rs
+++ b/ows/crates/ows-cli/src/commands/wallet.rs
@@ -47,21 +47,25 @@ pub fn import(
     // Read curve-specific keys from environment variables (cleared immediately after reading)
     let secp256k1_key = ows_signer::process_hardening::clear_env_var("OWS_SECP256K1_KEY");
     let ed25519_key = ows_signer::process_hardening::clear_env_var("OWS_ED25519_KEY");
+    let ed25519_bip32_key = ows_signer::process_hardening::clear_env_var("OWS_ED25519_BIP32_KEY");
     let secp256k1_key = secp256k1_key.as_deref().filter(|s| !s.is_empty());
     let ed25519_key = ed25519_key.as_deref().filter(|s| !s.is_empty());
+    let ed25519_bip32_key = ed25519_bip32_key.as_deref().filter(|s| !s.is_empty());
 
-    let has_curve_keys = secp256k1_key.is_some() || ed25519_key.is_some();
-    let both_curve_keys = secp256k1_key.is_some() && ed25519_key.is_some();
+    let has_some_curve_keys =
+        secp256k1_key.is_some() || ed25519_key.is_some() || ed25519_bip32_key.is_some();
+    let has_all_curve_keys =
+        secp256k1_key.is_some() && ed25519_key.is_some() && ed25519_bip32_key.is_some();
 
-    // Must specify exactly one import mode: --mnemonic, --private-key, or both curve keys (via env)
-    if use_mnemonic && (use_private_key || has_curve_keys) {
+    // Must specify exactly one import mode: --mnemonic, --private-key, or all curve keys (via env)
+    if use_mnemonic && (use_private_key || has_some_curve_keys) {
         return Err(CliError::InvalidArgs(
             "cannot combine --mnemonic with --private-key or curve-specific keys".into(),
         ));
     }
-    if !use_mnemonic && !use_private_key && !both_curve_keys {
+    if !use_mnemonic && !use_private_key && !has_all_curve_keys {
         return Err(CliError::InvalidArgs(
-            "specify --mnemonic, --private-key, or set OWS_SECP256K1_KEY and OWS_ED25519_KEY"
+            "specify --mnemonic, --private-key, or set OWS_SECP256K1_KEY, OWS_ED25519_KEY, and OWS_ED25519_BIP32_KEY"
                 .into(),
         ));
     }
@@ -70,8 +74,8 @@ pub fn import(
         let phrase = super::read_mnemonic()?;
         ows_lib::import_wallet_mnemonic(name, &phrase, None, Some(index), None)?
     } else {
-        // Read from env/stdin only when both curve keys are not already provided
-        let private_key_hex = if both_curve_keys {
+        // Read from env/stdin only when all curve keys are not already provided
+        let private_key_hex = if has_all_curve_keys {
             zeroize::Zeroizing::new(String::new())
         } else {
             super::read_private_key()?
@@ -84,6 +88,7 @@ pub fn import(
             None,
             secp256k1_key,
             ed25519_key,
+            ed25519_bip32_key,
         )?
     };
 

--- a/ows/crates/ows-cli/src/main.rs
+++ b/ows/crates/ows-cli/src/main.rs
@@ -159,6 +159,9 @@ enum SignCommands {
         /// Output structured JSON instead of raw hex
         #[arg(long)]
         json: bool,
+        /// Address that will be used to sign the message (e.g. stake/base/enterprise address on Cardano)
+        #[arg(long)]
+        address: Option<String>,
     },
     /// Sign a transaction (accepts hex-encoded unsigned transaction bytes)
     Tx {
@@ -429,6 +432,7 @@ fn run(cli: Cli) -> Result<(), CliError> {
                 typed_data,
                 index,
                 json,
+                address,
             } => commands::sign_message::run(
                 &chain,
                 &wallet,
@@ -437,6 +441,7 @@ fn run(cli: Cli) -> Result<(), CliError> {
                 typed_data.as_deref(),
                 index,
                 json,
+                address.as_deref(),
             ),
             SignCommands::Tx {
                 chain,

--- a/ows/crates/ows-core/src/chain.rs
+++ b/ows/crates/ows-core/src/chain.rs
@@ -18,10 +18,11 @@ pub enum ChainType {
     Xrpl,
     Nano,
     Near,
+    Cardano,
 }
 
 /// All supported chain families, used for universal wallet derivation.
-pub const ALL_CHAIN_TYPES: [ChainType; 12] = [
+pub const ALL_CHAIN_TYPES: [ChainType; 13] = [
     ChainType::Evm,
     ChainType::Solana,
     ChainType::Bitcoin,
@@ -34,6 +35,7 @@ pub const ALL_CHAIN_TYPES: [ChainType; 12] = [
     ChainType::Xrpl,
     ChainType::Nano,
     ChainType::Near,
+    ChainType::Cardano,
 ];
 
 /// A specific chain (e.g. "ethereum", "arbitrum") with its family type and CAIP-2 ID.
@@ -183,6 +185,22 @@ pub const KNOWN_CHAINS: &[Chain] = &[
         chain_type: ChainType::Nano,
         chain_id: "nano:mainnet",
     },
+    // Cardano mainnet
+    Chain {
+        name: "cardano",
+        chain_type: ChainType::Cardano,
+        chain_id: "cip34:1-764824073",
+    },
+    Chain {
+        name: "cardano-preprod",
+        chain_type: ChainType::Cardano,
+        chain_id: "cip34:0-1",
+    },
+    Chain {
+        name: "cardano-preview",
+        chain_type: ChainType::Cardano,
+        chain_id: "cip34:0-2",
+    },
     Chain {
         name: "near",
         chain_type: ChainType::Near,
@@ -267,7 +285,7 @@ pub fn parse_chain(s: &str) -> Result<Chain, String> {
            EVM:     ethereum, base, arbitrum, optimism, polygon, bsc, avalanche, plasma, etherlink\n  \
            Solana:  solana\n  \
            Bitcoin: bitcoin\n  \
-           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl, nano, near\n\n\
+           Other:   cosmos, tron, ton, sui, filecoin, spark, xrpl, nano, near, cardano, cardano-preprod, cardano-preview\n\n\
          Or use a CAIP-2 ID (eip155:8453) or bare EVM chain ID (8453)"
     ))
 }
@@ -275,6 +293,33 @@ pub fn parse_chain(s: &str) -> Result<Chain, String> {
 /// Returns the default `Chain` for a given `ChainType` (first match in registry).
 pub fn default_chain_for_type(ct: ChainType) -> Chain {
     *KNOWN_CHAINS.iter().find(|c| c.chain_type == ct).unwrap()
+}
+
+/// Friendly names in [`KNOWN_CHAINS`] appended after [`ALL_CHAIN_TYPES`] for universal-wallet
+/// derivation (same keys as the family default, different network / CAIP-2 id).
+pub const UNIVERSAL_WALLET_EXTRA_CHAIN_NAMES: &[&str] = &["cardano-preprod", "cardano-preview"];
+
+/// Accounts per universal wallet: one per [`ALL_CHAIN_TYPES`] plus [`UNIVERSAL_WALLET_EXTRA_CHAIN_NAMES`].
+pub const UNIVERSAL_WALLET_ACCOUNT_COUNT: usize =
+    ALL_CHAIN_TYPES.len() + UNIVERSAL_WALLET_EXTRA_CHAIN_NAMES.len();
+
+/// Ordered [`Chain`] rows for universal-wallet derivation and multi-network CLI output.
+pub fn universal_wallet_chains() -> Vec<Chain> {
+    let mut out = Vec::with_capacity(UNIVERSAL_WALLET_ACCOUNT_COUNT);
+    for ct in &ALL_CHAIN_TYPES {
+        out.push(default_chain_for_type(*ct));
+    }
+    for name in UNIVERSAL_WALLET_EXTRA_CHAIN_NAMES {
+        let chain = KNOWN_CHAINS
+            .iter()
+            .copied()
+            .find(|c| c.name == *name)
+            .unwrap_or_else(|| {
+                panic!("KNOWN_CHAINS must define `{name}` (universal wallet extras)")
+            });
+        out.push(chain);
+    }
+    out
 }
 
 impl ChainType {
@@ -293,6 +338,7 @@ impl ChainType {
             ChainType::Xrpl => "xrpl",
             ChainType::Nano => "nano",
             ChainType::Near => "near",
+            ChainType::Cardano => "cip34",
         }
     }
 
@@ -311,6 +357,7 @@ impl ChainType {
             ChainType::Xrpl => 144,
             ChainType::Nano => 165,
             ChainType::Near => 397,
+            ChainType::Cardano => 1815,
         }
     }
 
@@ -329,6 +376,7 @@ impl ChainType {
             "xrpl" => Some(ChainType::Xrpl),
             "nano" => Some(ChainType::Nano),
             "near" => Some(ChainType::Near),
+            "cip34" => Some(ChainType::Cardano),
             _ => None,
         }
     }
@@ -349,6 +397,7 @@ impl fmt::Display for ChainType {
             ChainType::Xrpl => "xrpl",
             ChainType::Nano => "nano",
             ChainType::Near => "near",
+            ChainType::Cardano => "cardano",
         };
         write!(f, "{}", s)
     }
@@ -371,6 +420,7 @@ impl FromStr for ChainType {
             "xrpl" => Ok(ChainType::Xrpl),
             "nano" => Ok(ChainType::Nano),
             "near" => Ok(ChainType::Near),
+            "cardano" => Ok(ChainType::Cardano),
             _ => Err(format!("unknown chain type: {}", s)),
         }
     }
@@ -404,6 +454,7 @@ mod tests {
             (ChainType::Xrpl, "\"xrpl\""),
             (ChainType::Nano, "\"nano\""),
             (ChainType::Near, "\"near\""),
+            (ChainType::Cardano, "\"cardano\""),
         ] {
             let json = serde_json::to_string(&chain).unwrap();
             assert_eq!(json, expected);
@@ -426,6 +477,7 @@ mod tests {
         assert_eq!(ChainType::Xrpl.namespace(), "xrpl");
         assert_eq!(ChainType::Nano.namespace(), "nano");
         assert_eq!(ChainType::Near.namespace(), "near");
+        assert_eq!(ChainType::Cardano.namespace(), "cip34");
     }
 
     #[test]
@@ -442,6 +494,7 @@ mod tests {
         assert_eq!(ChainType::Xrpl.default_coin_type(), 144);
         assert_eq!(ChainType::Nano.default_coin_type(), 165);
         assert_eq!(ChainType::Near.default_coin_type(), 397);
+        assert_eq!(ChainType::Cardano.default_coin_type(), 1815);
     }
 
     #[test]
@@ -461,6 +514,7 @@ mod tests {
         assert_eq!(ChainType::from_namespace("xrpl"), Some(ChainType::Xrpl));
         assert_eq!(ChainType::from_namespace("nano"), Some(ChainType::Nano));
         assert_eq!(ChainType::from_namespace("near"), Some(ChainType::Near));
+        assert_eq!(ChainType::from_namespace("cip34"), Some(ChainType::Cardano));
         assert_eq!(ChainType::from_namespace("unknown"), None);
     }
 
@@ -559,6 +613,26 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_chain_cardano() {
+        let chain = parse_chain("cardano").unwrap();
+        assert_eq!(chain.name, "cardano");
+        assert_eq!(chain.chain_type, ChainType::Cardano);
+        assert_eq!(chain.chain_id, "cip34:1-764824073");
+
+        let via_caip2 = parse_chain("cip34:1-764824073").unwrap();
+        assert_eq!(via_caip2.chain_type, ChainType::Cardano);
+        assert_eq!(via_caip2.chain_id, "cip34:1-764824073");
+
+        let preprod = parse_chain("cardano-preprod").unwrap();
+        assert_eq!(preprod.chain_id, "cip34:0-1");
+        assert_eq!(parse_chain("cip34:0-1").unwrap().name, "cardano-preprod");
+
+        let preview = parse_chain("cardano-preview").unwrap();
+        assert_eq!(preview.chain_id, "cip34:0-2");
+        assert_eq!(parse_chain("cip34:0-2").unwrap().name, "cardano-preview");
+    }
+
+    #[test]
     fn test_parse_chain_xrpl() {
         let chain = parse_chain("xrpl").unwrap();
         assert_eq!(chain.chain_type, ChainType::Xrpl);
@@ -641,7 +715,7 @@ mod tests {
 
     #[test]
     fn test_all_chain_types() {
-        assert_eq!(ALL_CHAIN_TYPES.len(), 12);
+        assert_eq!(ALL_CHAIN_TYPES.len(), 13);
     }
 
     #[test]
@@ -666,5 +740,23 @@ mod tests {
         let chain = default_chain_for_type(ChainType::Evm);
         assert_eq!(chain.name, "ethereum");
         assert_eq!(chain.chain_id, "eip155:1");
+
+        let ada = default_chain_for_type(ChainType::Cardano);
+        assert_eq!(ada.name, "cardano");
+        assert_eq!(ada.chain_id, "cip34:1-764824073");
+    }
+
+    #[test]
+    fn test_universal_wallet_chains_order_and_count() {
+        let chains = universal_wallet_chains();
+        assert_eq!(chains.len(), UNIVERSAL_WALLET_ACCOUNT_COUNT);
+        assert_eq!(
+            chains.len(),
+            ALL_CHAIN_TYPES.len() + UNIVERSAL_WALLET_EXTRA_CHAIN_NAMES.len()
+        );
+        assert_eq!(chains[12].chain_type, ChainType::Cardano);
+        assert_eq!(chains[12].name, "cardano");
+        assert_eq!(chains[13].name, "cardano-preprod");
+        assert_eq!(chains[14].name, "cardano-preview");
     }
 }

--- a/ows/crates/ows-core/src/config.rs
+++ b/ows/crates/ows-core/src/config.rs
@@ -81,6 +81,19 @@ impl Config {
             "eip155:999".into(),
             "https://rpc.hyperliquid.xyz/evm".into(),
         );
+        // Cardano mainnet
+        rpc.insert(
+            "cip34:1-764824073".into(),
+            "https://api.koios.rest/api/v1".into(),
+        );
+        rpc.insert(
+            "cip34:0-1".into(),
+            "https://preprod.koios.rest/api/v1".into(),
+        );
+        rpc.insert(
+            "cip34:0-2".into(),
+            "https://preview.koios.rest/api/v1".into(),
+        );
         rpc
     }
 }
@@ -224,6 +237,18 @@ mod tests {
             config.rpc_url("eip155:999"),
             Some("https://rpc.hyperliquid.xyz/evm")
         );
+        assert_eq!(
+            config.rpc_url("cip34:1-764824073"),
+            Some("https://api.koios.rest/api/v1")
+        );
+        assert_eq!(
+            config.rpc_url("cip34:0-1"),
+            Some("https://preprod.koios.rest/api/v1")
+        );
+        assert_eq!(
+            config.rpc_url("cip34:0-2"),
+            Some("https://preview.koios.rest/api/v1")
+        );
     }
 
     #[test]
@@ -266,7 +291,7 @@ mod tests {
     fn test_load_or_default_nonexistent() {
         let config = Config::load_or_default_from(std::path::Path::new("/nonexistent/config.json"));
         // Should have all default RPCs
-        assert_eq!(config.rpc.len(), 23);
+        assert_eq!(config.rpc.len(), 26);
         assert_eq!(config.rpc_url("eip155:1"), Some("https://eth.llamarpc.com"));
         assert_eq!(
             config.rpc_url("near:mainnet"),

--- a/ows/crates/ows-core/src/lib.rs
+++ b/ows/crates/ows-core/src/lib.rs
@@ -10,7 +10,9 @@ pub mod wallet_file;
 pub use api_key::ApiKeyFile;
 pub use caip::ChainId;
 pub use chain::{
-    default_chain_for_type, parse_chain, Chain, ChainType, ALL_CHAIN_TYPES, KNOWN_CHAINS,
+    default_chain_for_type, parse_chain, universal_wallet_chains, Chain, ChainType,
+    ALL_CHAIN_TYPES, KNOWN_CHAINS, UNIVERSAL_WALLET_ACCOUNT_COUNT,
+    UNIVERSAL_WALLET_EXTRA_CHAIN_NAMES,
 };
 pub use config::Config;
 pub use error::{OwsError, OwsErrorCode};

--- a/ows/crates/ows-core/src/lib.rs
+++ b/ows/crates/ows-core/src/lib.rs
@@ -16,6 +16,9 @@ pub use chain::{
 };
 pub use config::Config;
 pub use error::{OwsError, OwsErrorCode};
-pub use policy::{Policy, PolicyAction, PolicyContext, PolicyResult, PolicyRule, TypedDataContext};
+pub use policy::{
+    Policy, PolicyAction, PolicyContext, PolicyRequestType, PolicyResult, PolicyRule,
+    TypedDataContext,
+};
 pub use types::*;
 pub use wallet_file::*;

--- a/ows/crates/ows-core/src/policy.rs
+++ b/ows/crates/ows-core/src/policy.rs
@@ -45,7 +45,12 @@ pub struct PolicyContext {
     pub chain_id: String,
     pub wallet_id: String,
     pub api_key_id: String,
-    pub transaction: TransactionContext,
+    /// Transaction-shaped context for the signing request. Present for
+    /// `sign_transaction`, `sign_message`, and `sign_hash` (the latter two
+    /// surface their payload through `raw_hex`). Omitted for `sign_typed_data`,
+    /// which exposes its payload via [`TypedDataContext::raw_json`] instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction: Option<TransactionContext>,
     pub spending: SpendingContext,
     pub timestamp: String,
     /// EIP-712 typed data context (only present for `sign_typed_data` calls).
@@ -62,8 +67,7 @@ pub struct TransactionContext {
     /// Native value in smallest unit (wei, lamports, etc).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
-    /// Raw transaction hex. Empty for non-transaction signing requests such as
-    /// typed data, which is instead exposed via [`TypedDataContext::raw_json`].
+    /// Raw transaction hex.
     pub raw_hex: String,
     /// Calldata / input data (EVM).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -209,12 +213,12 @@ mod tests {
             chain_id: "eip155:8453".into(),
             wallet_id: "3198bc9c-6672-5ab3-d995-4942343ae5b6".into(),
             api_key_id: "7a2f1b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c".into(),
-            transaction: TransactionContext {
+            transaction: Some(TransactionContext {
                 to: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into()),
                 value: Some("100000000000000000".into()),
                 raw_hex: "0x02f8...".into(),
                 data: None,
-            },
+            }),
             spending: SpendingContext {
                 daily_total: "50000000000000000".into(),
                 date: "2026-03-22".into(),
@@ -227,8 +231,8 @@ mod tests {
         let deserialized: PolicyContext = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.chain_id, "eip155:8453");
         assert_eq!(
-            deserialized.transaction.to.unwrap(),
-            "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C"
+            deserialized.transaction.as_ref().unwrap().to.as_deref(),
+            Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C")
         );
         // data was None, should be absent from serialized form
         assert!(!json.contains("\"data\""));
@@ -332,12 +336,12 @@ mod tests {
             chain_id: "eip155:8453".into(),
             wallet_id: "w".into(),
             api_key_id: "k".into(),
-            transaction: TransactionContext {
+            transaction: Some(TransactionContext {
                 to: None,
                 value: None,
                 raw_hex: "0x00".into(),
                 data: None,
-            },
+            }),
             spending: SpendingContext {
                 daily_total: "0".into(),
                 date: "2026-03-30".into(),
@@ -348,5 +352,24 @@ mod tests {
 
         let json = serde_json::to_string(&ctx).unwrap();
         assert!(!json.contains("typed_data"));
+    }
+
+    #[test]
+    fn test_policy_context_transaction_none_omitted() {
+        let ctx = PolicyContext {
+            chain_id: "eip155:8453".into(),
+            wallet_id: "w".into(),
+            api_key_id: "k".into(),
+            transaction: None,
+            spending: SpendingContext {
+                daily_total: "0".into(),
+                date: "2026-03-30".into(),
+            },
+            timestamp: "2026-03-30T12:00:00Z".into(),
+            typed_data: None,
+        };
+
+        let json = serde_json::to_string(&ctx).unwrap();
+        assert!(!json.contains("transaction"));
     }
 }

--- a/ows/crates/ows-core/src/policy.rs
+++ b/ows/crates/ows-core/src/policy.rs
@@ -58,6 +58,12 @@ pub struct PolicyContext {
     pub typed_data: Option<TypedDataContext>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TransactionEffect {
+    pub address: String,
+    pub diff: Vec<(String, i64)>, // (asset, diff)
+}
+
 /// Signing-request fields available for policy evaluation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionContext {
@@ -67,6 +73,7 @@ pub struct TransactionContext {
     /// Native value in smallest unit (wei, lamports, etc).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
+    pub effects: Vec<TransactionEffect>,
     /// Raw transaction hex.
     pub raw_hex: String,
     /// Calldata / input data (EVM).
@@ -216,6 +223,10 @@ mod tests {
             transaction: Some(TransactionContext {
                 to: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into()),
                 value: Some("100000000000000000".into()),
+                effects: vec![TransactionEffect {
+                    address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),
+                    diff: vec![("ETH".into(), 100000000000000000)],
+                }],
                 raw_hex: "0x02f8...".into(),
                 data: None,
             }),
@@ -233,6 +244,13 @@ mod tests {
         assert_eq!(
             deserialized.transaction.as_ref().unwrap().to.as_deref(),
             Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C")
+        );
+        assert_eq!(
+            deserialized.transaction.unwrap().effects.first().unwrap(),
+            &TransactionEffect {
+                address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),
+                diff: vec![("ETH".into(), 100000000000000000)],
+            }
         );
         // data was None, should be absent from serialized form
         assert!(!json.contains("\"data\""));
@@ -339,6 +357,7 @@ mod tests {
             transaction: Some(TransactionContext {
                 to: None,
                 value: None,
+                effects: vec![],
                 raw_hex: "0x00".into(),
                 data: None,
             }),

--- a/ows/crates/ows-core/src/policy.rs
+++ b/ows/crates/ows-core/src/policy.rs
@@ -67,12 +67,6 @@ pub struct TransactionEffect {
 /// Signing-request fields available for policy evaluation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionContext {
-    /// Destination address (if applicable).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub to: Option<String>,
-    /// Native value in smallest unit (wei, lamports, etc).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
     pub effects: Vec<TransactionEffect>,
     /// Raw transaction hex.
     pub raw_hex: String,
@@ -221,8 +215,6 @@ mod tests {
             wallet_id: "3198bc9c-6672-5ab3-d995-4942343ae5b6".into(),
             api_key_id: "7a2f1b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c".into(),
             transaction: Some(TransactionContext {
-                to: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into()),
-                value: Some("100000000000000000".into()),
                 effects: vec![TransactionEffect {
                     address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),
                     diff: vec![("ETH".into(), 100000000000000000)],
@@ -241,10 +233,6 @@ mod tests {
         let json = serde_json::to_string(&ctx).unwrap();
         let deserialized: PolicyContext = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.chain_id, "eip155:8453");
-        assert_eq!(
-            deserialized.transaction.as_ref().unwrap().to.as_deref(),
-            Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C")
-        );
         assert_eq!(
             deserialized.transaction.unwrap().effects.first().unwrap(),
             &TransactionEffect {
@@ -355,8 +343,6 @@ mod tests {
             wallet_id: "w".into(),
             api_key_id: "k".into(),
             transaction: Some(TransactionContext {
-                to: None,
-                value: None,
                 effects: vec![],
                 raw_hex: "0x00".into(),
                 data: None,

--- a/ows/crates/ows-core/src/policy.rs
+++ b/ows/crates/ows-core/src/policy.rs
@@ -77,6 +77,11 @@ pub struct TransactionContext {
     /// Calldata / input data (EVM).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
+    /// Chain-specific extra context as opaque JSON, for signing requests whose per-transaction detail is
+    /// richer than the flat `effects` list. A chain populates this when it has structured context to
+    /// expose to executable policies that `effects` cannot carry; absent otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chain_extra: Option<serde_json::Value>,
 }
 
 /// Carried in [`PolicyContext`] for executable policies (opaque JSON). Not used by built-in rules.
@@ -225,6 +230,7 @@ mod tests {
                 }],
                 raw_hex: "0x02f8...".into(),
                 data: None,
+                chain_extra: None,
             }),
             spending: SpendingContext {
                 daily_total: "50000000000000000".into(),
@@ -350,6 +356,7 @@ mod tests {
                 effects: vec![],
                 raw_hex: "0x00".into(),
                 data: None,
+                chain_extra: None,
             }),
             spending: SpendingContext {
                 daily_total: "0".into(),

--- a/ows/crates/ows-core/src/policy.rs
+++ b/ows/crates/ows-core/src/policy.rs
@@ -61,7 +61,11 @@ pub struct PolicyContext {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TransactionEffect {
     pub address: String,
-    pub diff: Vec<(String, i64)>, // (asset, diff)
+    /// Per-asset balance change for `address`, as `(asset, signed decimal amount)`
+    /// in the asset's smallest unit. The amount is a string because it has no
+    /// domain ceiling — wei exceeds `i64` above ~9.22 ETH, and a JSON number
+    /// above 2^53 does not survive a policy written in JavaScript.
+    pub diff: Vec<(String, String)>,
 }
 
 /// Signing-request fields available for policy evaluation.
@@ -217,7 +221,7 @@ mod tests {
             transaction: Some(TransactionContext {
                 effects: vec![TransactionEffect {
                     address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),
-                    diff: vec![("ETH".into(), 100000000000000000)],
+                    diff: vec![("ETH".into(), "100000000000000000".into())],
                 }],
                 raw_hex: "0x02f8...".into(),
                 data: None,
@@ -237,7 +241,7 @@ mod tests {
             deserialized.transaction.unwrap().effects.first().unwrap(),
             &TransactionEffect {
                 address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),
-                diff: vec![("ETH".into(), 100000000000000000)],
+                diff: vec![("ETH".into(), "100000000000000000".into())],
             }
         );
         // data was None, should be absent from serialized form

--- a/ows/crates/ows-core/src/policy.rs
+++ b/ows/crates/ows-core/src/policy.rs
@@ -39,16 +39,32 @@ pub struct Policy {
     pub action: PolicyAction,
 }
 
+/// Which signing operation a [`PolicyContext`] was built for. Always present in the
+/// serialized context, so a policy can branch on the operation rather than infer it
+/// from which optional fields happen to be populated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyRequestType {
+    SignTransaction,
+    SignMessage,
+    SignHash,
+    SignTypedData,
+}
+
 /// Context passed to policy evaluation (and to executable policies via stdin).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyContext {
     pub chain_id: String,
     pub wallet_id: String,
     pub api_key_id: String,
+    pub request_type: PolicyRequestType,
     /// Transaction-shaped context for the signing request. Present for
     /// `sign_transaction`, `sign_message`, and `sign_hash` (the latter two
     /// surface their payload through `raw_hex`). Omitted for `sign_typed_data`,
-    /// which exposes its payload via [`TypedDataContext::raw_json`] instead.
+    /// which exposes its payload via [`TypedDataContext::raw_json`] instead —
+    /// branch on [`PolicyContext::request_type`] rather than on this field's
+    /// absence, which a defensively written policy cannot distinguish from an
+    /// empty transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction: Option<TransactionContext>,
     pub spending: SpendingContext,
@@ -223,6 +239,7 @@ mod tests {
             chain_id: "eip155:8453".into(),
             wallet_id: "3198bc9c-6672-5ab3-d995-4942343ae5b6".into(),
             api_key_id: "7a2f1b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c".into(),
+            request_type: PolicyRequestType::SignTransaction,
             transaction: Some(TransactionContext {
                 effects: vec![TransactionEffect {
                     address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),
@@ -352,6 +369,7 @@ mod tests {
             chain_id: "eip155:8453".into(),
             wallet_id: "w".into(),
             api_key_id: "k".into(),
+            request_type: PolicyRequestType::SignTransaction,
             transaction: Some(TransactionContext {
                 effects: vec![],
                 raw_hex: "0x00".into(),
@@ -376,6 +394,7 @@ mod tests {
             chain_id: "eip155:8453".into(),
             wallet_id: "w".into(),
             api_key_id: "k".into(),
+            request_type: PolicyRequestType::SignTypedData,
             transaction: None,
             spending: SpendingContext {
                 daily_total: "0".into(),
@@ -385,7 +404,25 @@ mod tests {
             typed_data: None,
         };
 
-        let json = serde_json::to_string(&ctx).unwrap();
-        assert!(!json.contains("transaction"));
+        let json: serde_json::Value = serde_json::to_value(&ctx).unwrap();
+        assert!(json.get("transaction").is_none());
+        // The absent key is not what a policy should key off; request_type is.
+        assert_eq!(json["request_type"], "sign_typed_data");
+    }
+
+    #[test]
+    fn test_policy_request_type_serde() {
+        for (variant, expected) in [
+            (PolicyRequestType::SignTransaction, "sign_transaction"),
+            (PolicyRequestType::SignMessage, "sign_message"),
+            (PolicyRequestType::SignHash, "sign_hash"),
+            (PolicyRequestType::SignTypedData, "sign_typed_data"),
+        ] {
+            assert_eq!(serde_json::to_value(variant).unwrap(), expected);
+            assert_eq!(
+                serde_json::from_value::<PolicyRequestType>(expected.into()).unwrap(),
+                variant
+            );
+        }
     }
 }

--- a/ows/crates/ows-core/src/wallet_file.rs
+++ b/ows/crates/ows-core/src/wallet_file.rs
@@ -34,7 +34,7 @@ pub struct WalletAccount {
 #[serde(rename_all = "snake_case")]
 pub enum KeyType {
     Mnemonic,
-    /// Multi-curve key pair: encrypted JSON `{"secp256k1":"hex","ed25519":"hex"}`.
+    /// Multi-curve key pair: encrypted JSON `{"secp256k1":"hex","ed25519":"hex","ed25519_bip32":"hex"}`.
     /// Supports all 6 chains.
     PrivateKey,
 }

--- a/ows/crates/ows-core/src/wallet_file.rs
+++ b/ows/crates/ows-core/src/wallet_file.rs
@@ -35,7 +35,7 @@ pub struct WalletAccount {
 pub enum KeyType {
     Mnemonic,
     /// Multi-curve key pair: encrypted JSON `{"secp256k1":"hex","ed25519":"hex","ed25519_bip32":"hex"}`.
-    /// Supports all 6 chains.
+    /// Derives one account per [`crate::chain::universal_wallet_chains`] row from these keys.
     PrivateKey,
 }
 

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -28,6 +28,7 @@ rand = "0.8"
 prost = "0.13"
 tonic = { version = "0.12", features = ["transport"] }
 tokio = { version = "1", features = ["rt"] }
+ed25519-bip32 = "0.4.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/ows/crates/ows-lib/Cargo.toml
+++ b/ows/crates/ows-lib/Cargo.toml
@@ -22,7 +22,7 @@ uuid = { version = "1", features = ["v4"] }
 hex = "0.4"
 base64 = "0.22"
 getrandom = "0.2"
-zeroize = "1"
+zeroize = { version = "1", features = ["serde"] }
 sha2 = "0.10"
 rand = "0.8"
 prost = "0.13"

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -126,6 +126,7 @@ pub fn sign_message_with_api_key(
     let transaction = ows_core::policy::TransactionContext {
         to: None,
         value: None,
+        effects: vec![],
         raw_hex: hex::encode(msg_bytes),
         data: None,
     };
@@ -162,6 +163,7 @@ pub fn sign_hash_with_api_key(
     let transaction = ows_core::policy::TransactionContext {
         to: None,
         value: None,
+        effects: vec![],
         raw_hex: hex::encode(policy_bytes),
         data: None,
     };

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -95,7 +95,14 @@ pub fn sign_with_api_key(
         data: None,
     };
     let (key, _) = enforce_policies_and_decrypt_key(
-        token, key_file, wallet, chain, transaction, None, index, vault_path,
+        token,
+        key_file,
+        wallet,
+        chain,
+        Some(transaction),
+        None,
+        index,
+        vault_path,
     )?;
 
     // 7. Sign (extract signable portion first — e.g. strips Solana sig-slot headers)
@@ -126,7 +133,14 @@ pub fn sign_message_with_api_key(
         data: None,
     };
     let (key, _) = enforce_policies_and_decrypt_key(
-        token, key_file, wallet, chain, transaction, None, index, vault_path,
+        token,
+        key_file,
+        wallet,
+        chain,
+        Some(transaction),
+        None,
+        index,
+        vault_path,
     )?;
     let signer = signer_for_chain(chain.chain_type);
     let output = signer.sign_message(key.expose(), msg_bytes)?;
@@ -155,7 +169,14 @@ pub fn sign_hash_with_api_key(
         data: None,
     };
     let (key, _) = enforce_policies_and_decrypt_key(
-        token, key_file, wallet, chain, transaction, None, index, vault_path,
+        token,
+        key_file,
+        wallet,
+        chain,
+        Some(transaction),
+        None,
+        index,
+        vault_path,
     )?;
 
     let signer = signer_for_chain(chain.chain_type);
@@ -207,7 +228,7 @@ pub fn sign_typed_data_with_api_key(
         }
     }
 
-    // 4. Build TypedDataContext + placeholder TransactionContext
+    // 4. Build TypedDataContext (no TransactionContext — typed data is not a transaction)
     let typed_data_ctx = ows_core::policy::TypedDataContext {
         verifying_contract: parsed
             .domain
@@ -228,12 +249,6 @@ pub fn sign_typed_data_with_api_key(
             .map(String::from),
         raw_json: typed_data_json.to_string(),
     };
-    let transaction = ows_core::policy::TransactionContext {
-        to: None,
-        value: None,
-        raw_hex: String::new(),
-        data: None,
-    };
 
     // 5. Evaluate policies
     let (key, _) = enforce_policies_and_decrypt_key(
@@ -241,7 +256,7 @@ pub fn sign_typed_data_with_api_key(
         key_file,
         wallet,
         chain,
-        transaction,
+        None,
         Some(typed_data_ctx),
         index,
         vault_path,
@@ -280,16 +295,16 @@ pub fn load_authorized_wallet(
 
 /// Assemble the `PolicyContext` around a caller-built `TransactionContext`
 /// (and optional `TypedDataContext`), run the policy engine, and decrypt
-/// the signing key on allow. Each flow constructs its own
-/// `TransactionContext` — the tx flow via the chain signer, non-tx flows
-/// via a `raw_hex`-only placeholder built from the payload.
+/// the signing key on allow. `transaction` is `None` for `sign_typed_data`
+/// (the payload is surfaced via `typed_data.raw_json` instead); other
+/// flows pass `Some(...)` with at least `raw_hex` populated.
 #[allow(clippy::too_many_arguments)]
 pub fn enforce_policies_and_decrypt_key(
     token: &str,
     key_file: ApiKeyFile,
     wallet: EncryptedWallet,
     chain: &ows_core::Chain,
-    transaction: ows_core::policy::TransactionContext,
+    transaction: Option<ows_core::policy::TransactionContext>,
     typed_data: Option<ows_core::policy::TypedDataContext>,
     index: Option<u32>,
     vault_path: Option<&Path>,
@@ -1168,7 +1183,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn sign_typed_data_with_api_key_executable_policy_receives_raw_json_not_raw_hex() {
+    fn sign_typed_data_with_api_key_executable_policy_receives_raw_json_no_transaction() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
@@ -1187,12 +1202,11 @@ import sys
 
 payload = json.load(sys.stdin)
 typed_data = payload.get("typed_data") or {{}}
-transaction = payload.get("transaction") or {{}}
 
-if typed_data.get("raw_json") == {typed_data_json:?} and transaction.get("raw_hex") == "":
+if typed_data.get("raw_json") == {typed_data_json:?} and "transaction" not in payload:
     print('{{"allow": true}}')
 else:
-    print(json.dumps({{"allow": False, "reason": f"raw_hex={{transaction.get('raw_hex')}} raw_json={{typed_data.get('raw_json')}}"}}))
+    print(json.dumps({{"allow": False, "reason": f"transaction={{payload.get('transaction')!r}} raw_json={{typed_data.get('raw_json')}}"}}))
 "#
             ),
         )

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -124,8 +124,6 @@ pub fn sign_message_with_api_key(
 ) -> Result<crate::types::SignResult, OwsLibError> {
     let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
     let transaction = ows_core::policy::TransactionContext {
-        to: None,
-        value: None,
         effects: vec![],
         raw_hex: hex::encode(msg_bytes),
         data: None,
@@ -161,8 +159,6 @@ pub fn sign_hash_with_api_key(
 ) -> Result<crate::types::SignResult, OwsLibError> {
     let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
     let transaction = ows_core::policy::TransactionContext {
-        to: None,
-        value: None,
         effects: vec![],
         raw_hex: hex::encode(policy_bytes),
         data: None,

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -87,13 +87,15 @@ pub fn sign_with_api_key(
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<crate::types::SignResult, OwsLibError> {
-    let (key, _) = enforce_policy_and_decrypt_key_with_raw_hex(
-        token,
-        wallet_name_or_id,
-        chain,
-        &hex::encode(tx_bytes),
-        index,
-        vault_path,
+    let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
+    let transaction = ows_core::policy::TransactionContext {
+        to: None,
+        value: None,
+        raw_hex: hex::encode(tx_bytes),
+        data: None,
+    };
+    let (key, _) = enforce_policies_and_decrypt_key(
+        token, key_file, wallet, chain, transaction, None, index, vault_path,
     )?;
 
     // 7. Sign (extract signable portion first — e.g. strips Solana sig-slot headers)
@@ -116,13 +118,15 @@ pub fn sign_message_with_api_key(
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<crate::types::SignResult, OwsLibError> {
-    let (key, _) = enforce_policy_and_decrypt_key_with_raw_hex(
-        token,
-        wallet_name_or_id,
-        chain,
-        &hex::encode(msg_bytes),
-        index,
-        vault_path,
+    let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
+    let transaction = ows_core::policy::TransactionContext {
+        to: None,
+        value: None,
+        raw_hex: hex::encode(msg_bytes),
+        data: None,
+    };
+    let (key, _) = enforce_policies_and_decrypt_key(
+        token, key_file, wallet, chain, transaction, None, index, vault_path,
     )?;
     let signer = signer_for_chain(chain.chain_type);
     let output = signer.sign_message(key.expose(), msg_bytes)?;
@@ -143,13 +147,15 @@ pub fn sign_hash_with_api_key(
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<crate::types::SignResult, OwsLibError> {
-    let (key, _) = enforce_policy_and_decrypt_key_with_raw_hex(
-        token,
-        wallet_name_or_id,
-        chain,
-        &hex::encode(policy_bytes),
-        index,
-        vault_path,
+    let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
+    let transaction = ows_core::policy::TransactionContext {
+        to: None,
+        value: None,
+        raw_hex: hex::encode(policy_bytes),
+        data: None,
+    };
+    let (key, _) = enforce_policies_and_decrypt_key(
+        token, key_file, wallet, chain, transaction, None, index, vault_path,
     )?;
 
     let signer = signer_for_chain(chain.chain_type);
@@ -181,26 +187,13 @@ pub fn sign_typed_data_with_api_key(
         ));
     }
 
-    // 2. Token lookup
-    let token_hash = key_store::hash_token(token);
-    let key_file = key_store::load_api_key_by_token_hash(&token_hash, vault_path)?;
+    // 2. Token lookup + expiry + wallet scope
+    let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
 
-    // 3. Expiry check
-    check_expiry(&key_file)?;
-
-    // 4. Wallet scope check
-    let wallet = vault::load_wallet_by_name_or_id(wallet_name_or_id, vault_path)?;
-    if !key_file.wallet_ids.contains(&wallet.id) {
-        return Err(OwsLibError::InvalidInput(format!(
-            "API key '{}' does not have access to wallet '{}'",
-            key_file.name, wallet.id,
-        )));
-    }
-
-    // 5. Parse typed data early — validates JSON and extracts domain fields
+    // 3. Parse typed data early — validates JSON and extracts domain fields
     let parsed = eip712::parse_typed_data(typed_data_json)?;
 
-    // 5b. Validate domain.chainId matches the requested chain (if present)
+    // 3b. Validate domain.chainId matches the requested chain (if present)
     // Prevents bypassing AllowedChains by submitting typed data with a different chainId
     if let Some(domain_chain_id) = parsed.domain.get("chainId").and_then(parse_domain_chain_id) {
         let expected_chain_id = chain
@@ -214,11 +207,7 @@ pub fn sign_typed_data_with_api_key(
         }
     }
 
-    // 6. Build PolicyContext with TypedDataContext
-    let policies = load_policies_for_key(&key_file, vault_path)?;
-    let now = chrono::Utc::now();
-    let date = now.format("%Y-%m-%d").to_string();
-
+    // 4. Build TypedDataContext + placeholder TransactionContext
     let typed_data_ctx = ows_core::policy::TypedDataContext {
         verifying_contract: parsed
             .domain
@@ -239,33 +228,26 @@ pub fn sign_typed_data_with_api_key(
             .map(String::from),
         raw_json: typed_data_json.to_string(),
     };
-
-    let context = ows_core::PolicyContext {
-        chain_id: chain.chain_id.to_string(),
-        wallet_id: wallet.id.clone(),
-        api_key_id: key_file.id.clone(),
-        transaction: ows_core::policy::TransactionContext {
-            to: None,
-            value: None,
-            raw_hex: String::new(),
-            data: None,
-        },
-        spending: noop_spending_context(&date),
-        timestamp: now.to_rfc3339(),
-        typed_data: Some(typed_data_ctx),
+    let transaction = ows_core::policy::TransactionContext {
+        to: None,
+        value: None,
+        raw_hex: String::new(),
+        data: None,
     };
 
-    // 7. Evaluate policies
-    let result = policy_engine::evaluate_policies(&policies, &context);
-    if !result.allow {
-        return Err(OwsLibError::Core(OwsError::PolicyDenied {
-            policy_id: result.policy_id.unwrap_or_default(),
-            reason: result.reason.unwrap_or_else(|| "denied".into()),
-        }));
-    }
+    // 5. Evaluate policies
+    let (key, _) = enforce_policies_and_decrypt_key(
+        token,
+        key_file,
+        wallet,
+        chain,
+        transaction,
+        Some(typed_data_ctx),
+        index,
+        vault_path,
+    )?;
 
-    // 8. Decrypt key and sign
-    let key = decrypt_key_from_api_key(&key_file, &wallet, token, chain.chain_type, index)?;
+    // 6. Sign
     let evm_signer = ows_signer::chains::EvmSigner;
     let output = evm_signer.sign_typed_data(key.expose(), typed_data_json)?;
 
@@ -275,34 +257,13 @@ pub fn sign_typed_data_with_api_key(
     })
 }
 
-/// Enforce policies for a token-based transaction and return the decrypted
-/// signing key. Used by `sign_and_send` which needs the raw key for broadcast.
-pub fn enforce_policy_and_decrypt_key(
+/// Token → key file lookup, expiry check, wallet load + scope check.
+/// Shared by every API-key-authorized flow.
+pub fn load_authorized_wallet(
     token: &str,
     wallet_name_or_id: &str,
-    chain: &ows_core::Chain,
-    tx_bytes: &[u8],
-    index: Option<u32>,
     vault_path: Option<&Path>,
-) -> Result<(SecretBytes, ApiKeyFile), OwsLibError> {
-    enforce_policy_and_decrypt_key_with_raw_hex(
-        token,
-        wallet_name_or_id,
-        chain,
-        &hex::encode(tx_bytes),
-        index,
-        vault_path,
-    )
-}
-
-fn enforce_policy_and_decrypt_key_with_raw_hex(
-    token: &str,
-    wallet_name_or_id: &str,
-    chain: &ows_core::Chain,
-    raw_hex: &str,
-    index: Option<u32>,
-    vault_path: Option<&Path>,
-) -> Result<(SecretBytes, ApiKeyFile), OwsLibError> {
+) -> Result<(ApiKeyFile, EncryptedWallet), OwsLibError> {
     let token_hash = key_store::hash_token(token);
     let key_file = key_store::load_api_key_by_token_hash(&token_hash, vault_path)?;
     check_expiry(&key_file)?;
@@ -314,7 +275,25 @@ fn enforce_policy_and_decrypt_key_with_raw_hex(
             key_file.name, wallet.id,
         )));
     }
+    Ok((key_file, wallet))
+}
 
+/// Assemble the `PolicyContext` around a caller-built `TransactionContext`
+/// (and optional `TypedDataContext`), run the policy engine, and decrypt
+/// the signing key on allow. Each flow constructs its own
+/// `TransactionContext` — the tx flow via the chain signer, non-tx flows
+/// via a `raw_hex`-only placeholder built from the payload.
+#[allow(clippy::too_many_arguments)]
+pub fn enforce_policies_and_decrypt_key(
+    token: &str,
+    key_file: ApiKeyFile,
+    wallet: EncryptedWallet,
+    chain: &ows_core::Chain,
+    transaction: ows_core::policy::TransactionContext,
+    typed_data: Option<ows_core::policy::TypedDataContext>,
+    index: Option<u32>,
+    vault_path: Option<&Path>,
+) -> Result<(SecretBytes, ApiKeyFile), OwsLibError> {
     let policies = load_policies_for_key(&key_file, vault_path)?;
     let now = chrono::Utc::now();
     let date = now.format("%Y-%m-%d").to_string();
@@ -323,15 +302,10 @@ fn enforce_policy_and_decrypt_key_with_raw_hex(
         chain_id: chain.chain_id.to_string(),
         wallet_id: wallet.id.clone(),
         api_key_id: key_file.id.clone(),
-        transaction: ows_core::policy::TransactionContext {
-            to: None,
-            value: None,
-            raw_hex: raw_hex.to_string(),
-            data: None,
-        },
+        transaction,
         spending: noop_spending_context(&date),
         timestamp: now.to_rfc3339(),
-        typed_data: None,
+        typed_data,
     };
 
     let result = policy_engine::evaluate_policies(&policies, &context);
@@ -343,7 +317,6 @@ fn enforce_policy_and_decrypt_key_with_raw_hex(
     }
 
     let key = decrypt_key_from_api_key(&key_file, &wallet, token, chain.chain_type, index)?;
-
     Ok((key, key_file))
 }
 

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -88,12 +88,10 @@ pub fn sign_with_api_key(
     vault_path: Option<&Path>,
 ) -> Result<crate::types::SignResult, OwsLibError> {
     let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
-    let transaction = ows_core::policy::TransactionContext {
-        to: None,
-        value: None,
-        raw_hex: hex::encode(tx_bytes),
-        data: None,
-    };
+
+    let signer = signer_for_chain(chain.chain_type);
+    let transaction = signer.make_transaction_context(tx_bytes, None)?;
+
     let (key, _) = enforce_policies_and_decrypt_key(
         token,
         key_file,
@@ -106,7 +104,6 @@ pub fn sign_with_api_key(
     )?;
 
     // 7. Sign (extract signable portion first — e.g. strips Solana sig-slot headers)
-    let signer = signer_for_chain(chain.chain_type);
     let signable = signer.extract_signable_bytes(tx_bytes)?;
     let output = signer.sign_transaction(key.expose(), signable)?;
 

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use ows_core::ChainType;
 use ows_core::{ApiKeyFile, EncryptedWallet, OwsError};
 use ows_signer::{
     decrypt, eip712, encrypt_with_hkdf, signer_for_chain, ChainSigner, CryptoEnvelope, SecretBytes,
@@ -90,7 +91,16 @@ pub fn sign_with_api_key(
     let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
 
     let signer = signer_for_chain(chain);
-    let transaction = signer.make_transaction_context(tx_bytes, None)?;
+    let rpc_url = if chain.chain_type == ChainType::Cardano {
+        Some(crate::ops::resolve_rpc_url(
+            chain.chain_id,
+            chain.chain_type,
+            None,
+        )?)
+    } else {
+        None
+    };
+    let transaction = signer.make_transaction_context(tx_bytes, rpc_url.as_deref())?;
 
     let (key, _) = enforce_policies_and_decrypt_key(
         token,

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use ows_core::{ApiKeyFile, EncryptedWallet, OwsError};
 use ows_signer::{
-    decrypt, eip712, encrypt_with_hkdf, signer_for_chain, CryptoEnvelope, SecretBytes,
+    decrypt, eip712, encrypt_with_hkdf, signer_for_chain, ChainSigner, CryptoEnvelope, SecretBytes,
 };
 
 use crate::error::OwsLibError;
@@ -120,6 +120,7 @@ pub fn sign_message_with_api_key(
     chain: &ows_core::Chain,
     msg_bytes: &[u8],
     index: Option<u32>,
+    address: Option<&str>,
     vault_path: Option<&Path>,
 ) -> Result<crate::types::SignResult, OwsLibError> {
     let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
@@ -139,7 +140,7 @@ pub fn sign_message_with_api_key(
         vault_path,
     )?;
     let signer = signer_for_chain(chain);
-    let output = signer.sign_message(key.expose(), msg_bytes)?;
+    let output = signer.sign_message(key.expose(), msg_bytes, address)?;
 
     Ok(crate::types::SignResult {
         signature: hex::encode(&output.signature),
@@ -194,6 +195,7 @@ pub fn sign_typed_data_with_api_key(
     chain: &ows_core::Chain,
     typed_data_json: &str,
     index: Option<u32>,
+    address: Option<&str>,
     vault_path: Option<&Path>,
 ) -> Result<crate::types::SignResult, OwsLibError> {
     // 1. EVM-only gate — cheapest check first
@@ -259,6 +261,7 @@ pub fn sign_typed_data_with_api_key(
 
     // 6. Sign
     let evm_signer = ows_signer::chains::EvmSigner;
+    evm_signer.verify_sign_message_address(key.expose(), address)?;
     let output = evm_signer.sign_typed_data(key.expose(), typed_data_json)?;
 
     Ok(crate::types::SignResult {
@@ -683,6 +686,7 @@ mod tests {
             &chain,
             b"hello",
             None,
+            None,
             Some(&vault),
         );
         assert!(
@@ -922,6 +926,7 @@ mod tests {
             &chain,
             &test_typed_data_json(),
             None,
+            None,
             Some(&vault),
         );
         assert!(
@@ -957,6 +962,7 @@ mod tests {
             "test-wallet",
             &chain,
             &test_typed_data_json(),
+            None,
             None,
             Some(&vault),
         );
@@ -1004,6 +1010,7 @@ mod tests {
             &chain,
             &wrong_contract_td,
             None,
+            None,
             Some(&vault),
         );
         assert!(result.is_err());
@@ -1038,6 +1045,7 @@ mod tests {
             &chain,
             "not valid json",
             None,
+            None,
             Some(&vault),
         );
         assert!(result.is_err());
@@ -1065,6 +1073,7 @@ mod tests {
             "test-wallet",
             &chain,
             &test_typed_data_json(),
+            None,
             None,
             Some(&vault),
         );
@@ -1108,6 +1117,7 @@ mod tests {
             "other-wallet",
             &chain,
             &test_typed_data_json(),
+            None,
             None,
             Some(&vault),
         );
@@ -1165,6 +1175,7 @@ mod tests {
             "test-wallet",
             &chain,
             &mismatched_td,
+            None,
             None,
             Some(&vault),
         );
@@ -1237,6 +1248,7 @@ else:
             "test-wallet",
             &chain,
             &typed_data_json,
+            None,
             None,
             Some(&vault),
         );

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -644,6 +644,7 @@ mod tests {
             Some(&vault),
             None,
             None,
+            None,
         )
         .unwrap();
         let policy_id = setup_test_policy(&vault);

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -89,7 +89,7 @@ pub fn sign_with_api_key(
 ) -> Result<crate::types::SignResult, OwsLibError> {
     let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
 
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(chain);
     let transaction = signer.make_transaction_context(tx_bytes, None)?;
 
     let (key, _) = enforce_policies_and_decrypt_key(
@@ -138,7 +138,7 @@ pub fn sign_message_with_api_key(
         index,
         vault_path,
     )?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(chain);
     let output = signer.sign_message(key.expose(), msg_bytes)?;
 
     Ok(crate::types::SignResult {
@@ -174,7 +174,7 @@ pub fn sign_hash_with_api_key(
         vault_path,
     )?;
 
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(chain);
     let output = signer.sign(key.expose(), hash_bytes)?;
 
     Ok(crate::types::SignResult {

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use ows_core::ChainType;
-use ows_core::{ApiKeyFile, EncryptedWallet, OwsError};
+use ows_core::{ApiKeyFile, EncryptedWallet, OwsError, PolicyRequestType};
 use ows_signer::{
     decrypt, eip712, encrypt_with_hkdf, signer_for_chain, ChainSigner, CryptoEnvelope, SecretBytes,
 };
@@ -107,6 +107,7 @@ pub fn sign_with_api_key(
         key_file,
         wallet,
         chain,
+        PolicyRequestType::SignTransaction,
         Some(transaction),
         None,
         index,
@@ -145,6 +146,7 @@ pub fn sign_message_with_api_key(
         key_file,
         wallet,
         chain,
+        PolicyRequestType::SignMessage,
         Some(transaction),
         None,
         index,
@@ -181,6 +183,7 @@ pub fn sign_hash_with_api_key(
         key_file,
         wallet,
         chain,
+        PolicyRequestType::SignHash,
         Some(transaction),
         None,
         index,
@@ -265,6 +268,7 @@ pub fn sign_typed_data_with_api_key(
         key_file,
         wallet,
         chain,
+        PolicyRequestType::SignTypedData,
         None,
         Some(typed_data_ctx),
         index,
@@ -307,13 +311,16 @@ pub fn load_authorized_wallet(
 /// (and optional `TypedDataContext`), run the policy engine, and decrypt
 /// the signing key on allow. `transaction` is `None` for `sign_typed_data`
 /// (the payload is surfaced via `typed_data.raw_json` instead); other
-/// flows pass `Some(...)` with at least `raw_hex` populated.
+/// flows pass `Some(...)` with at least `raw_hex` populated. `request_type`
+/// is what a policy branches on, so every call path has to name its
+/// operation rather than leave it to be inferred.
 #[allow(clippy::too_many_arguments)]
 pub fn enforce_policies_and_decrypt_key(
     token: &str,
     key_file: ApiKeyFile,
     wallet: EncryptedWallet,
     chain: &ows_core::Chain,
+    request_type: PolicyRequestType,
     transaction: Option<ows_core::policy::TransactionContext>,
     typed_data: Option<ows_core::policy::TypedDataContext>,
     index: Option<u32>,
@@ -327,6 +334,7 @@ pub fn enforce_policies_and_decrypt_key(
         chain_id: chain.chain_id.to_string(),
         wallet_id: wallet.id.clone(),
         api_key_id: key_file.id.clone(),
+        request_type,
         transaction,
         spending: noop_spending_context(&date),
         timestamp: now.to_rfc3339(),
@@ -1222,10 +1230,12 @@ import sys
 payload = json.load(sys.stdin)
 typed_data = payload.get("typed_data") or {{}}
 
-if typed_data.get("raw_json") == {typed_data_json:?} and "transaction" not in payload:
+if (typed_data.get("raw_json") == {typed_data_json:?}
+        and "transaction" not in payload
+        and payload.get("request_type") == "sign_typed_data"):
     print('{{"allow": true}}')
 else:
-    print(json.dumps({{"allow": False, "reason": f"transaction={{payload.get('transaction')!r}} raw_json={{typed_data.get('raw_json')}}"}}))
+    print(json.dumps({{"allow": False, "reason": f"request_type={{payload.get('request_type')!r}} transaction={{payload.get('transaction')!r}} raw_json={{typed_data.get('raw_json')}}"}}))
 "#
             ),
         )
@@ -1269,6 +1279,95 @@ else:
             result.is_ok(),
             "typed-data executable policy rejected context: {:?}",
             result.err()
+        );
+    }
+
+    /// A policy that reads the transaction context defensively (`or {}`) cannot tell an
+    /// absent `transaction` from an empty one, so it cannot recognize a typed-data
+    /// request that way. `request_type` is what lets it deny one, and it must not deny
+    /// the other operations along with it.
+    #[cfg(unix)]
+    #[test]
+    fn executable_policy_denies_typed_data_by_request_type_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let passphrase = "test-pass";
+        let wallet_id = setup_test_wallet(&vault, passphrase);
+
+        let script = vault.join("no-typed-data.py");
+        std::fs::write(
+            &script,
+            r#"#!/usr/bin/env python3
+import json
+import sys
+
+payload = json.load(sys.stdin)
+tx = payload.get("transaction") or {}
+if payload["request_type"] == "sign_typed_data":
+    print(json.dumps({"allow": False, "reason": "typed data signing is not permitted"}))
+else:
+    print(json.dumps({"allow": True, "reason": tx.get("raw_hex")}))
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let policy = ows_core::Policy {
+            id: "no-typed-data".to_string(),
+            name: "no typed data".to_string(),
+            version: 1,
+            created_at: "2026-03-22T10:00:00Z".to_string(),
+            rules: vec![],
+            executable: Some(script.display().to_string()),
+            config: None,
+            action: ows_core::PolicyAction::Deny,
+        };
+        policy_store::save_policy(&policy, Some(&vault)).unwrap();
+
+        let (token, _) = create_api_key(
+            "no-td-agent",
+            &[wallet_id],
+            &["no-typed-data".to_string()],
+            passphrase,
+            None,
+            Some(&vault),
+        )
+        .unwrap();
+
+        let chain = ows_core::parse_chain("base").unwrap();
+
+        let denied = sign_typed_data_with_api_key(
+            &token,
+            "test-wallet",
+            &chain,
+            &test_typed_data_json(),
+            None,
+            None,
+            Some(&vault),
+        );
+        assert!(
+            matches!(
+                denied,
+                Err(OwsLibError::Core(OwsError::PolicyDenied { .. }))
+            ),
+            "typed data should be denied, got {denied:?}"
+        );
+
+        let allowed = sign_message_with_api_key(
+            &token,
+            "test-wallet",
+            &chain,
+            b"hello",
+            None,
+            None,
+            Some(&vault),
+        );
+        assert!(
+            allowed.is_ok(),
+            "message signing should still be allowed: {:?}",
+            allowed.err()
         );
     }
 }

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -89,7 +89,7 @@ pub fn sign_with_api_key(
 ) -> Result<crate::types::SignResult, OwsLibError> {
     let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
 
-    let signer = signer_for_chain(chain);
+    let signer = signer_for_chain(chain)?;
     let rpc_url = if signer.transaction_context_needs_rpc() {
         Some(crate::ops::resolve_rpc_url(
             chain.chain_id,
@@ -151,7 +151,7 @@ pub fn sign_message_with_api_key(
         index,
         vault_path,
     )?;
-    let signer = signer_for_chain(chain);
+    let signer = signer_for_chain(chain)?;
     let output = signer.sign_message(key.expose(), msg_bytes, address)?;
 
     Ok(crate::types::SignResult {
@@ -189,7 +189,7 @@ pub fn sign_hash_with_api_key(
         vault_path,
     )?;
 
-    let signer = signer_for_chain(chain);
+    let signer = signer_for_chain(chain)?;
     let output = signer.sign(key.expose(), hash_bytes)?;
 
     Ok(crate::types::SignResult {

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -138,6 +138,7 @@ pub fn sign_message_with_api_key(
         effects: vec![],
         raw_hex: hex::encode(msg_bytes),
         data: None,
+        chain_extra: None,
     };
     let (key, _) = enforce_policies_and_decrypt_key(
         token,
@@ -173,6 +174,7 @@ pub fn sign_hash_with_api_key(
         effects: vec![],
         raw_hex: hex::encode(policy_bytes),
         data: None,
+        chain_extra: None,
     };
     let (key, _) = enforce_policies_and_decrypt_key(
         token,

--- a/ows/crates/ows-lib/src/key_ops.rs
+++ b/ows/crates/ows-lib/src/key_ops.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use ows_core::ChainType;
 use ows_core::{ApiKeyFile, EncryptedWallet, OwsError, PolicyRequestType};
 use ows_signer::{
     decrypt, eip712, encrypt_with_hkdf, signer_for_chain, ChainSigner, CryptoEnvelope, SecretBytes,
@@ -91,7 +90,7 @@ pub fn sign_with_api_key(
     let (key_file, wallet) = load_authorized_wallet(token, wallet_name_or_id, vault_path)?;
 
     let signer = signer_for_chain(chain);
-    let rpc_url = if chain.chain_type == ChainType::Cardano {
+    let rpc_url = if signer.transaction_context_needs_rpc() {
         Some(crate::ops::resolve_rpc_url(
             chain.chain_id,
             chain.chain_type,

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -705,7 +705,7 @@ pub fn sign_and_send(
             key_file,
             wallet_obj,
             &chain_info,
-            transaction,
+            Some(transaction),
             None,
             index,
             vault_path,

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -694,12 +694,8 @@ pub fn sign_and_send(
         let chain_info = parse_chain(chain)?;
         let (key_file, wallet_obj) =
             crate::key_ops::load_authorized_wallet(credential, wallet, vault_path)?;
-        let transaction = ows_core::policy::TransactionContext {
-            to: None,
-            value: None,
-            raw_hex: hex::encode(&tx_bytes),
-            data: None,
-        };
+        let signer = signer_for_chain(chain_info.chain_type);
+        let transaction = signer.make_transaction_context(&tx_bytes, rpc_url)?;
         let (key, _) = crate::key_ops::enforce_policies_and_decrypt_key(
             credential,
             key_file,

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -692,11 +692,21 @@ pub fn sign_and_send(
     // Agent mode: enforce policies, decrypt key, then sign + broadcast
     if credential.starts_with(crate::key_store::TOKEN_PREFIX) {
         let chain_info = parse_chain(chain)?;
-        let (key, _) = crate::key_ops::enforce_policy_and_decrypt_key(
+        let (key_file, wallet_obj) =
+            crate::key_ops::load_authorized_wallet(credential, wallet, vault_path)?;
+        let transaction = ows_core::policy::TransactionContext {
+            to: None,
+            value: None,
+            raw_hex: hex::encode(&tx_bytes),
+            data: None,
+        };
+        let (key, _) = crate::key_ops::enforce_policies_and_decrypt_key(
             credential,
-            wallet,
+            key_file,
+            wallet_obj,
             &chain_info,
-            &tx_bytes,
+            transaction,
+            None,
             index,
             vault_path,
         )?;

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -648,6 +648,7 @@ pub fn sign_authorization(
 ///
 /// The `passphrase` parameter accepts either the owner's passphrase or an
 /// API token (`ows_key_...`).
+#[allow(clippy::too_many_arguments)]
 pub fn sign_message(
     wallet: &str,
     chain: &str,
@@ -655,6 +656,7 @@ pub fn sign_message(
     passphrase: Option<&str>,
     encoding: Option<&str>,
     index: Option<u32>,
+    address: Option<&str>,
     vault_path: Option<&Path>,
 ) -> Result<SignResult, OwsLibError> {
     let credential = passphrase.unwrap_or("");
@@ -675,7 +677,7 @@ pub fn sign_message(
     if credential.starts_with(crate::key_store::TOKEN_PREFIX) {
         let chain = parse_chain(chain)?;
         return crate::key_ops::sign_message_with_api_key(
-            credential, wallet, &chain, &msg_bytes, index, vault_path,
+            credential, wallet, &chain, &msg_bytes, index, address, vault_path,
         );
     }
 
@@ -683,7 +685,7 @@ pub fn sign_message(
     let chain = parse_chain(chain)?;
     let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
     let signer = signer_for_chain(&chain);
-    let output = signer.sign_message(key.expose(), &msg_bytes)?;
+    let output = signer.sign_message(key.expose(), &msg_bytes, address)?;
 
     Ok(SignResult {
         signature: hex::encode(&output.signature),
@@ -702,6 +704,7 @@ pub fn sign_typed_data(
     typed_data_json: &str,
     passphrase: Option<&str>,
     index: Option<u32>,
+    address: Option<&str>,
     vault_path: Option<&Path>,
 ) -> Result<SignResult, OwsLibError> {
     let credential = passphrase.unwrap_or("");
@@ -720,11 +723,14 @@ pub fn sign_typed_data(
             &chain,
             typed_data_json,
             index,
+            address,
             vault_path,
         );
     }
 
     let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
+    let signer = signer_for_chain(&chain);
+    signer.verify_sign_message_address(key.expose(), address)?;
     let evm_signer = ows_signer::chains::EvmSigner;
     let output = evm_signer.sign_typed_data(key.expose(), typed_data_json)?;
 
@@ -1423,6 +1429,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
                 Some(vault),
             );
             assert!(
@@ -1495,8 +1502,28 @@ mod tests {
         let vault = dir.path();
         create_wallet("det-sign", None, None, Some(vault)).unwrap();
 
-        let s1 = sign_message("det-sign", "evm", "hello", None, None, None, Some(vault)).unwrap();
-        let s2 = sign_message("det-sign", "evm", "hello", None, None, None, Some(vault)).unwrap();
+        let s1 = sign_message(
+            "det-sign",
+            "evm",
+            "hello",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
+        let s2 = sign_message(
+            "det-sign",
+            "evm",
+            "hello",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
         assert_eq!(
             s1.signature, s2.signature,
             "same message should produce same signature"
@@ -1509,8 +1536,28 @@ mod tests {
         let vault = dir.path();
         create_wallet("diff-msg", None, None, Some(vault)).unwrap();
 
-        let s1 = sign_message("diff-msg", "evm", "hello", None, None, None, Some(vault)).unwrap();
-        let s2 = sign_message("diff-msg", "evm", "world", None, None, None, Some(vault)).unwrap();
+        let s1 = sign_message(
+            "diff-msg",
+            "evm",
+            "hello",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
+        let s2 = sign_message(
+            "diff-msg",
+            "evm",
+            "world",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
         assert_ne!(s1.signature, s2.signature);
     }
 
@@ -1527,6 +1574,7 @@ mod tests {
             "pk-sign",
             "evm",
             "hello",
+            None,
             None,
             None,
             None,
@@ -1567,8 +1615,28 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         save_privkey_wallet("pk-det", TEST_PRIVKEY, "", dir.path());
 
-        let s1 = sign_message("pk-det", "evm", "test", None, None, None, Some(dir.path())).unwrap();
-        let s2 = sign_message("pk-det", "evm", "test", None, None, None, Some(dir.path())).unwrap();
+        let s1 = sign_message(
+            "pk-det",
+            "evm",
+            "test",
+            None,
+            None,
+            None,
+            None,
+            Some(dir.path()),
+        )
+        .unwrap();
+        let s2 = sign_message(
+            "pk-det",
+            "evm",
+            "test",
+            None,
+            None,
+            None,
+            None,
+            Some(dir.path()),
+        )
+        .unwrap();
         assert_eq!(s1.signature, s2.signature);
     }
 
@@ -1580,8 +1648,10 @@ mod tests {
         create_wallet("mn-w", None, None, Some(vault)).unwrap();
         save_privkey_wallet("pk-w", TEST_PRIVKEY, "", vault);
 
-        let mn_sig = sign_message("mn-w", "evm", "hello", None, None, None, Some(vault)).unwrap();
-        let pk_sig = sign_message("pk-w", "evm", "hello", None, None, None, Some(vault)).unwrap();
+        let mn_sig =
+            sign_message("mn-w", "evm", "hello", None, None, None, None, Some(vault)).unwrap();
+        let pk_sig =
+            sign_message("pk-w", "evm", "hello", None, None, None, None, Some(vault)).unwrap();
         assert_ne!(
             mn_sig.signature, pk_sig.signature,
             "different keys should produce different signatures"
@@ -1610,7 +1680,17 @@ mod tests {
         );
 
         // Should be able to sign
-        let sig = sign_message("pk-api", "evm", "hello", None, None, None, Some(vault)).unwrap();
+        let sig = sign_message(
+            "pk-api",
+            "evm",
+            "hello",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
         assert!(!sig.signature.is_empty());
 
         // Export should return JSON key pair with original key
@@ -1653,6 +1733,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(vault),
         )
         .unwrap();
@@ -1663,6 +1744,7 @@ mod tests {
             "pk-secp-and-ed",
             "solana",
             "hello",
+            None,
             None,
             None,
             None,
@@ -1802,6 +1884,7 @@ mod tests {
             Some("s3cret"),
             None,
             None,
+            None,
             Some(vault),
         )
         .unwrap();
@@ -1819,13 +1902,24 @@ mod tests {
             Some("wrong"),
             None,
             None,
+            None,
             Some(vault)
         )
         .is_err());
         assert!(export_wallet("pass-mn", Some("wrong"), Some(vault)).is_err());
 
         // No passphrase should fail (defaults to empty string, which is wrong)
-        assert!(sign_message("pass-mn", "evm", "hello", None, None, None, Some(vault)).is_err());
+        assert!(sign_message(
+            "pass-mn",
+            "evm",
+            "hello",
+            None,
+            None,
+            None,
+            None,
+            Some(vault)
+        )
+        .is_err());
     }
 
     #[test]
@@ -1839,6 +1933,7 @@ mod tests {
             "evm",
             "hello",
             Some("mypass"),
+            None,
             None,
             None,
             Some(dir.path()),
@@ -1856,6 +1951,7 @@ mod tests {
             "evm",
             "hello",
             Some("wrong"),
+            None,
             None,
             None,
             Some(dir.path())
@@ -1887,6 +1983,7 @@ mod tests {
             "verify-evm",
             "evm",
             "hello world",
+            None,
             None,
             None,
             None,
@@ -1941,7 +2038,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         assert!(get_wallet("nope", Some(dir.path())).is_err());
         assert!(export_wallet("nope", None, Some(dir.path())).is_err());
-        assert!(sign_message("nope", "evm", "x", None, None, None, Some(dir.path())).is_err());
+        assert!(
+            sign_message("nope", "evm", "x", None, None, None, None, Some(dir.path())).is_err()
+        );
         assert!(delete_wallet("nope", Some(dir.path())).is_err());
     }
 
@@ -1974,9 +2073,17 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
         create_wallet("chain-err", None, None, Some(vault)).unwrap();
-        assert!(
-            sign_message("chain-err", "fakecoin", "hi", None, None, None, Some(vault)).is_err()
-        );
+        assert!(sign_message(
+            "chain-err",
+            "fakecoin",
+            "hi",
+            None,
+            None,
+            None,
+            None,
+            Some(vault)
+        )
+        .is_err());
     }
 
     #[test]
@@ -2064,6 +2171,7 @@ mod tests {
             None,
             Some("hex"),
             None,
+            None,
             Some(vault),
         )
         .unwrap();
@@ -2076,6 +2184,7 @@ mod tests {
             "hello",
             None,
             Some("utf8"),
+            None,
             None,
             Some(vault),
         )
@@ -2097,6 +2206,7 @@ mod tests {
             "hello",
             None,
             Some("base64"),
+            None,
             None,
             Some(vault)
         )
@@ -2120,9 +2230,9 @@ mod tests {
         assert_eq!(wallets.len(), 3);
 
         // All can sign independently
-        let s1 = sign_message("w1", "evm", "test", None, None, None, Some(vault)).unwrap();
-        let s2 = sign_message("w2", "evm", "test", None, None, None, Some(vault)).unwrap();
-        let s3 = sign_message("w3", "evm", "test", None, None, None, Some(vault)).unwrap();
+        let s1 = sign_message("w1", "evm", "test", None, None, None, None, Some(vault)).unwrap();
+        let s2 = sign_message("w2", "evm", "test", None, None, None, None, Some(vault)).unwrap();
+        let s3 = sign_message("w3", "evm", "test", None, None, None, None, Some(vault)).unwrap();
 
         // All signatures should be different (different keys)
         assert_ne!(s1.signature, s2.signature);
@@ -2132,8 +2242,8 @@ mod tests {
         // Delete one, others survive
         delete_wallet("w2", Some(vault)).unwrap();
         assert_eq!(list_wallets(Some(vault)).unwrap().len(), 2);
-        assert!(sign_message("w1", "evm", "test", None, None, None, Some(vault)).is_ok());
-        assert!(sign_message("w3", "evm", "test", None, None, None, Some(vault)).is_ok());
+        assert!(sign_message("w1", "evm", "test", None, None, None, None, Some(vault)).is_ok());
+        assert!(sign_message("w3", "evm", "test", None, None, None, None, Some(vault)).is_ok());
     }
 
     // ================================================================
@@ -2268,6 +2378,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(vault),
         )
         .unwrap();
@@ -2307,13 +2418,23 @@ mod tests {
         );
 
         // Same for sign_message
-        let msg_none =
-            sign_message("char-equiv", "evm", "test", None, None, None, Some(vault)).unwrap();
+        let msg_none = sign_message(
+            "char-equiv",
+            "evm",
+            "test",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
         let msg_empty = sign_message(
             "char-equiv",
             "evm",
             "test",
             Some(""),
+            None,
             None,
             None,
             Some(vault),
@@ -2360,6 +2481,7 @@ mod tests {
             "evm",
             "test",
             Some("some-random-passphrase"),
+            None,
             None,
             None,
             Some(vault),
@@ -2453,17 +2575,47 @@ mod tests {
         create_wallet("orig-name", None, None, Some(vault)).unwrap();
 
         // Sign with original name
-        let sig1 = sign_message("orig-name", "evm", "test", None, None, None, Some(vault)).unwrap();
+        let sig1 = sign_message(
+            "orig-name",
+            "evm",
+            "test",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
         assert!(!sig1.signature.is_empty());
 
         // Rename
         rename_wallet("orig-name", "new-name", Some(vault)).unwrap();
 
         // Old name no longer works
-        assert!(sign_message("orig-name", "evm", "test", None, None, None, Some(vault)).is_err());
+        assert!(sign_message(
+            "orig-name",
+            "evm",
+            "test",
+            None,
+            None,
+            None,
+            None,
+            Some(vault)
+        )
+        .is_err());
 
         // Sign with new name — should produce same signature (same key)
-        let sig2 = sign_message("new-name", "evm", "test", None, None, None, Some(vault)).unwrap();
+        let sig2 = sign_message(
+            "new-name",
+            "evm",
+            "test",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
         assert_eq!(
             sig1.signature, sig2.signature,
             "renamed wallet should produce identical signatures"
@@ -2477,15 +2629,33 @@ mod tests {
         create_wallet("del-me-char", None, None, Some(vault)).unwrap();
 
         // Sign succeeds
-        let sig =
-            sign_message("del-me-char", "evm", "test", None, None, None, Some(vault)).unwrap();
+        let sig = sign_message(
+            "del-me-char",
+            "evm",
+            "test",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
         assert!(!sig.signature.is_empty());
 
         // Delete
         delete_wallet("del-me-char", Some(vault)).unwrap();
 
         // Sign after delete fails with WalletNotFound
-        let result = sign_message("del-me-char", "evm", "test", None, None, None, Some(vault));
+        let result = sign_message(
+            "del-me-char",
+            "evm",
+            "test",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        );
         assert!(result.is_err());
         match result.unwrap_err() {
             OwsLibError::WalletNotFound(name) => assert_eq!(name, "del-me-char"),
@@ -2510,6 +2680,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(v1.path()),
         )
         .unwrap();
@@ -2526,6 +2697,7 @@ mod tests {
             "char-det-2",
             "evm",
             "determinism test",
+            None,
             None,
             None,
             None,
@@ -2575,6 +2747,7 @@ mod tests {
             ("cosmos", true),
             ("tron", true),
             ("ton", false),
+            ("spark", false),
             ("sui", false),
             ("cardano", false),
         ];
@@ -2583,6 +2756,7 @@ mod tests {
                 "char-all-chains",
                 chain,
                 "hello",
+                None,
                 None,
                 None,
                 None,
@@ -2624,7 +2798,15 @@ mod tests {
             "message": {"value": "42"}
         }"#;
 
-        let result = sign_typed_data("char-typed", "evm", typed_data, None, None, Some(vault));
+        let result = sign_typed_data(
+            "char-typed",
+            "evm",
+            typed_data,
+            None,
+            None,
+            None,
+            Some(vault),
+        );
         assert!(result.is_ok(), "sign_typed_data failed: {:?}", result.err());
 
         let sig = result.unwrap();
@@ -2679,6 +2861,7 @@ mod tests {
             None,
             None,
             Some(0),
+            None,
             Some(vault),
         )
         .unwrap();
@@ -2689,6 +2872,7 @@ mod tests {
             None,
             None,
             Some(1),
+            None,
             Some(vault),
         )
         .unwrap();
@@ -2745,7 +2929,16 @@ mod tests {
 
         // Sign message on multiple chains
         for chain in &["evm", "solana", "bitcoin", "cosmos"] {
-            let result = sign_message("char-24w", chain, "test", None, None, None, Some(vault));
+            let result = sign_message(
+                "char-24w",
+                chain,
+                "test",
+                None,
+                None,
+                None,
+                None,
+                Some(vault),
+            );
             assert!(
                 result.is_ok(),
                 "24-word wallet sign_message failed for {chain}: {:?}",
@@ -2783,6 +2976,7 @@ mod tests {
                         "char-conc",
                         "evm",
                         &msg,
+                        None,
                         None,
                         None,
                         None,
@@ -3019,7 +3213,15 @@ mod tests {
             "message": {"value": "1"}
         }"#;
 
-        let result = sign_typed_data(&w.id, "solana", typed_data, Some("pass"), None, Some(vault));
+        let result = sign_typed_data(
+            &w.id,
+            "solana",
+            typed_data,
+            Some("pass"),
+            None,
+            None,
+            Some(vault),
+        );
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -3049,7 +3251,15 @@ mod tests {
             "message": {"value": "42"}
         }"#;
 
-        let result = sign_typed_data(&w.id, "evm", typed_data, Some("pass"), None, Some(vault));
+        let result = sign_typed_data(
+            &w.id,
+            "evm",
+            typed_data,
+            Some("pass"),
+            None,
+            None,
+            Some(vault),
+        );
         assert!(result.is_ok(), "sign_typed_data failed: {:?}", result.err());
 
         let sign_result = result.unwrap();
@@ -3441,13 +3651,22 @@ mod tests {
         create_wallet("reg-msg", None, None, Some(vault)).unwrap();
 
         // Through the public API
-        let api_result =
-            sign_message("reg-msg", "evm", "hello", None, None, None, Some(vault)).unwrap();
+        let api_result = sign_message(
+            "reg-msg",
+            "evm",
+            "hello",
+            None,
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
 
         // Direct signer
         let key = decrypt_signing_key("reg-msg", ChainType::Evm, "", None, Some(vault)).unwrap();
         let signer = signer_for_chain_type(ChainType::Evm);
-        let direct = signer.sign_message(key.expose(), b"hello").unwrap();
+        let direct = signer.sign_message(key.expose(), b"hello", None).unwrap();
 
         assert_eq!(
             api_result.signature,

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -6,8 +6,8 @@ use ows_core::{
     ALL_CHAIN_TYPES,
 };
 use ows_signer::{
-    decrypt, encrypt, signer_for_chain, CryptoEnvelope, Curve, HdDeriver, Mnemonic,
-    MnemonicStrength, SecretBytes,
+    decrypt, encrypt, signer_for_chain, signer_for_chain_type, CryptoEnvelope, Curve, HdDeriver,
+    Mnemonic, MnemonicStrength, SecretBytes,
 };
 
 use crate::error::OwsLibError;
@@ -41,7 +41,7 @@ fn derive_all_accounts(mnemonic: &Mnemonic, index: u32) -> Result<Vec<WalletAcco
     let mut accounts = Vec::with_capacity(ALL_CHAIN_TYPES.len());
     for ct in &ALL_CHAIN_TYPES {
         let chain = default_chain_for_type(*ct);
-        let signer = signer_for_chain(*ct);
+        let signer = signer_for_chain_type(*ct);
         let paths = signer.default_derivation_paths(index);
         let curve = signer.curve();
         let keys = HdDeriver::derive_keys_from_mnemonic(mnemonic, "", paths, curve)?;
@@ -115,7 +115,7 @@ impl KeyPair {
 fn derive_all_accounts_from_keys(keys: &KeyPair) -> Result<Vec<WalletAccount>, OwsLibError> {
     let mut accounts = Vec::with_capacity(ALL_CHAIN_TYPES.len());
     for ct in &ALL_CHAIN_TYPES {
-        let signer = signer_for_chain(*ct);
+        let signer = signer_for_chain_type(*ct);
         let key = keys.key_for_curve(signer.curve());
         let address = signer.derive_address(key)?;
         let chain = default_chain_for_type(*ct);
@@ -142,7 +142,7 @@ pub(crate) fn secret_to_signing_key(
                 OwsLibError::InvalidInput("wallet contains invalid UTF-8 mnemonic".into())
             })?;
             let mnemonic = Mnemonic::from_phrase(phrase)?;
-            let signer = signer_for_chain(chain_type);
+            let signer = signer_for_chain_type(chain_type);
             let keys = HdDeriver::derive_keys_from_mnemonic_cached(
                 &mnemonic,
                 "",
@@ -154,7 +154,7 @@ pub(crate) fn secret_to_signing_key(
         KeyType::PrivateKey => {
             // JSON key pair — extract the right key for this chain's curve
             let keys = KeyPair::from_json_bytes(secret.expose())?;
-            let signer = signer_for_chain(chain_type);
+            let signer = signer_for_chain_type(chain_type);
             Ok(SecretBytes::from_slice(keys.key_for_curve(signer.curve())))
         }
     }
@@ -182,7 +182,7 @@ pub fn derive_address(
 ) -> Result<String, OwsLibError> {
     let chain = parse_chain(chain)?;
     let mnemonic = Mnemonic::from_phrase(mnemonic_phrase)?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
     let paths = signer.default_derivation_paths(index.unwrap_or(0));
     let curve = signer.curve();
 
@@ -313,7 +313,7 @@ pub fn import_wallet_private_key(
             let source_curve = match chain {
                 Some(c) => {
                     let parsed = parse_chain(c)?;
-                    signer_for_chain(parsed.chain_type).curve()
+                    signer_for_chain(&parsed).curve()
                 }
                 None => ows_signer::Curve::Secp256k1,
             };
@@ -451,7 +451,7 @@ fn sign_hash_with_credential(
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<SignResult, OwsLibError> {
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(chain);
     if signer.curve() != Curve::Secp256k1 {
         return Err(OwsLibError::InvalidInput(
             "raw hash signing is only supported for secp256k1-backed chains".into(),
@@ -516,7 +516,7 @@ pub fn sign_transaction(
     // Owner mode: existing passphrase-based signing (unchanged)
     let chain = parse_chain(chain)?;
     let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
     let signable = signer.extract_signable_bytes(&tx_bytes)?;
     let output = signer.sign_transaction(key.expose(), signable)?;
 
@@ -621,7 +621,7 @@ pub fn sign_message(
     // Owner mode
     let chain = parse_chain(chain)?;
     let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
     let output = signer.sign_message(key.expose(), &msg_bytes)?;
 
     Ok(SignResult {
@@ -698,7 +698,7 @@ pub fn sign_and_send(
         let chain_info = parse_chain(chain)?;
         let (key_file, wallet_obj) =
             crate::key_ops::load_authorized_wallet(credential, wallet, vault_path)?;
-        let signer = signer_for_chain(chain_info.chain_type);
+        let signer = signer_for_chain(&chain_info);
         let transaction = signer.make_transaction_context(&tx_bytes, rpc_url)?;
         let (key, _) = crate::key_ops::enforce_policies_and_decrypt_key(
             credential,
@@ -733,7 +733,7 @@ pub fn sign_encode_and_broadcast(
     rpc_url: Option<&str>,
 ) -> Result<SendResult, OwsLibError> {
     let chain = parse_chain(chain)?;
-    let signer = signer_for_chain(chain.chain_type);
+    let signer = signer_for_chain(&chain);
 
     // 1. Extract signable portion (strips signature-slot headers for Solana; no-op for others)
     let signable = signer.extract_signable_bytes(tx_bytes)?;
@@ -1913,7 +1913,7 @@ mod tests {
 
         // Now encode the full signed transaction (what the library does correctly)
         let key = decrypt_signing_key("send-bug", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm);
         let output = signer.sign_transaction(key.expose(), &unsigned_tx).unwrap();
         let full_signed_tx = signer
             .encode_signed_transaction(&unsigned_tx, &output)
@@ -2630,7 +2630,7 @@ mod tests {
         // by manually calling the signer's extract/sign/encode chain:
         let key =
             decrypt_signing_key("char-sol-sig", ChainType::Solana, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Solana);
+        let signer = signer_for_chain_type(ChainType::Solana);
 
         let signable = signer.extract_signable_bytes(&tx_bytes).unwrap();
         assert_eq!(
@@ -2696,7 +2696,7 @@ mod tests {
         // Path B: the internal pipeline (what sign_and_send uses)
         let key =
             decrypt_signing_key("char-encode", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm);
         let output = signer.sign_transaction(key.expose(), &unsigned_tx).unwrap();
         let full_signed_tx = signer
             .encode_signed_transaction(&unsigned_tx, &output)
@@ -2817,7 +2817,7 @@ mod tests {
 
         let key =
             decrypt_signing_key(&wallet.id, ChainType::Evm, "pass", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm);
         let direct = signer
             .sign(key.expose(), &hex::decode(&hash_hex).unwrap())
             .unwrap();
@@ -3107,7 +3107,7 @@ mod tests {
 
         // Path B: direct signer call (no credential branch)
         let key = decrypt_signing_key("reg-owner", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm);
         let tx_bytes = hex::decode(tx_hex).unwrap();
         let direct_output = signer.sign_transaction(key.expose(), &tx_bytes).unwrap();
 
@@ -3177,7 +3177,7 @@ mod tests {
 
         // Direct signer
         let key = decrypt_signing_key("reg-msg", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm);
         let direct = signer.sign_message(key.expose(), b"hello").unwrap();
 
         assert_eq!(
@@ -3308,7 +3308,7 @@ mod tests {
         // Path B: manual extract + sign
         let key =
             decrypt_signing_key("sol-match", ChainType::Solana, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain(ChainType::Solana);
+        let signer = signer_for_chain_type(ChainType::Solana);
         let signable = signer.extract_signable_bytes(&full_tx).unwrap();
         let direct = signer.sign_transaction(key.expose(), signable).unwrap();
 

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -1,10 +1,11 @@
+use std::io::Write;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use zeroize::Zeroizing;
 
 use ows_core::{
-    default_chain_for_type, ChainType, Config, EncryptedWallet, KeyType, WalletAccount,
-    ALL_CHAIN_TYPES,
+    universal_wallet_chains, ChainType, Config, EncryptedWallet, KeyType, WalletAccount,
+    UNIVERSAL_WALLET_ACCOUNT_COUNT,
 };
 use ows_signer::{
     decrypt, encrypt, signer_for_chain, signer_for_chain_type, CryptoEnvelope, Curve, HdDeriver,
@@ -39,10 +40,9 @@ fn parse_chain(s: &str) -> Result<ows_core::Chain, OwsLibError> {
 
 /// Derive accounts for all chain families from a mnemonic at the given index.
 fn derive_all_accounts(mnemonic: &Mnemonic, index: u32) -> Result<Vec<WalletAccount>, OwsLibError> {
-    let mut accounts = Vec::with_capacity(ALL_CHAIN_TYPES.len());
-    for ct in &ALL_CHAIN_TYPES {
-        let chain = default_chain_for_type(*ct);
-        let signer = signer_for_chain_type(*ct);
+    let mut accounts = Vec::with_capacity(UNIVERSAL_WALLET_ACCOUNT_COUNT);
+    for chain in universal_wallet_chains() {
+        let signer = signer_for_chain(&chain);
         let paths = signer.default_derivation_paths(index);
         let curve = signer.curve();
         let keys = HdDeriver::derive_keys_from_mnemonic(mnemonic, "", paths, curve)?;
@@ -53,6 +53,7 @@ fn derive_all_accounts(mnemonic: &Mnemonic, index: u32) -> Result<Vec<WalletAcco
             account_id,
             address,
             chain_id: chain.chain_id.to_string(),
+            // TODO: Cardano addresses are derived using multiple paths, consider storing all paths in WalletAccount
             derivation_path: signer.default_derivation_path(index),
         });
     }
@@ -164,12 +165,11 @@ impl KeyPair {
 
 /// Derive accounts for all chain families using a key pair (one key per curve).
 fn derive_all_accounts_from_keys(keys: &KeyPair) -> Result<Vec<WalletAccount>, OwsLibError> {
-    let mut accounts = Vec::with_capacity(ALL_CHAIN_TYPES.len());
-    for ct in &ALL_CHAIN_TYPES {
-        let signer = signer_for_chain_type(*ct);
+    let mut accounts = Vec::with_capacity(UNIVERSAL_WALLET_ACCOUNT_COUNT);
+    for chain in universal_wallet_chains() {
+        let signer = signer_for_chain(&chain);
         let key = keys.key_for_curve(signer.curve());
         let address = signer.derive_address(key)?;
-        let chain = default_chain_for_type(*ct);
         accounts.push(WalletAccount {
             account_id: format!("{}:{}", chain.chain_id, address),
             address,
@@ -891,7 +891,80 @@ fn broadcast(chain: ChainType, rpc_url: &str, signed_bytes: &[u8]) -> Result<Str
         ChainType::Xrpl => broadcast_xrpl(rpc_url, signed_bytes),
         ChainType::Nano => broadcast_nano(rpc_url, signed_bytes),
         ChainType::Near => crate::near_rpc::broadcast_tx_commit(rpc_url, signed_bytes),
+        ChainType::Cardano => broadcast_cardano(rpc_url, signed_bytes),
     }
+}
+
+fn broadcast_cardano(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibError> {
+    let url = format!("{}/submittx", rpc_url.trim_end_matches('/'));
+
+    // `--data-binary @-` tells curl to read the request body verbatim from stdin
+    let mut child = Command::new("curl")
+        .args([
+            "-sSL",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/cbor",
+            "--data-binary",
+            "@-",
+            "-w",
+            "\n%{http_code}",
+            &url,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            OwsLibError::BroadcastFailed(format!("Cardano broadcast: failed to run curl: {e}"))
+        })?;
+
+    {
+        let stdin = child.stdin.as_mut().ok_or_else(|| {
+            OwsLibError::BroadcastFailed("Cardano broadcast: failed to open curl stdin".into())
+        })?;
+        stdin.write_all(signed_bytes).map_err(|e| {
+            OwsLibError::BroadcastFailed(format!(
+                "Cardano broadcast: failed to write request body to curl stdin: {e}"
+            ))
+        })?;
+    }
+
+    let output = child.wait_with_output().map_err(|e| {
+        OwsLibError::BroadcastFailed(format!("Cardano broadcast: failed to wait for curl: {e}"))
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(OwsLibError::BroadcastFailed(format!(
+            "Cardano broadcast failed: {stderr}"
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let (body, status_raw) = stdout.rsplit_once('\n').unwrap_or(("", stdout.as_str()));
+
+    let status: u16 = status_raw.parse().map_err(|_| {
+        OwsLibError::BroadcastFailed(format!(
+            "Cardano broadcast: could not parse HTTP status from curl output: {stdout}"
+        ))
+    })?;
+
+    if status != 202 {
+        return Err(OwsLibError::BroadcastFailed(format!(
+            "Cardano broadcast: failed to broadcast transaction: {body}"
+        )));
+    }
+
+    let tx_hash = body.trim_matches('"').to_string();
+    if tx_hash.len() != 64 {
+        return Err(OwsLibError::BroadcastFailed(format!(
+            "Cardano broadcast: invalid transaction hash in response: {tx_hash}"
+        )));
+    }
+
+    Ok(tx_hash)
 }
 
 fn broadcast_xrpl(rpc_url: &str, signed_bytes: &[u8]) -> Result<String, OwsLibError> {
@@ -1340,7 +1413,7 @@ mod tests {
         // support generic off-chain message signing without a defined convention.
         // NEAR's V1 sign_message is raw ed25519 (NEP-413 follow-up tracked).
         let chains = [
-            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "near",
+            "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "near", "cardano",
         ];
         for chain in &chains {
             let result = sign_message(
@@ -1388,8 +1461,12 @@ mod tests {
         // binary-encoded *unsigned* transaction (no SigningPubKey/TxnSignature).
         let xrpl_tx_hex = "12000024000000016140000000000F424068400000000000000C8114AFF3C2E33458B30714CA16FFEE19952DD35C17C883145720939C1336A7356A70ED861D5934345C6B6360";
 
+        // Valid Cardano Conway-era `FixedTransaction` CBOR fixture (from cardano-serialization-lib tests).
+        const CARDANO_TX_HEX: &str = "84a700818258208b9c96823c19f2047f32210a330434b3d163e194ea17b2b702c0667f6fea7a7a000d80018182581d6138fe1dd1d91221a199ff0dacf41fdd5b87506b533d00e70fae8dae8f1abfbac06a021a0002b645031a03962de305a1581de1b3cabd3914ef99169ace1e8b545b635f809caa35f8b6c8bc69ae48061abf4009040e80a100828258207dc05ac55cdfb9cc24571d491d3a3bdbd7d48489a916d27fce3ffe5c9af1b7f55840d7eda8457f1814fe3333b7b1916e3b034e6d480f97f4f286b1443ef72383279718a3a3fddf127dae0505b01a48fd9ffe0f52d9d8c46d02bcb85d1d106c13aa048258201b3d6e1236891a921abf1a3f90a9fb1b2568b1096b6cd6d3eaaeb0ef0ee0802f58401ce4658303c3eb0f2b9705992ccd62de30423ade90219e2c4cfc9eb488c892ea28ba3110f0c062298447f4f6365499d97d31207075f9815c3fe530bd9a927402f5f6";
+
         let chains = [
             "evm", "solana", "bitcoin", "cosmos", "tron", "ton", "spark", "sui", "xrpl", "near",
+            "cardano",
         ];
         for chain in &chains {
             let tx = if *chain == "solana" {
@@ -1398,6 +1475,8 @@ mod tests {
                 &near_tx_hex
             } else if *chain == "xrpl" {
                 xrpl_tx_hex
+            } else if *chain == "cardano" {
+                CARDANO_TX_HEX
             } else {
                 generic_tx_hex
             };
@@ -1562,8 +1641,8 @@ mod tests {
 
         assert_eq!(
             info.accounts.len(),
-            ALL_CHAIN_TYPES.len(),
-            "should have one account per chain type"
+            UNIVERSAL_WALLET_ACCOUNT_COUNT,
+            "should have one account per chain type plus Cardano testnets"
         );
 
         // Sign on EVM (secp256k1)
@@ -2484,7 +2563,7 @@ mod tests {
 
     #[test]
     fn char_sign_message_all_chain_families() {
-        // Verify sign_message works for every chain family (EVM, Solana, Bitcoin, Cosmos, Tron, TON, Sui)
+        // Verify sign_message works for every chain family (EVM, Solana, Bitcoin, Cosmos, Tron, TON, Sui, Cardano)
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
         create_wallet("char-all-chains", None, None, Some(vault)).unwrap();
@@ -2497,6 +2576,7 @@ mod tests {
             ("tron", true),
             ("ton", false),
             ("sui", false),
+            ("cardano", false),
         ];
         for (chain, has_recovery_id) in &chains {
             let result = sign_message(

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::process::Command;
+use zeroize::Zeroizing;
 
 use ows_core::{
     default_chain_for_type, ChainType, Config, EncryptedWallet, KeyType, WalletAccount,
@@ -58,19 +59,56 @@ fn derive_all_accounts(mnemonic: &Mnemonic, index: u32) -> Result<Vec<WalletAcco
     Ok(accounts)
 }
 
+fn random_32() -> Result<Zeroizing<Vec<u8>>, OwsLibError> {
+    let mut b = Zeroizing::new(vec![0u8; 32]);
+    getrandom::getrandom(&mut b)
+        .map_err(|e| OwsLibError::InvalidInput(format!("failed to generate random key: {e}")))?;
+    Ok(b)
+}
+
+fn random_ed25519_bip32_key() -> Result<Zeroizing<[u8; ed25519_bip32::XPRV_SIZE]>, OwsLibError> {
+    let mut key = Zeroizing::new([0u8; ed25519_bip32::XPRV_SIZE]);
+    getrandom::getrandom(key.as_mut()).map_err(|e| {
+        OwsLibError::InvalidInput(format!("failed to generate random Ed25519-BIP32 key: {e}"))
+    })?;
+
+    Ok(Zeroizing::new(
+        ed25519_bip32::XPrv::normalize_bytes_force3rd(*key).into(),
+    ))
+}
+
+fn random_ed25519_bip32() -> Result<Zeroizing<Vec<u8>>, OwsLibError> {
+    let payment_key = random_ed25519_bip32_key()?;
+    let stake_key = random_ed25519_bip32_key()?;
+    Ok(Zeroizing::new([*payment_key, *stake_key].concat()))
+}
+
+fn validate_ed25519_bip32_key(bytes: &[u8]) -> Result<(), OwsLibError> {
+    use ed25519_bip32::XPRV_SIZE;
+
+    if bytes.len() != XPRV_SIZE && bytes.len() != XPRV_SIZE * 2 {
+        return Err(OwsLibError::InvalidInput(format!(
+            "Ed25519-BIP32 key must be 96 (payment) or 192 (payment||stake) bytes, got {}",
+            bytes.len()
+        )));
+    }
+
+    for (i, half) in bytes.chunks(XPRV_SIZE).enumerate() {
+        let role = if i == 0 { "payment" } else { "stake" };
+        ed25519_bip32::XPrv::from_slice_verified(half).map_err(|e| {
+            OwsLibError::InvalidInput(format!("invalid Ed25519-BIP32 {role} key: {e}"))
+        })?;
+    }
+
+    Ok(())
+}
+
 /// A key pair: one key per curve.
 /// Private key material is zeroized on drop.
 struct KeyPair {
-    secp256k1: Vec<u8>,
-    ed25519: Vec<u8>,
-}
-
-impl Drop for KeyPair {
-    fn drop(&mut self) {
-        use zeroize::Zeroize;
-        self.secp256k1.zeroize();
-        self.ed25519.zeroize();
-    }
+    secp256k1: Zeroizing<Vec<u8>>,
+    ed25519: Zeroizing<Vec<u8>>,
+    ed25519_bip32: Zeroizing<Vec<u8>>,
 }
 
 impl KeyPair {
@@ -79,16 +117,18 @@ impl KeyPair {
         match curve {
             ows_signer::Curve::Secp256k1 => &self.secp256k1,
             ows_signer::Curve::Ed25519 => &self.ed25519,
+            ows_signer::Curve::Ed25519Bip32 => &self.ed25519_bip32,
         }
     }
 
     /// Serialize to JSON bytes for encryption.
-    fn to_json_bytes(&self) -> Vec<u8> {
+    fn to_json_bytes(&self) -> Zeroizing<Vec<u8>> {
         let obj = serde_json::json!({
-            "secp256k1": hex::encode(&self.secp256k1),
-            "ed25519": hex::encode(&self.ed25519),
+            "secp256k1": hex::encode(&*self.secp256k1),
+            "ed25519": hex::encode(&*self.ed25519),
+            "ed25519_bip32": hex::encode(&*self.ed25519_bip32),
         });
-        obj.to_string().into_bytes()
+        Zeroizing::new(obj.to_string().into_bytes())
     }
 
     /// Deserialize from JSON bytes after decryption.
@@ -102,11 +142,22 @@ impl KeyPair {
         let ed = obj["ed25519"]
             .as_str()
             .ok_or_else(|| OwsLibError::InvalidInput("missing ed25519 key".into()))?;
+        // using an empty string as the default value for backwards compatibility with wallets that were imported with only secp256k1 and ed25519 private keys
+        let ed_bip32 = obj["ed25519_bip32"].as_str().unwrap_or("");
+
         Ok(KeyPair {
-            secp256k1: hex::decode(secp)
-                .map_err(|e| OwsLibError::InvalidInput(format!("invalid secp256k1 hex: {e}")))?,
-            ed25519: hex::decode(ed)
-                .map_err(|e| OwsLibError::InvalidInput(format!("invalid ed25519 hex: {e}")))?,
+            secp256k1: Zeroizing::new(
+                hex::decode(secp).map_err(|e| {
+                    OwsLibError::InvalidInput(format!("invalid secp256k1 hex: {e}"))
+                })?,
+            ),
+            ed25519: Zeroizing::new(
+                hex::decode(ed)
+                    .map_err(|e| OwsLibError::InvalidInput(format!("invalid ed25519 hex: {e}")))?,
+            ),
+            ed25519_bip32: Zeroizing::new(hex::decode(ed_bip32).map_err(|e| {
+                OwsLibError::InvalidInput(format!("invalid ed25519_bip32 hex: {e}"))
+            })?),
         })
     }
 }
@@ -155,7 +206,17 @@ pub(crate) fn secret_to_signing_key(
             // JSON key pair — extract the right key for this chain's curve
             let keys = KeyPair::from_json_bytes(secret.expose())?;
             let signer = signer_for_chain_type(chain_type);
-            Ok(SecretBytes::from_slice(keys.key_for_curve(signer.curve())))
+            let key = keys.key_for_curve(signer.curve());
+
+            // if the key for the requested curve is empty, it means that the wallet was imported using private keys before the support for the requested curve was added
+            if key.is_empty() {
+                return Err(OwsLibError::InvalidInput(format!(
+                    "Private key for chain {} is empty",
+                    chain_type
+                )));
+            }
+
+            Ok(SecretBytes::from_slice(key))
         }
     }
 }
@@ -270,20 +331,20 @@ pub fn import_wallet_mnemonic(
 }
 
 /// Decode a hex-encoded key, stripping an optional `0x` prefix.
-fn decode_hex_key(hex_str: &str) -> Result<Vec<u8>, OwsLibError> {
+fn decode_hex_key(hex_str: &str) -> Result<Zeroizing<Vec<u8>>, OwsLibError> {
     let trimmed = hex_str.strip_prefix("0x").unwrap_or(hex_str);
     hex::decode(trimmed)
+        .map(Zeroizing::new)
         .map_err(|e| OwsLibError::InvalidInput(format!("invalid hex private key: {e}")))
 }
 
 /// Import a wallet from a hex-encoded private key.
 /// The `chain` parameter specifies which chain the key originates from (e.g. "evm", "solana").
-/// A random key is generated for the other curve so all 6 chains are supported.
+/// A random key is generated for each curve that is not supplied explicitly or via `private_key_hex`.
 ///
-/// Alternatively, provide both `secp256k1_key_hex` and `ed25519_key_hex` to supply
-/// explicit keys for each curve. When both are given, `private_key_hex` and `chain`
-/// are ignored. When only one curve key is given alongside `private_key_hex`, it
-/// overrides the random generation for that curve.
+/// For each curve, the key is chosen in order: `secp256k1_key_hex` / `ed25519_key_hex` /
+/// `ed25519_bip32_key_hex` if set; else `private_key_hex` when `chain` maps to that curve; else a random key.
+#[allow(clippy::too_many_arguments)]
 pub fn import_wallet_private_key(
     name: &str,
     private_key_hex: &str,
@@ -292,6 +353,7 @@ pub fn import_wallet_private_key(
     vault_path: Option<&Path>,
     secp256k1_key_hex: Option<&str>,
     ed25519_key_hex: Option<&str>,
+    ed25519_bip32_key_hex: Option<&str>,
 ) -> Result<WalletInfo, OwsLibError> {
     let passphrase = passphrase.unwrap_or("");
 
@@ -299,48 +361,47 @@ pub fn import_wallet_private_key(
         return Err(OwsLibError::WalletNameExists(name.to_string()));
     }
 
-    let keys = match (secp256k1_key_hex, ed25519_key_hex) {
-        // Both curve keys explicitly provided — use them directly
-        (Some(secp_hex), Some(ed_hex)) => KeyPair {
-            secp256k1: decode_hex_key(secp_hex)?,
-            ed25519: decode_hex_key(ed_hex)?,
-        },
-        // Existing single-key behavior
-        _ => {
-            let key_bytes = decode_hex_key(private_key_hex)?;
+    let private_key = (!private_key_hex.is_empty())
+        .then(|| decode_hex_key(private_key_hex))
+        .transpose()?;
 
-            // Determine curve from the source chain (default: secp256k1)
-            let source_curve = match chain {
-                Some(c) => {
-                    let parsed = parse_chain(c)?;
-                    signer_for_chain(&parsed).curve()
-                }
-                None => ows_signer::Curve::Secp256k1,
-            };
+    let source_curve = chain
+        .map(|c| parse_chain(c).map(|parsed| signer_for_chain(&parsed).curve()))
+        .transpose()?
+        .unwrap_or(ows_signer::Curve::Secp256k1);
 
-            // Build key pair: provided key for its curve, random 32 bytes for the other
-            let mut other_key = vec![0u8; 32];
-            getrandom::getrandom(&mut other_key).map_err(|e| {
-                OwsLibError::InvalidInput(format!("failed to generate random key: {e}"))
-            })?;
-
-            match source_curve {
-                ows_signer::Curve::Secp256k1 => KeyPair {
-                    secp256k1: key_bytes,
-                    ed25519: ed25519_key_hex
-                        .map(decode_hex_key)
-                        .transpose()?
-                        .unwrap_or(other_key),
+    let get_key =
+        |key_hex: Option<&str>,
+         curve: ows_signer::Curve,
+         generate_random: fn() -> Result<Zeroizing<Vec<u8>>, OwsLibError>| {
+            key_hex.map(decode_hex_key).transpose()?.map_or_else(
+                || {
+                    if curve == source_curve {
+                        private_key
+                            .as_ref()
+                            .cloned()
+                            .map_or_else(generate_random, Ok)
+                    } else {
+                        generate_random()
+                    }
                 },
-                ows_signer::Curve::Ed25519 => KeyPair {
-                    secp256k1: secp256k1_key_hex
-                        .map(decode_hex_key)
-                        .transpose()?
-                        .unwrap_or(other_key),
-                    ed25519: key_bytes,
-                },
-            }
-        }
+                Ok,
+            )
+        };
+
+    let secp256k1 = get_key(secp256k1_key_hex, ows_signer::Curve::Secp256k1, random_32)?;
+    let ed25519 = get_key(ed25519_key_hex, ows_signer::Curve::Ed25519, random_32)?;
+    let ed25519_bip32 = get_key(
+        ed25519_bip32_key_hex,
+        ows_signer::Curve::Ed25519Bip32,
+        random_ed25519_bip32,
+    )?;
+    validate_ed25519_bip32_key(&ed25519_bip32)?;
+
+    let keys = KeyPair {
+        secp256k1,
+        ed25519,
+        ed25519_bip32,
     };
 
     let accounts = derive_all_accounts_from_keys(&keys)?;
@@ -383,7 +444,7 @@ pub fn delete_wallet(name_or_id: &str, vault_path: Option<&Path>) -> Result<(), 
 }
 
 /// Export a wallet's secret.
-/// Mnemonic wallets return the phrase. Private key wallets return JSON with both keys.
+/// Mnemonic wallets return the phrase. Private key wallets return JSON with all keys.
 pub fn export_wallet(
     name_or_id: &str,
     passphrase: Option<&str>,
@@ -1114,13 +1175,15 @@ mod tests {
     ) -> WalletInfo {
         let key_bytes = hex::decode(privkey_hex).unwrap();
 
-        // Generate a random ed25519 key for the other curve
+        // Generate random keys for the other curves
         let mut ed_key = vec![0u8; 32];
         getrandom::getrandom(&mut ed_key).unwrap();
+        let ed_bip32 = random_ed25519_bip32().unwrap();
 
         let keys = KeyPair {
-            secp256k1: key_bytes,
-            ed25519: ed_key,
+            secp256k1: Zeroizing::new(key_bytes),
+            ed25519: Zeroizing::new(ed_key),
+            ed25519_bip32: ed_bip32,
         };
         let accounts = derive_all_accounts_from_keys(&keys).unwrap();
         let payload = keys.to_json_bytes();
@@ -1459,6 +1522,7 @@ mod tests {
             Some(vault),
             None,
             None,
+            None,
         )
         .unwrap();
         assert!(
@@ -1477,7 +1541,7 @@ mod tests {
     }
 
     #[test]
-    fn privkey_wallet_import_both_curve_keys() {
+    fn privkey_wallet_import_secp_and_ed_curve_keys() {
         let dir = tempfile::tempdir().unwrap();
         let vault = dir.path();
 
@@ -1485,13 +1549,14 @@ mod tests {
         let ed_key = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
 
         let info = import_wallet_private_key(
-            "pk-both",
-            "",   // ignored when both curve keys provided
-            None, // chain ignored too
+            "pk-secp-and-ed",
+            "",
+            None,
             None,
             Some(vault),
             Some(secp_key),
             Some(ed_key),
+            None, // ed25519_bip32 will be randomly generated
         )
         .unwrap();
 
@@ -1502,19 +1567,141 @@ mod tests {
         );
 
         // Sign on EVM (secp256k1)
-        let sig = sign_message("pk-both", "evm", "hello", None, None, None, Some(vault)).unwrap();
+        let sig = sign_message(
+            "pk-secp-and-ed",
+            "evm",
+            "hello",
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
         assert!(!sig.signature.is_empty());
 
         // Sign on Solana (ed25519)
-        let sig =
-            sign_message("pk-both", "solana", "hello", None, None, None, Some(vault)).unwrap();
+        let sig = sign_message(
+            "pk-secp-and-ed",
+            "solana",
+            "hello",
+            None,
+            None,
+            None,
+            Some(vault),
+        )
+        .unwrap();
         assert!(!sig.signature.is_empty());
 
-        // Export should return both keys
-        let exported = export_wallet("pk-both", None, Some(vault)).unwrap();
+        let exported = export_wallet("pk-secp-and-ed", None, Some(vault)).unwrap();
         let obj: serde_json::Value = serde_json::from_str(&exported).unwrap();
         assert_eq!(obj["secp256k1"].as_str().unwrap(), secp_key);
         assert_eq!(obj["ed25519"].as_str().unwrap(), ed_key);
+        assert_eq!(
+            obj["ed25519_bip32"].as_str().unwrap().len(),
+            ed25519_bip32::XPRV_SIZE * 2 * 2
+        );
+    }
+
+    #[test]
+    fn privkey_wallet_import_three_explicit_curve_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+
+        let secp_key = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318";
+        let ed_key = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+        let ed_bip32_key = "f8a29231ee38d6c5bf715d5bac21c750577aa3798b22d79d65bf97d6fadea15adcd1ee1abdf78bd4be64731a12deb94d3671784112eb6f364b871851fd1c9a247384db9ad6003bbd08b3b1ddc0d07a597293ff85e961bf252b331262eddfad0d";
+
+        import_wallet_private_key(
+            "pk-all-explicit",
+            "",
+            None,
+            None,
+            Some(vault),
+            Some(secp_key),
+            Some(ed_key),
+            Some(ed_bip32_key),
+        )
+        .unwrap();
+
+        let exported = export_wallet("pk-all-explicit", None, Some(vault)).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(&exported).unwrap();
+        assert_eq!(obj["secp256k1"].as_str().unwrap(), secp_key);
+        assert_eq!(obj["ed25519"].as_str().unwrap(), ed_key);
+        assert_eq!(obj["ed25519_bip32"].as_str().unwrap(), ed_bip32_key);
+    }
+
+    #[test]
+    fn privkey_wallet_import_single_curve_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+
+        let ed_bip32_key = "f8a29231ee38d6c5bf715d5bac21c750577aa3798b22d79d65bf97d6fadea15adcd1ee1abdf78bd4be64731a12deb94d3671784112eb6f364b871851fd1c9a247384db9ad6003bbd08b3b1ddc0d07a597293ff85e961bf252b331262eddfad0d";
+
+        import_wallet_private_key(
+            "pk-evm-plus-bip32",
+            TEST_PRIVKEY,
+            Some("evm"),
+            None,
+            Some(vault),
+            None,
+            None, // ed25519 will be randomly generated
+            Some(ed_bip32_key),
+        )
+        .unwrap();
+
+        let exported = export_wallet("pk-evm-plus-bip32", None, Some(vault)).unwrap();
+        let obj: serde_json::Value = serde_json::from_str(&exported).unwrap();
+        assert_eq!(obj["secp256k1"].as_str().unwrap(), TEST_PRIVKEY);
+        assert_eq!(obj["ed25519_bip32"].as_str().unwrap(), ed_bip32_key);
+    }
+
+    /// A single 96-byte payment `XPrv` and a 192-byte payment‖stake blob are the two shapes
+    /// the Cardano signer decodes; both must import.
+    #[test]
+    fn privkey_wallet_import_accepts_both_ed25519_bip32_shapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+
+        let payment = "f8a29231ee38d6c5bf715d5bac21c750577aa3798b22d79d65bf97d6fadea15adcd1ee1abdf78bd4be64731a12deb94d3671784112eb6f364b871851fd1c9a247384db9ad6003bbd08b3b1ddc0d07a597293ff85e961bf252b331262eddfad0d";
+        let payment_and_stake = format!("{payment}{payment}");
+
+        for (name, key) in [("bip32-96", payment), ("bip32-192", &payment_and_stake)] {
+            import_wallet_private_key(name, "", None, None, Some(vault), None, None, Some(key))
+                .unwrap();
+            let exported = export_wallet(name, None, Some(vault)).unwrap();
+            let obj: serde_json::Value = serde_json::from_str(&exported).unwrap();
+            assert_eq!(obj["ed25519_bip32"].as_str().unwrap(), key);
+        }
+    }
+
+    #[test]
+    fn privkey_wallet_rejects_malformed_ed25519_bip32_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+
+        // A 64-byte key: valid hex, but not a shape any Cardano signer can decode.
+        let too_short = "f8a29231ee38d6c5bf715d5bac21c750577aa3798b22d79d65bf97d6fadea15adcd1ee1abdf78bd4be64731a12deb94d3671784112eb6f364b871851fd1c9a24";
+        // 96 bytes, but the scalar's high bits violate the Ed25519-BIP32 clamping rules
+        // (first byte's low 3 bits set, byte 31 not 0b01xxxxxx).
+        let bad_scalar_bits = "f".repeat(ed25519_bip32::XPRV_SIZE * 2);
+
+        for key in [too_short, bad_scalar_bits.as_str()] {
+            let err = import_wallet_private_key(
+                "bip32-bad",
+                "",
+                None,
+                None,
+                Some(vault),
+                None,
+                None,
+                Some(key),
+            )
+            .expect_err("expected malformed Ed25519-BIP32 key to be rejected");
+            assert!(
+                err.to_string().contains("Ed25519-BIP32"),
+                "unexpected error: {err}"
+            );
+        }
     }
 
     // ================================================================
@@ -1696,6 +1883,7 @@ mod tests {
             Some("evm"),
             None,
             Some(dir.path()),
+            None,
             None,
             None,
         )
@@ -2283,6 +2471,7 @@ mod tests {
             Some("evm"),
             None,
             Some(vault),
+            None,
             None,
             None,
         )

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -142,11 +142,13 @@ pub(crate) fn secret_to_signing_key(
             })?;
             let mnemonic = Mnemonic::from_phrase(phrase)?;
             let signer = signer_for_chain(chain_type);
-            let path = signer.default_derivation_path(index.unwrap_or(0));
-            let curve = signer.curve();
-            Ok(HdDeriver::derive_from_mnemonic_cached(
-                &mnemonic, "", &path, curve,
-            )?)
+            let keys = HdDeriver::derive_keys_from_mnemonic_cached(
+                &mnemonic,
+                "",
+                signer.default_derivation_paths(index.unwrap_or(0)),
+                signer.curve(),
+            )?;
+            Ok(signer.encode_keys(&keys)?)
         }
         KeyType::PrivateKey => {
             // JSON key pair — extract the right key for this chain's curve

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -766,6 +766,19 @@ pub fn sign_and_send(
         let (key_file, wallet_obj) =
             crate::key_ops::load_authorized_wallet(credential, wallet, vault_path)?;
         let signer = signer_for_chain(&chain_info);
+
+        // if rpc_url is provided, use it, otherwise, resolve it if the chain is Cardano, because it's needed in make_transaction_context
+        let resolved_rpc_url = match rpc_url {
+            Some(url) => Some(url.to_string()),
+            None if chain_info.chain_type == ChainType::Cardano => Some(resolve_rpc_url(
+                chain_info.chain_id,
+                chain_info.chain_type,
+                None,
+            )?),
+            None => None,
+        };
+        let rpc_url = resolved_rpc_url.as_deref();
+
         let transaction = signer.make_transaction_context(&tx_bytes, rpc_url)?;
         let (key, _) = crate::key_ops::enforce_policies_and_decrypt_key(
             credential,
@@ -840,7 +853,7 @@ pub fn decrypt_signing_key(
 }
 
 /// Resolve the RPC URL: explicit > config override (exact chain_id) > config (namespace) > built-in default.
-fn resolve_rpc_url(
+pub fn resolve_rpc_url(
     chain_id: &str,
     chain_type: ChainType,
     explicit: Option<&str>,

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -42,16 +42,17 @@ fn derive_all_accounts(mnemonic: &Mnemonic, index: u32) -> Result<Vec<WalletAcco
     for ct in &ALL_CHAIN_TYPES {
         let chain = default_chain_for_type(*ct);
         let signer = signer_for_chain(*ct);
-        let path = signer.default_derivation_path(index);
+        let paths = signer.default_derivation_paths(index);
         let curve = signer.curve();
-        let key = HdDeriver::derive_from_mnemonic(mnemonic, "", &path, curve)?;
-        let address = signer.derive_address(key.expose())?;
+        let keys = HdDeriver::derive_keys_from_mnemonic(mnemonic, "", paths, curve)?;
+        let signing_key = signer.encode_keys(&keys)?;
+        let address = signer.derive_address(signing_key.expose())?;
         let account_id = format!("{}:{}", chain.chain_id, address);
         accounts.push(WalletAccount {
             account_id,
             address,
             chain_id: chain.chain_id.to_string(),
-            derivation_path: path,
+            derivation_path: signer.default_derivation_path(index),
         });
     }
     Ok(accounts)
@@ -182,11 +183,12 @@ pub fn derive_address(
     let chain = parse_chain(chain)?;
     let mnemonic = Mnemonic::from_phrase(mnemonic_phrase)?;
     let signer = signer_for_chain(chain.chain_type);
-    let path = signer.default_derivation_path(index.unwrap_or(0));
+    let paths = signer.default_derivation_paths(index.unwrap_or(0));
     let curve = signer.curve();
 
-    let key = HdDeriver::derive_from_mnemonic(&mnemonic, "", &path, curve)?;
-    let address = signer.derive_address(key.expose())?;
+    let keys = HdDeriver::derive_keys_from_mnemonic(&mnemonic, "", paths, curve)?;
+    let signing_key = signer.encode_keys(&keys)?;
+    let address = signer.derive_address(signing_key.expose())?;
     Ok(address)
 }
 

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -767,10 +767,11 @@ pub fn sign_and_send(
             crate::key_ops::load_authorized_wallet(credential, wallet, vault_path)?;
         let signer = signer_for_chain(&chain_info);
 
-        // if rpc_url is provided, use it, otherwise, resolve it if the chain is Cardano, because it's needed in make_transaction_context
+        // An explicit URL wins; otherwise resolve the configured one for the chains whose
+        // make_transaction_context cannot build a context without it.
         let resolved_rpc_url = match rpc_url {
             Some(url) => Some(url.to_string()),
-            None if chain_info.chain_type == ChainType::Cardano => Some(resolve_rpc_url(
+            None if signer.transaction_context_needs_rpc() => Some(resolve_rpc_url(
                 chain_info.chain_id,
                 chain_info.chain_type,
                 None,

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -42,7 +42,7 @@ fn parse_chain(s: &str) -> Result<ows_core::Chain, OwsLibError> {
 fn derive_all_accounts(mnemonic: &Mnemonic, index: u32) -> Result<Vec<WalletAccount>, OwsLibError> {
     let mut accounts = Vec::with_capacity(UNIVERSAL_WALLET_ACCOUNT_COUNT);
     for chain in universal_wallet_chains() {
-        let signer = signer_for_chain(&chain);
+        let signer = signer_for_chain(&chain)?;
         let paths = signer.default_derivation_paths(index);
         let curve = signer.curve();
         let keys = HdDeriver::derive_keys_from_mnemonic(mnemonic, "", paths, curve)?;
@@ -187,7 +187,7 @@ impl KeyPair {
 fn derive_all_accounts_from_keys(keys: &KeyPair) -> Result<Vec<WalletAccount>, OwsLibError> {
     let mut accounts = Vec::with_capacity(UNIVERSAL_WALLET_ACCOUNT_COUNT);
     for chain in universal_wallet_chains() {
-        let signer = signer_for_chain(&chain);
+        let signer = signer_for_chain(&chain)?;
         let key = keys.key_for_curve(signer.curve());
         let address = signer.derive_address(key)?;
         accounts.push(WalletAccount {
@@ -213,7 +213,7 @@ pub(crate) fn secret_to_signing_key(
                 OwsLibError::InvalidInput("wallet contains invalid UTF-8 mnemonic".into())
             })?;
             let mnemonic = Mnemonic::from_phrase(phrase)?;
-            let signer = signer_for_chain_type(chain_type);
+            let signer = signer_for_chain_type(chain_type)?;
             let keys = HdDeriver::derive_keys_from_mnemonic_cached(
                 &mnemonic,
                 "",
@@ -225,7 +225,7 @@ pub(crate) fn secret_to_signing_key(
         KeyType::PrivateKey => {
             // JSON key pair — extract the right key for this chain's curve
             let keys = KeyPair::from_json_bytes(secret.expose())?;
-            let signer = signer_for_chain_type(chain_type);
+            let signer = signer_for_chain_type(chain_type)?;
             let key = keys.key_for_curve(signer.curve());
 
             // if the key for the requested curve is empty, it means that the wallet was imported using private keys before the support for the requested curve was added
@@ -263,7 +263,7 @@ pub fn derive_address(
 ) -> Result<String, OwsLibError> {
     let chain = parse_chain(chain)?;
     let mnemonic = Mnemonic::from_phrase(mnemonic_phrase)?;
-    let signer = signer_for_chain(&chain);
+    let signer = signer_for_chain(&chain)?;
     let paths = signer.default_derivation_paths(index.unwrap_or(0));
     let curve = signer.curve();
 
@@ -385,10 +385,10 @@ pub fn import_wallet_private_key(
         .then(|| decode_hex_key(private_key_hex))
         .transpose()?;
 
-    let source_curve = chain
-        .map(|c| parse_chain(c).map(|parsed| signer_for_chain(&parsed).curve()))
-        .transpose()?
-        .unwrap_or(ows_signer::Curve::Secp256k1);
+    let source_curve = match chain {
+        Some(c) => signer_for_chain(&parse_chain(c)?)?.curve(),
+        None => ows_signer::Curve::Secp256k1,
+    };
 
     let get_key =
         |key_hex: Option<&str>,
@@ -532,7 +532,7 @@ fn sign_hash_with_credential(
     index: Option<u32>,
     vault_path: Option<&Path>,
 ) -> Result<SignResult, OwsLibError> {
-    let signer = signer_for_chain(chain);
+    let signer = signer_for_chain(chain)?;
     if signer.curve() != Curve::Secp256k1 {
         return Err(OwsLibError::InvalidInput(
             "raw hash signing is only supported for secp256k1-backed chains".into(),
@@ -597,7 +597,7 @@ pub fn sign_transaction(
     // Owner mode: existing passphrase-based signing (unchanged)
     let chain = parse_chain(chain)?;
     let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
-    let signer = signer_for_chain(&chain);
+    let signer = signer_for_chain(&chain)?;
     let signable = signer.extract_signable_bytes(&tx_bytes)?;
     let output = signer.sign_transaction(key.expose(), signable)?;
 
@@ -704,7 +704,7 @@ pub fn sign_message(
     // Owner mode
     let chain = parse_chain(chain)?;
     let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
-    let signer = signer_for_chain(&chain);
+    let signer = signer_for_chain(&chain)?;
     let output = signer.sign_message(key.expose(), &msg_bytes, address)?;
 
     Ok(SignResult {
@@ -749,7 +749,7 @@ pub fn sign_typed_data(
     }
 
     let key = decrypt_signing_key(wallet, chain.chain_type, credential, index, vault_path)?;
-    let signer = signer_for_chain(&chain);
+    let signer = signer_for_chain(&chain)?;
     signer.verify_sign_message_address(key.expose(), address)?;
     let evm_signer = ows_signer::chains::EvmSigner;
     let output = evm_signer.sign_typed_data(key.expose(), typed_data_json)?;
@@ -785,7 +785,7 @@ pub fn sign_and_send(
         let chain_info = parse_chain(chain)?;
         let (key_file, wallet_obj) =
             crate::key_ops::load_authorized_wallet(credential, wallet, vault_path)?;
-        let signer = signer_for_chain(&chain_info);
+        let signer = signer_for_chain(&chain_info)?;
 
         // An explicit URL wins; otherwise resolve the configured one for the chains whose
         // make_transaction_context cannot build a context without it.
@@ -835,7 +835,7 @@ pub fn sign_encode_and_broadcast(
     rpc_url: Option<&str>,
 ) -> Result<SendResult, OwsLibError> {
     let chain = parse_chain(chain)?;
-    let signer = signer_for_chain(&chain);
+    let signer = signer_for_chain(&chain)?;
 
     // 1. Extract signable portion (strips signature-slot headers for Solana; no-op for others)
     let signable = signer.extract_signable_bytes(tx_bytes)?;
@@ -2362,7 +2362,7 @@ mod tests {
 
         // Now encode the full signed transaction (what the library does correctly)
         let key = decrypt_signing_key("send-bug", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain_type(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm).unwrap();
         let output = signer.sign_transaction(key.expose(), &unsigned_tx).unwrap();
         let full_signed_tx = signer
             .encode_signed_transaction(&unsigned_tx, &output)
@@ -3165,7 +3165,7 @@ mod tests {
         // by manually calling the signer's extract/sign/encode chain:
         let key =
             decrypt_signing_key("char-sol-sig", ChainType::Solana, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain_type(ChainType::Solana);
+        let signer = signer_for_chain_type(ChainType::Solana).unwrap();
 
         let signable = signer.extract_signable_bytes(&tx_bytes).unwrap();
         assert_eq!(
@@ -3231,7 +3231,7 @@ mod tests {
         // Path B: the internal pipeline (what sign_and_send uses)
         let key =
             decrypt_signing_key("char-encode", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain_type(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm).unwrap();
         let output = signer.sign_transaction(key.expose(), &unsigned_tx).unwrap();
         let full_signed_tx = signer
             .encode_signed_transaction(&unsigned_tx, &output)
@@ -3368,7 +3368,7 @@ mod tests {
 
         let key =
             decrypt_signing_key(&wallet.id, ChainType::Evm, "pass", None, Some(vault)).unwrap();
-        let signer = signer_for_chain_type(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm).unwrap();
         let direct = signer
             .sign(key.expose(), &hex::decode(&hash_hex).unwrap())
             .unwrap();
@@ -3658,7 +3658,7 @@ mod tests {
 
         // Path B: direct signer call (no credential branch)
         let key = decrypt_signing_key("reg-owner", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain_type(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm).unwrap();
         let tx_bytes = hex::decode(tx_hex).unwrap();
         let direct_output = signer.sign_transaction(key.expose(), &tx_bytes).unwrap();
 
@@ -3737,7 +3737,7 @@ mod tests {
 
         // Direct signer
         let key = decrypt_signing_key("reg-msg", ChainType::Evm, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain_type(ChainType::Evm);
+        let signer = signer_for_chain_type(ChainType::Evm).unwrap();
         let direct = signer.sign_message(key.expose(), b"hello", None).unwrap();
 
         assert_eq!(
@@ -3868,7 +3868,7 @@ mod tests {
         // Path B: manual extract + sign
         let key =
             decrypt_signing_key("sol-match", ChainType::Solana, "", None, Some(vault)).unwrap();
-        let signer = signer_for_chain_type(ChainType::Solana);
+        let signer = signer_for_chain_type(ChainType::Solana).unwrap();
         let signable = signer.extract_signable_bytes(&full_tx).unwrap();
         let direct = signer.sign_transaction(key.expose(), signable).unwrap();
 

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -785,6 +785,7 @@ pub fn sign_and_send(
             key_file,
             wallet_obj,
             &chain_info,
+            ows_core::PolicyRequestType::SignTransaction,
             Some(transaction),
             None,
             index,

--- a/ows/crates/ows-lib/src/ops.rs
+++ b/ows/crates/ows-lib/src/ops.rs
@@ -104,6 +104,21 @@ fn validate_ed25519_bip32_key(bytes: &[u8]) -> Result<(), OwsLibError> {
     Ok(())
 }
 
+/// The on-disk (encrypted) form of a `KeyPair`: one hex string per curve.
+///
+/// The hex sits in `Zeroizing` so that every plaintext copy the serializer
+/// produces or the parser hands back is wiped, including the ones dropped when
+/// deserialization fails on a later field.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct KeyPairJson {
+    secp256k1: Zeroizing<String>,
+    ed25519: Zeroizing<String>,
+    // defaults to empty for wallets imported before Ed25519-BIP32 support,
+    // which stored only the secp256k1 and ed25519 private keys
+    #[serde(default)]
+    ed25519_bip32: Zeroizing<String>,
+}
+
 /// A key pair: one key per curve.
 /// Private key material is zeroized on drop.
 struct KeyPair {
@@ -124,39 +139,44 @@ impl KeyPair {
 
     /// Serialize to JSON bytes for encryption.
     fn to_json_bytes(&self) -> Zeroizing<Vec<u8>> {
-        let obj = serde_json::json!({
-            "secp256k1": hex::encode(&*self.secp256k1),
-            "ed25519": hex::encode(&*self.ed25519),
-            "ed25519_bip32": hex::encode(&*self.ed25519_bip32),
-        });
-        Zeroizing::new(obj.to_string().into_bytes())
+        let json = KeyPairJson {
+            secp256k1: Zeroizing::new(hex::encode(&*self.secp256k1)),
+            ed25519: Zeroizing::new(hex::encode(&*self.ed25519)),
+            ed25519_bip32: Zeroizing::new(hex::encode(&*self.ed25519_bip32)),
+        };
+
+        // Sized up front for the field names, punctuation and hex: growing the
+        // buffer mid-write would leave an unwiped partial copy of the keys in
+        // the old allocation. The assertion below keeps that true if the shape
+        // of KeyPairJson changes.
+        let mut bytes = Zeroizing::new(Vec::with_capacity(
+            64 + json.secp256k1.len() + json.ed25519.len() + json.ed25519_bip32.len(),
+        ));
+        let capacity = bytes.capacity();
+        serde_json::to_writer(&mut *bytes, &json).expect("writing JSON to a Vec cannot fail");
+        debug_assert_eq!(
+            bytes.capacity(),
+            capacity,
+            "serialized key pair outgrew its buffer"
+        );
+        bytes
     }
 
     /// Deserialize from JSON bytes after decryption.
     fn from_json_bytes(bytes: &[u8]) -> Result<Self, OwsLibError> {
-        let s = String::from_utf8(bytes.to_vec())
-            .map_err(|_| OwsLibError::InvalidInput("invalid key pair data".into()))?;
-        let obj: serde_json::Value = serde_json::from_str(&s)?;
-        let secp = obj["secp256k1"]
-            .as_str()
-            .ok_or_else(|| OwsLibError::InvalidInput("missing secp256k1 key".into()))?;
-        let ed = obj["ed25519"]
-            .as_str()
-            .ok_or_else(|| OwsLibError::InvalidInput("missing ed25519 key".into()))?;
-        // using an empty string as the default value for backwards compatibility with wallets that were imported with only secp256k1 and ed25519 private keys
-        let ed_bip32 = obj["ed25519_bip32"].as_str().unwrap_or("");
+        let json: KeyPairJson = serde_json::from_slice(bytes)?;
 
         Ok(KeyPair {
             secp256k1: Zeroizing::new(
-                hex::decode(secp).map_err(|e| {
+                hex::decode(&*json.secp256k1).map_err(|e| {
                     OwsLibError::InvalidInput(format!("invalid secp256k1 hex: {e}"))
                 })?,
             ),
             ed25519: Zeroizing::new(
-                hex::decode(ed)
+                hex::decode(&*json.ed25519)
                     .map_err(|e| OwsLibError::InvalidInput(format!("invalid ed25519 hex: {e}")))?,
             ),
-            ed25519_bip32: Zeroizing::new(hex::decode(ed_bip32).map_err(|e| {
+            ed25519_bip32: Zeroizing::new(hex::decode(&*json.ed25519_bip32).map_err(|e| {
                 OwsLibError::InvalidInput(format!("invalid ed25519_bip32 hex: {e}"))
             })?),
         })
@@ -1608,6 +1628,43 @@ mod tests {
         let tx = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
         let sig = sign_transaction("pk-tx", "evm", tx, None, None, Some(dir.path())).unwrap();
         assert!(!sig.signature.is_empty());
+    }
+
+    #[test]
+    fn key_pair_json_round_trips() {
+        let keys = KeyPair {
+            secp256k1: Zeroizing::new(vec![0x11; 32]),
+            ed25519: Zeroizing::new(vec![0x22; 32]),
+            ed25519_bip32: Zeroizing::new(vec![0x33; 192]),
+        };
+
+        let bytes = keys.to_json_bytes();
+        let obj: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(obj["secp256k1"].as_str().unwrap(), hex::encode([0x11; 32]));
+        assert_eq!(obj["ed25519"].as_str().unwrap(), hex::encode([0x22; 32]));
+        assert_eq!(
+            obj["ed25519_bip32"].as_str().unwrap(),
+            hex::encode([0x33; 192])
+        );
+
+        let parsed = KeyPair::from_json_bytes(&bytes).unwrap();
+        assert_eq!(&*parsed.secp256k1, &*keys.secp256k1);
+        assert_eq!(&*parsed.ed25519, &*keys.ed25519);
+        assert_eq!(&*parsed.ed25519_bip32, &*keys.ed25519_bip32);
+    }
+
+    #[test]
+    fn key_pair_json_accepts_payload_without_ed25519_bip32() {
+        let legacy = format!(
+            r#"{{"secp256k1":"{}","ed25519":"{}"}}"#,
+            hex::encode([0x11; 32]),
+            hex::encode([0x22; 32])
+        );
+
+        let parsed = KeyPair::from_json_bytes(legacy.as_bytes()).unwrap();
+        assert_eq!(&*parsed.secp256k1, &[0x11; 32]);
+        assert_eq!(&*parsed.ed25519, &[0x22; 32]);
+        assert!(parsed.ed25519_bip32.is_empty());
     }
 
     #[test]

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -239,8 +239,6 @@ mod tests {
             wallet_id: "wallet-1".to_string(),
             api_key_id: "key-1".to_string(),
             transaction: Some(TransactionContext {
-                to: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".to_string()),
-                value: Some("100000000000000000".to_string()), // 0.1 ETH
                 effects: vec![TransactionEffect {
                     address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),
                     diff: vec![("ETH".into(), 100000000000000000)], // 0.1 ETH

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -236,12 +236,12 @@ mod tests {
             chain_id: "eip155:8453".to_string(),
             wallet_id: "wallet-1".to_string(),
             api_key_id: "key-1".to_string(),
-            transaction: TransactionContext {
+            transaction: Some(TransactionContext {
                 to: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".to_string()),
                 value: Some("100000000000000000".to_string()), // 0.1 ETH
                 raw_hex: "0x02f8...".to_string(),
                 data: None,
-            },
+            }),
             spending: SpendingContext {
                 daily_total: "50000000000000000".to_string(), // 0.05 ETH already spent
                 date: "2026-03-22".to_string(),

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -228,7 +228,9 @@ fn wait_with_timeout(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ows_core::policy::{SpendingContext, TransactionContext, TypedDataContext};
+    use ows_core::policy::{
+        SpendingContext, TransactionContext, TransactionEffect, TypedDataContext,
+    };
     use ows_core::PolicyAction;
 
     fn base_context() -> PolicyContext {
@@ -239,6 +241,10 @@ mod tests {
             transaction: Some(TransactionContext {
                 to: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".to_string()),
                 value: Some("100000000000000000".to_string()), // 0.1 ETH
+                effects: vec![TransactionEffect {
+                    address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),
+                    diff: vec![("ETH".into(), 100000000000000000)], // 0.1 ETH
+                }],
                 raw_hex: "0x02f8...".to_string(),
                 data: None,
             }),

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -245,6 +245,7 @@ mod tests {
                 }],
                 raw_hex: "0x02f8...".to_string(),
                 data: None,
+                chain_extra: None,
             }),
             spending: SpendingContext {
                 daily_total: "50000000000000000".to_string(), // 0.05 ETH already spent

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -241,7 +241,7 @@ mod tests {
             transaction: Some(TransactionContext {
                 effects: vec![TransactionEffect {
                     address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),
-                    diff: vec![("ETH".into(), 100000000000000000)], // 0.1 ETH
+                    diff: vec![("ETH".into(), "100000000000000000".into())], // 0.1 ETH
                 }],
                 raw_hex: "0x02f8...".to_string(),
                 data: None,

--- a/ows/crates/ows-lib/src/policy_engine.rs
+++ b/ows/crates/ows-lib/src/policy_engine.rs
@@ -231,13 +231,14 @@ mod tests {
     use ows_core::policy::{
         SpendingContext, TransactionContext, TransactionEffect, TypedDataContext,
     };
-    use ows_core::PolicyAction;
+    use ows_core::{PolicyAction, PolicyRequestType};
 
     fn base_context() -> PolicyContext {
         PolicyContext {
             chain_id: "eip155:8453".to_string(),
             wallet_id: "wallet-1".to_string(),
             api_key_id: "key-1".to_string(),
+            request_type: PolicyRequestType::SignTransaction,
             transaction: Some(TransactionContext {
                 effects: vec![TransactionEffect {
                     address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD0C".into(),

--- a/ows/crates/ows-pay/Cargo.toml
+++ b/ows/crates/ows-pay/Cargo.toml
@@ -27,3 +27,6 @@ thiserror = "2"
 
 # Random nonce generation
 getrandom = "0.2"
+
+[dev-dependencies]
+mockito = "1"

--- a/ows/crates/ows-pay/src/cardano.rs
+++ b/ows/crates/ows-pay/src/cardano.rs
@@ -1,0 +1,306 @@
+use crate::error::{PayError, PayErrorCode};
+use crate::types::{BalanceInfo, TokenBalance};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KoiosAddressInfoRow {
+    balance: String,
+    utxo_set: Vec<KoiosAddressUtxo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KoiosAddressUtxo {
+    asset_list: Option<Vec<KoiosAsset>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KoiosAsset {
+    policy_id: String,
+    asset_name: Option<String>,
+    fingerprint: String,
+    quantity: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KoiosAssetInfoRow {
+    policy_id: String,
+    asset_name: Option<String>,
+    token_registry_metadata: Option<KoiosTokenRegistryMetadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KoiosTokenRegistryMetadata {
+    ticker: Option<String>,
+    #[serde(default)]
+    decimals: u32,
+}
+
+const ADA_DECIMALS: u32 = 6;
+
+// keeping page size small to avoid 413 Payload Too Large errors
+const KOIOS_ASSET_LIST_CHUNK_SIZE: usize = 20;
+
+pub(crate) async fn get_cardano_balances(
+    wallet_address: &str,
+    koios_base_url: &str,
+) -> Result<Vec<TokenBalance>, PayError> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({ "_addresses": [wallet_address] });
+    let url = format!("{koios_base_url}/address_info");
+
+    let resp = client.post(&url).json(&body).send().await?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(PayError::new(
+            PayErrorCode::HttpStatus,
+            format!("Koios address_info returned {status}: {body}"),
+        ));
+    }
+
+    let rows: Vec<KoiosAddressInfoRow> = resp.json().await?;
+
+    // we are fetching the balances for a single address, so we expect only one row
+    let Some(info) = rows.into_iter().next() else {
+        return Ok(Vec::new());
+    };
+
+    let total_lovelace = info.balance.parse::<u64>().map_err(|e| {
+        PayError::new(
+            PayErrorCode::InvalidData,
+            format!("invalid lovelace balance: {e}"),
+        )
+    })?;
+
+    let mut assets_quantities: HashMap<(String, String, String), u64> = HashMap::new();
+    for utxo in info.utxo_set {
+        for asset in utxo.asset_list.unwrap_or_default() {
+            let qty = asset.quantity.parse::<u64>().map_err(|e| {
+                PayError::new(
+                    PayErrorCode::InvalidData,
+                    format!("invalid asset quantity: {e}"),
+                )
+            })?;
+            if qty == 0 {
+                continue;
+            }
+
+            let key = (
+                asset.policy_id.clone(),
+                asset.asset_name.clone().unwrap_or_default(),
+                asset.fingerprint.clone(),
+            );
+            *assets_quantities.entry(key).or_insert(0) += qty;
+        }
+    }
+
+    let assets = assets_quantities
+        .keys()
+        .cloned()
+        .map(|(p, a, _f)| (p, a))
+        .collect::<Vec<(String, String)>>();
+    let assets_info = fetch_assets_info(&client, koios_base_url, &assets).await?;
+
+    let mut out: Vec<TokenBalance> = Vec::new();
+
+    if total_lovelace > 0 {
+        out.push(TokenBalance {
+            address: "lovelace".into(),
+            name: "Cardano".into(),
+            symbol: "ADA".into(),
+            chain: "cardano".into(),
+            decimals: ADA_DECIMALS,
+            balance: BalanceInfo {
+                amount: total_lovelace as f64 / 10_f64.powi(ADA_DECIMALS as i32),
+                value: None,
+                price: None,
+            },
+        });
+    }
+
+    out.extend(
+        assets_quantities
+            .iter()
+            .map(|((policy_id, asset_name, fingerprint), quantity)| {
+                let asset_info = assets_info.get(&(policy_id.clone(), asset_name.clone()));
+
+                let ticker = asset_info
+                    .and_then(|i| i.token_registry_metadata.as_ref())
+                    .and_then(|m| m.ticker.clone())
+                    .unwrap_or_else(|| asset_name.chars().take(10).collect());
+
+                let decimals = asset_info
+                    .and_then(|i| i.token_registry_metadata.as_ref().map(|m| m.decimals))
+                    .unwrap_or(0);
+
+                TokenBalance {
+                    address: fingerprint.into(),
+                    name: format!("{policy_id}.{asset_name}"),
+                    symbol: ticker.clone(),
+                    chain: "cardano".into(),
+                    decimals,
+                    balance: BalanceInfo {
+                        amount: *quantity as f64 / 10_f64.powi(decimals as i32),
+                        value: None,
+                        price: None,
+                    },
+                }
+            }),
+    );
+
+    out.sort_by(|a, b| {
+        b.balance
+            .amount
+            .partial_cmp(&a.balance.amount)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(out)
+}
+
+async fn fetch_assets_info(
+    client: &reqwest::Client,
+    koios_base: &str,
+    assets: &[(String, String)], // (policy_id, asset_name)
+) -> Result<HashMap<(String, String), KoiosAssetInfoRow>, PayError> {
+    let mut out: HashMap<(String, String), KoiosAssetInfoRow> = HashMap::new();
+    if assets.is_empty() {
+        return Ok(out);
+    }
+
+    let url = format!("{koios_base}/asset_info");
+
+    for assets_chunk in assets.chunks(KOIOS_ASSET_LIST_CHUNK_SIZE) {
+        let body = serde_json::json!({
+            "_asset_list": assets_chunk.iter().map(|(p, a)| [p.clone(), a.clone()]).collect::<Vec<_>>()
+        });
+
+        let resp = client.post(&url).json(&body).send().await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(PayError::new(
+                PayErrorCode::HttpStatus,
+                format!("Koios asset_info returned {status}: {body}"),
+            ));
+        }
+        let rows: Vec<KoiosAssetInfoRow> = resp.json().await?;
+        for row in rows {
+            let key = (
+                row.policy_id.clone(),
+                row.asset_name.clone().unwrap_or_default(),
+            );
+            out.insert(key, row);
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+
+    fn mock_address_info_response(
+        server: &mut Server,
+        rows: &[KoiosAddressInfoRow],
+    ) -> mockito::Mock {
+        server
+            .mock("POST", "/address_info")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(rows).unwrap())
+            .create()
+    }
+
+    fn mock_asset_info_response(server: &mut Server, rows: &[KoiosAssetInfoRow]) -> mockito::Mock {
+        server
+            .mock("POST", "/asset_info")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(rows).unwrap())
+            .create()
+    }
+
+    #[test]
+    fn get_cardano_balances_from_koios() {
+        let wallet = "addr1q9dfl5qs6jncq6200cxqy7juhw7fm2mk5wm5p0qnx5pmsl80734zn65gc55ecvafkhuxawlnn6wevkmg8dm5kt9vxyys322t44";
+        let policy_id = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+        let asset_name = "54455354";
+        let fingerprint = "asset1ua6pz3yd5mdka946z8jw2fld3f8d0mmxt75gv9";
+
+        let mut server = Server::new();
+
+        let address_mock = mock_address_info_response(
+            &mut server,
+            &[KoiosAddressInfoRow {
+                balance: "10000000".into(),
+                utxo_set: vec![KoiosAddressUtxo {
+                    asset_list: Some(vec![KoiosAsset {
+                        policy_id: policy_id.into(),
+                        asset_name: Some(asset_name.into()),
+                        fingerprint: fingerprint.into(),
+                        quantity: "2500000".into(),
+                    }]),
+                }],
+            }],
+        );
+
+        let asset_mock = mock_asset_info_response(
+            &mut server,
+            &[KoiosAssetInfoRow {
+                policy_id: policy_id.into(),
+                asset_name: Some(asset_name.into()),
+                token_registry_metadata: Some(KoiosTokenRegistryMetadata {
+                    ticker: Some("TEST".into()),
+                    decimals: 6,
+                }),
+            }],
+        );
+
+        let koios_url = server.url();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let balances = rt
+            .block_on(get_cardano_balances(wallet, &koios_url))
+            .unwrap();
+
+        address_mock.assert();
+        asset_mock.assert();
+
+        assert_eq!(
+            balances,
+            vec![
+                TokenBalance {
+                    address: "lovelace".into(),
+                    name: "Cardano".into(),
+                    symbol: "ADA".into(),
+                    chain: "cardano".into(),
+                    decimals: ADA_DECIMALS,
+                    balance: BalanceInfo {
+                        amount: 10.0,
+                        value: None,
+                        price: None,
+                    },
+                },
+                TokenBalance {
+                    address: fingerprint.into(),
+                    name: format!("{policy_id}.{asset_name}"),
+                    symbol: "TEST".into(),
+                    chain: "cardano".into(),
+                    decimals: 6,
+                    balance: BalanceInfo {
+                        amount: 2.5,
+                        value: None,
+                        price: None,
+                    },
+                },
+            ]
+        );
+    }
+}

--- a/ows/crates/ows-pay/src/error.rs
+++ b/ows/crates/ows-pay/src/error.rs
@@ -21,6 +21,8 @@ pub enum PayErrorCode {
     DiscoveryFailed,
     /// Invalid input (e.g. unsupported HTTP method).
     InvalidInput,
+    /// Invalid data (e.g. invalid balance).
+    InvalidData,
 }
 
 #[derive(Debug, Error)]

--- a/ows/crates/ows-pay/src/fund.rs
+++ b/ows/crates/ows-pay/src/fund.rs
@@ -1,3 +1,6 @@
+use ows_core::{parse_chain, ChainType};
+
+use crate::cardano::get_cardano_balances;
 use crate::error::{PayError, PayErrorCode};
 use crate::types::{
     FundResult, MoonPayBalanceRequest, MoonPayBalanceResponse, MoonPayDepositRequest,
@@ -152,10 +155,35 @@ pub async fn fund(
 }
 
 /// Check token balances for a wallet address via MoonPay.
+/// If the chain is Cardano, rpc+url is required and it's used to fetch the token balances instead of MoonPay.
 pub async fn get_balances(
     wallet_address: &str,
     chain: Option<&str>,
+    rpc_url: Option<&str>,
 ) -> Result<Vec<TokenBalance>, PayError> {
+    if let Some(c) = chain {
+        let chain = parse_chain(c).map_err(|e| {
+            PayError::new(
+                PayErrorCode::UnsupportedChain,
+                format!("unknown chain: {e}"),
+            )
+        })?;
+
+        if chain.chain_type == ChainType::Cardano {
+            let rpc_url = rpc_url.map_or_else(
+                || {
+                    Err(PayError::new(
+                        PayErrorCode::InvalidInput,
+                        "RPC URL is required for Cardano",
+                    ))
+                },
+                Ok,
+            )?;
+
+            return get_cardano_balances(wallet_address, rpc_url).await;
+        }
+    }
+
     let mapping = resolve_moonpay_chain(chain)?;
     let client = reqwest::Client::new();
 

--- a/ows/crates/ows-pay/src/lib.rs
+++ b/ows/crates/ows-pay/src/lib.rs
@@ -14,6 +14,8 @@ pub(crate) mod discovery;
 pub mod error;
 pub mod fund;
 pub mod types;
+
+mod cardano;
 pub mod wallet;
 
 // Protocol implementations (internal).

--- a/ows/crates/ows-pay/src/types.rs
+++ b/ows/crates/ows-pay/src/types.rs
@@ -245,7 +245,7 @@ pub struct MoonPayBalanceResponse {
     pub items: Vec<TokenBalance>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct TokenBalance {
     pub address: String,
     pub name: String,
@@ -255,11 +255,15 @@ pub struct TokenBalance {
     pub balance: BalanceInfo,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct BalanceInfo {
     pub amount: f64,
-    pub value: f64,
-    pub price: f64,
+    /// Fiat value when known (e.g. MoonPay). Absent for chains without pricing (e.g. Cardano via Koios).
+    #[serde(default)]
+    pub value: Option<f64>,
+    /// Spot price when known. Absent for chains without pricing.
+    #[serde(default)]
+    pub price: Option<f64>,
 }
 
 /// Result of `ows fund`.

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -17,6 +17,8 @@ bitcoin = { version = "0.32", features = ["base64"] }
 xrpl-rust = { version = "1.1.0", default-features = false, features = ["core"] }
 k256 = { version = "0.13", features = ["ecdsa", "arithmetic"] }
 ed25519-dalek = { version = "2", features = ["hazmat"] }
+ed25519-bip32 = "0.4.1"
+pbkdf2 = { version = "0.12", default-features = false, features = ["std"] }
 coins-bip32 = "0.11"
 coins-bip39 = "0.11"
 sha2 = "0.10"

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -41,5 +41,6 @@ blake2 = "0.10"
 digest = "0.10"
 libc = "0.2"
 signal-hook = "0.4"
+cardano-serialization-lib = "14.1.1"
 
 [dev-dependencies]

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -42,5 +42,6 @@ digest = "0.10"
 libc = "0.2"
 signal-hook = "0.4"
 cardano-serialization-lib = "14.1.1"
+emurgo-cardano-message-signing = "1.1.0"
 
 [dev-dependencies]

--- a/ows/crates/ows-signer/Cargo.toml
+++ b/ows/crates/ows-signer/Cargo.toml
@@ -35,6 +35,7 @@ hmac = "0.12"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls"], default-features = false }
 aes-gcm = "0.10"
 scrypt = "0.11"
 blake2 = "0.10"
@@ -45,3 +46,4 @@ cardano-serialization-lib = "14.1.1"
 emurgo-cardano-message-signing = "1.1.0"
 
 [dev-dependencies]
+mockito = "1"

--- a/ows/crates/ows-signer/src/chains/bitcoin.rs
+++ b/ows/crates/ows-signer/src/chains/bitcoin.rs
@@ -263,7 +263,13 @@ impl ChainSigner for BitcoinSigner {
         self.sign(private_key, &hash)
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         // Bitcoin message signing: double-SHA256 of prefixed message
         let prefix = b"\x18Bitcoin Signed Message:\n";
         let mut data = Vec::new();
@@ -341,7 +347,7 @@ mod tests {
 
         // Message longer than 252 bytes requires multi-byte CompactSize varint
         let message = vec![0x42u8; 300];
-        let result = signer.sign_message(&privkey, &message).unwrap();
+        let result = signer.sign_message(&privkey, &message, None).unwrap();
 
         // Compute expected hash with CORRECT varint encoding:
         // CompactSize for 300: 0xFD followed by 300 as 2-byte LE (0x2C, 0x01)
@@ -375,7 +381,7 @@ mod tests {
 
         // 253 bytes: the exact boundary where single-byte varint becomes invalid
         let message = vec![0xAA; 253];
-        let result = signer.sign_message(&privkey, &message).unwrap();
+        let result = signer.sign_message(&privkey, &message, None).unwrap();
 
         let mut expected_data = Vec::new();
         expected_data.extend_from_slice(b"\x18Bitcoin Signed Message:\n");
@@ -433,7 +439,7 @@ mod tests {
 
         // Short message (< 253 bytes) uses single-byte varint
         let message = b"Hello Bitcoin!";
-        let result = signer.sign_message(&privkey, message).unwrap();
+        let result = signer.sign_message(&privkey, message, None).unwrap();
 
         let mut expected_data = Vec::new();
         expected_data.extend_from_slice(b"\x18Bitcoin Signed Message:\n");

--- a/ows/crates/ows-signer/src/chains/cardano.rs
+++ b/ows/crates/ows-signer/src/chains/cardano.rs
@@ -1,6 +1,17 @@
 use crate::curve::Curve;
 use crate::traits::{ChainSigner, SignOutput, SignerError};
-use cardano_serialization_lib::NetworkInfo;
+use crate::{DerivedKey, SecretBytes};
+use cardano_serialization_lib::{
+    make_vkey_witness, Address, AddressKind, BaseAddress, Bip32PrivateKey, Certificate,
+    CertificateKind, Credential, Ed25519KeyHashes, EnterpriseAddress, FixedTransaction,
+    NetworkInfo, RewardAddress, TransactionBody, Vkeywitnesses,
+};
+use emurgo_cardano_message_signing::builders::{AlgorithmId, COSESign1Builder, EdDSA25519Key};
+use emurgo_cardano_message_signing::cbor::CBORValue;
+use emurgo_cardano_message_signing::utils::ToBytes as EmurgoToBytes;
+use emurgo_cardano_message_signing::{
+    HeaderMap, Headers, Label, ProtectedHeaderMap, SignedMessage,
+};
 use ows_core::ChainType;
 
 pub struct CardanoSigner {
@@ -43,6 +54,148 @@ impl CardanoSigner {
     pub fn stake_derivation_path(index: u32) -> String {
         format!("m/1852'/1815'/{index}'/2/0")
     }
+
+    fn decode_keys(
+        key_material: &[u8],
+    ) -> Result<(Bip32PrivateKey, Option<Bip32PrivateKey>), SignerError> {
+        match key_material.len() {
+            ed25519_bip32::XPRV_SIZE => {
+                let pay = Bip32PrivateKey::from_bytes(key_material)
+                    .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
+                Ok((pay, None))
+            }
+            len if len == ed25519_bip32::XPRV_SIZE * 2 => {
+                let pay = Bip32PrivateKey::from_bytes(&key_material[..ed25519_bip32::XPRV_SIZE])
+                    .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
+                let stake = Bip32PrivateKey::from_bytes(&key_material[ed25519_bip32::XPRV_SIZE..])
+                    .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
+                Ok((pay, Some(stake)))
+            }
+            _ => Err(SignerError::InvalidPrivateKey(format!(
+                "Cardano key material must be 96 (payment) or 192 (payment||stake) bytes, got {}",
+                key_material.len()
+            ))),
+        }
+    }
+
+    fn base_address_bech32(
+        &self,
+        pay: &Bip32PrivateKey,
+        stake: &Bip32PrivateKey,
+    ) -> Result<String, SignerError> {
+        let network_id = self.network_id;
+        let pay_cred = Credential::from_keyhash(&pay.to_public().to_raw_key().hash());
+        let stake_cred = Credential::from_keyhash(&stake.to_public().to_raw_key().hash());
+        let base = BaseAddress::new(network_id, &pay_cred, &stake_cred);
+        base.to_address()
+            .to_bech32(None)
+            .map_err(|e| SignerError::AddressDerivationFailed(e.to_string()))
+    }
+
+    fn enterprise_address_bech32(&self, pay: &Bip32PrivateKey) -> Result<String, SignerError> {
+        let network_id = self.network_id;
+        let pay_cred = Credential::from_keyhash(&pay.to_public().to_raw_key().hash());
+        let ent = EnterpriseAddress::new(network_id, &pay_cred);
+        ent.to_address()
+            .to_bech32(None)
+            .map_err(|e| SignerError::AddressDerivationFailed(e.to_string()))
+    }
+
+    /// Adds the vkey hashes `cert` needs a signature from, limited to the credential
+    /// kinds that can be a CIP-1852 stake key. Mirrors the stake-credential arms of
+    /// the ledger's `witsVKeyNeeded`.
+    fn add_cert_key_hashes(cert: &Certificate, hashes: &mut Ed25519KeyHashes) {
+        let stake_credential = match cert.kind() {
+            // A legacy `stake_registration` needs no witness; a Conway `reg_cert`
+            // (registration with an explicit deposit) does. `as_reg_cert` returns
+            // `Some` only for the latter.
+            CertificateKind::StakeRegistration => cert.as_reg_cert().map(|c| c.stake_credential()),
+            CertificateKind::StakeDeregistration => {
+                cert.as_stake_deregistration().map(|c| c.stake_credential())
+            }
+            CertificateKind::StakeDelegation => {
+                cert.as_stake_delegation().map(|c| c.stake_credential())
+            }
+            CertificateKind::StakeAndVoteDelegation => cert
+                .as_stake_and_vote_delegation()
+                .map(|c| c.stake_credential()),
+            CertificateKind::StakeRegistrationAndDelegation => cert
+                .as_stake_registration_and_delegation()
+                .map(|c| c.stake_credential()),
+            CertificateKind::StakeVoteRegistrationAndDelegation => cert
+                .as_stake_vote_registration_and_delegation()
+                .map(|c| c.stake_credential()),
+            CertificateKind::VoteDelegation => {
+                cert.as_vote_delegation().map(|c| c.stake_credential())
+            }
+            CertificateKind::VoteRegistrationAndDelegation => cert
+                .as_vote_registration_and_delegation()
+                .map(|c| c.stake_credential()),
+            // Pool owners are stake key hashes. The operator is a cold pool key, so
+            // it is not collected here.
+            CertificateKind::PoolRegistration => {
+                if let Some(cert) = cert.as_pool_registration() {
+                    let owners = cert.pool_params().pool_owners();
+                    for i in 0..owners.len() {
+                        hashes.add(&owners.get(i));
+                    }
+                }
+                None
+            }
+            // Pool cold keys, genesis delegates, committee cold credentials and DRep
+            // credentials are never derived at the CIP-1852 stake role, so a stake
+            // key can never satisfy them and we do not collect them.
+            CertificateKind::PoolRetirement
+            | CertificateKind::GenesisKeyDelegation
+            | CertificateKind::MoveInstantaneousRewardsCert
+            | CertificateKind::CommitteeHotAuth
+            | CertificateKind::CommitteeColdResign
+            | CertificateKind::DRepRegistration
+            | CertificateKind::DRepDeregistration
+            | CertificateKind::DRepUpdate => None,
+        };
+
+        // Script credentials are witnessed by the script, not by a vkey.
+        if let Some(hash) = stake_credential.and_then(|c| c.to_keyhash()) {
+            hashes.add(&hash);
+        }
+    }
+
+    /// Vkey hashes the transaction structurally requires a stake signature from:
+    /// certificate stake credentials, pool owners and withdrawal reward accounts.
+    ///
+    /// `required_signers` is deliberately not folded in here: a hash listed there
+    /// routinely belongs to a co-signer rather than to this wallet, so it must not
+    /// drive the "we are missing a stake key" error.
+    fn stake_key_hashes_required_by_body(body: &TransactionBody) -> Ed25519KeyHashes {
+        let mut hashes = Ed25519KeyHashes::new();
+
+        if let Some(certs) = body.certs() {
+            for i in 0..certs.len() {
+                Self::add_cert_key_hashes(&certs.get(i), &mut hashes);
+            }
+        }
+
+        if let Some(withdrawals) = body.withdrawals() {
+            let reward_addresses = withdrawals.keys();
+            for i in 0..reward_addresses.len() {
+                if let Some(hash) = reward_addresses.get(i).payment_cred().to_keyhash() {
+                    hashes.add(&hash);
+                }
+            }
+        }
+
+        hashes
+    }
+
+    fn reward_address_bech32(&self, stake: &Bip32PrivateKey) -> Result<String, SignerError> {
+        let network_id = self.network_id;
+        let stake_cred = Credential::from_keyhash(&stake.to_public().to_raw_key().hash());
+        let rew = RewardAddress::new(network_id, &stake_cred);
+        rew.to_address()
+            .to_bech32(None)
+            .map_err(|e| SignerError::AddressDerivationFailed(e.to_string()))
+    }
 }
 
 impl ChainSigner for CardanoSigner {
@@ -58,45 +211,263 @@ impl ChainSigner for CardanoSigner {
         1815
     }
 
-    /// Planned: Shelley **base** address from `payment_xprv || stake_xprv` (see module docs).
-    fn derive_address(&self, _private_key: &[u8]) -> Result<String, SignerError> {
-        Err(SignerError::AddressDerivationFailed(
-            "Cardano Shelley base address encoding not implemented yet; planned `private_key` layout \
-             is 192 bytes: payment XPrv (96) || stake XPrv (96) at matching CIP-1852 indices"
-                .into(),
-        ))
+    fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError> {
+        let (pay, stake) = Self::decode_keys(private_key)?;
+        match stake.as_ref() {
+            Some(s) => self.base_address_bech32(&pay, s),
+            None => self.enterprise_address_bech32(&pay),
+        }
     }
 
-    fn sign(&self, _private_key: &[u8], _message: &[u8]) -> Result<SignOutput, SignerError> {
-        Err(SignerError::SigningFailed("not implemented".into()))
+    fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+        let (pay, _) = Self::decode_keys(private_key)?;
+        let public_key = pay.to_public().to_raw_key().as_bytes();
+
+        let signature = pay.to_raw_key().sign(message).to_bytes();
+
+        Ok(SignOutput {
+            signature,
+            recovery_id: None,
+            public_key: Some(public_key),
+        })
     }
 
     fn sign_message(
         &self,
-        _private_key: &[u8],
-        _message: &[u8],
-        _address: Option<&str>,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
     ) -> Result<SignOutput, SignerError> {
-        Err(SignerError::SigningFailed("not implemented".into()))
+        let (pay, stake) = Self::decode_keys(private_key)?;
+
+        let (address_bytes, sk) = match address {
+            Some(a) => {
+                let addr = Address::from_bech32(a)
+                    .map_err(|e| SignerError::SigningFailed(e.to_string()))?;
+
+                let sk = match addr.kind() {
+                    AddressKind::Reward => {
+                        let stake = stake.map_or_else(
+                            || {
+                                Err(SignerError::InvalidPrivateKey(
+                                    "provided private key does not have a stake key".to_string(),
+                                ))
+                            },
+                            Ok,
+                        )?;
+
+                        if self.reward_address_bech32(&stake)? != a {
+                            return Err(SignerError::AddressMismatch);
+                        }
+
+                        stake
+                    }
+                    AddressKind::Base => {
+                        let stake = stake.map_or_else(
+                            || {
+                                Err(SignerError::InvalidPrivateKey(
+                                    "provided private key does not have a stake key".to_string(),
+                                ))
+                            },
+                            Ok,
+                        )?;
+
+                        if self.base_address_bech32(&pay, &stake)? != a {
+                            return Err(SignerError::AddressMismatch);
+                        }
+
+                        pay
+                    }
+                    AddressKind::Enterprise => {
+                        if self.enterprise_address_bech32(&pay)? != a {
+                            return Err(SignerError::AddressMismatch);
+                        }
+
+                        pay
+                    }
+                    _ => {
+                        return Err(SignerError::AddressMismatch);
+                    }
+                };
+
+                (addr.to_bytes(), sk)
+            }
+            // if the address is not provided, we sign the message with the payment credentials and address derived from the provided private key
+            None => {
+                let addr = Address::from_bech32(&match stake.as_ref() {
+                    Some(s) => self.base_address_bech32(&pay, s)?,
+                    None => self.enterprise_address_bech32(&pay)?,
+                })
+                .map_err(|e| SignerError::SigningFailed(e.to_string()))?;
+
+                (addr.to_bytes(), pay)
+            }
+        };
+
+        let mut protected_headers = HeaderMap::new();
+        protected_headers.set_algorithm_id(&AlgorithmId::EdDSA.into());
+        protected_headers
+            .set_header(
+                &Label::new_text(String::from("address")),
+                &CBORValue::new_bytes(address_bytes),
+            )
+            .map_err(|e| SignerError::SigningFailed(e.to_string()))?;
+
+        let protected_headers_serialized = ProtectedHeaderMap::new(&protected_headers);
+        let headers: Headers = Headers::new(&protected_headers_serialized, &HeaderMap::new());
+
+        let builder = COSESign1Builder::new(&headers, message.to_vec(), false);
+        let sig_structure = builder.make_data_to_sign();
+        let sig_bytes = EmurgoToBytes::to_bytes(&sig_structure);
+
+        let sig = sk.to_raw_key().sign(&sig_bytes);
+
+        let cose = builder.build(sig.to_bytes());
+        let signed = SignedMessage::new_cose_sign1(&cose);
+        let signature = EmurgoToBytes::to_bytes(&signed);
+        let cose_key = EdDSA25519Key::new(sk.to_public().to_raw_key().as_bytes()).build();
+
+        Ok(SignOutput {
+            signature,
+            recovery_id: None,
+            public_key: Some(EmurgoToBytes::to_bytes(&cose_key)),
+        })
     }
 
     fn sign_transaction(
         &self,
-        _private_key: &[u8],
-        _tx_bytes: &[u8],
+        private_key: &[u8],
+        tx_bytes: &[u8],
     ) -> Result<SignOutput, SignerError> {
-        Err(SignerError::SigningFailed("not implemented".into()))
+        let (pay, stake) = Self::decode_keys(private_key)?;
+
+        let tx = FixedTransaction::from_bytes(tx_bytes.to_vec())
+            .map_err(|e| SignerError::InvalidTransaction(e.to_string()))?;
+
+        let tx_hash = tx.transaction_hash();
+        let body = tx.body();
+        let stake_hashes = Self::stake_key_hashes_required_by_body(&body);
+
+        let pay_witness = make_vkey_witness(&tx_hash, &pay.to_raw_key());
+
+        let mut witnesses = Vkeywitnesses::new();
+        witnesses.add(&pay_witness);
+
+        match stake {
+            Some(stake) => {
+                let stake_hash = stake.to_public().to_raw_key().hash();
+                let needs_stake_signature = stake_hashes.contains(&stake_hash)
+                    || body
+                        .required_signers()
+                        .map(|required_signers| required_signers.contains(&stake_hash))
+                        .unwrap_or(false);
+
+                if needs_stake_signature {
+                    witnesses.add(&make_vkey_witness(&tx_hash, &stake.to_raw_key()));
+                }
+            }
+            None => {
+                // No stake key to offer. If the body needs one for anything other than
+                // the payment credential, refuse rather than hand back a transaction
+                // that fails phase-1 validation.
+                let pay_hash = pay.to_public().to_raw_key().hash();
+                let unsatisfied = (0..stake_hashes.len())
+                    .map(|i| stake_hashes.get(i))
+                    .any(|hash| hash != pay_hash);
+
+                if unsatisfied {
+                    return Err(SignerError::InvalidTransaction(
+                        "transaction requires a stake key signature but the key material \
+                         contains no stake key"
+                            .into(),
+                    ));
+                }
+            }
+        }
+
+        let signature = witnesses.to_bytes();
+
+        Ok(SignOutput {
+            // signature is the CBOR-encoded witness set
+            signature,
+            recovery_id: None,
+            public_key: Some(pay_witness.vkey().public_key().as_bytes()),
+        })
     }
 
-    /// Payment leaf (account 0) for generic single-path key resolution (`decrypt_signing_key`, etc.).
+    fn encode_signed_transaction(
+        &self,
+        tx_bytes: &[u8],
+        signature: &SignOutput,
+    ) -> Result<Vec<u8>, SignerError> {
+        let mut tx = FixedTransaction::from_bytes(tx_bytes.to_vec())
+            .map_err(|e| SignerError::InvalidTransaction(e.to_string()))?;
+
+        let witnesses = Vkeywitnesses::from_bytes(signature.signature.clone())
+            .map_err(|e| SignerError::InvalidTransaction(e.to_string()))?;
+
+        for witness in witnesses.into_iter() {
+            tx.add_vkey_witness(witness);
+        }
+
+        Ok(tx.to_bytes())
+    }
+
     fn default_derivation_path(&self, index: u32) -> String {
         Self::payment_derivation_path(index)
+    }
+
+    fn default_derivation_paths(&self, index: u32) -> Vec<String> {
+        vec![
+            Self::payment_derivation_path(index),
+            Self::stake_derivation_path(index),
+        ]
+    }
+
+    fn encode_keys(&self, keys: &[DerivedKey]) -> Result<SecretBytes, SignerError> {
+        if keys.is_empty() {
+            return Err(SignerError::InvalidPrivateKey(
+                "no derived keys to encode".into(),
+            ));
+        }
+
+        let mut buf = Vec::new();
+        for key in keys {
+            buf.extend_from_slice(key.secret.expose());
+        }
+
+        if buf.len() != ed25519_bip32::XPRV_SIZE && buf.len() != ed25519_bip32::XPRV_SIZE * 2 {
+            return Err(SignerError::InvalidPrivateKey(format!(
+                "Cardano encoded keys must be 96 (payment) or 192 (payment||stake) bytes, got {}",
+                buf.len()
+            )));
+        }
+
+        Ok(SecretBytes::new(buf))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hd::HdDeriver;
+    use crate::mnemonic::Mnemonic;
+    use cardano_serialization_lib::{
+        BigNum, Certificates, Ed25519KeyHash, StakeDelegation, TransactionHash, TransactionInput,
+        TransactionInputs, TransactionOutput, TransactionOutputs, Value, Withdrawals,
+    };
+    use hex::FromHex;
+
+    fn derive_key_material(signer: &CardanoSigner, m: &Mnemonic, index: u32) -> SecretBytes {
+        let keys = HdDeriver::derive_keys_from_mnemonic_cached(
+            m,
+            "",
+            signer.default_derivation_paths(index),
+            signer.curve(),
+        )
+        .unwrap();
+        signer.encode_keys(&keys).unwrap()
+    }
 
     #[test]
     fn test_cip1852_paths() {
@@ -127,5 +498,343 @@ mod tests {
         let s = CardanoSigner::mainnet();
         assert_eq!(s.default_derivation_path(0), "m/1852'/1815'/0'/0/0");
         assert_eq!(s.default_derivation_path(5), "m/1852'/1815'/5'/0/0");
+    }
+
+    #[test]
+    fn derive_base_address_from_12_words() {
+        let s = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+        let key = derive_key_material(&s, &m, 0);
+        assert_eq!(s.derive_address(key.expose()).unwrap(), "addr1qyrqjj5nmz8emqexj7yc5wragnk0yfj4wznvjfccmrksxqcj04pscfgjxcvtant3cxg7588twyywwm68nglxaqul8xps7np3y0");
+    }
+
+    #[test]
+    fn derive_base_address_from_24_words() {
+        let s = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase("struggle garbage joke erupt hawk write misery fold hobby shoulder speed movie earth tool medal permit fever wage kid fence off wait order state").unwrap();
+        let key = derive_key_material(&s, &m, 0);
+        assert_eq!(s.derive_address(key.expose()).unwrap(), "addr1q9dfl5qs6jncq6200cxqy7juhw7fm2mk5wm5p0qnx5pmsl80734zn65gc55ecvafkhuxawlnn6wevkmg8dm5kt9vxyys322t44");
+    }
+
+    #[test]
+    fn derive_enterprise_address_from_12_words() {
+        let s = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+
+        let payment_path = CardanoSigner::payment_derivation_path(0);
+        let payment_key = HdDeriver::derive_from_mnemonic(&m, "", &payment_path, s.curve())
+            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+            .unwrap();
+
+        let address = s.derive_address(&payment_key.expose()).unwrap();
+        assert_eq!(
+            address,
+            "addr1vyrqjj5nmz8emqexj7yc5wragnk0yfj4wznvjfccmrksxqcx2tst3"
+        );
+    }
+
+    #[test]
+    fn derive_enterprise_address_from_24_words() {
+        let s = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase(
+            "struggle garbage joke erupt hawk write misery fold hobby shoulder speed movie earth tool medal permit fever wage kid fence off wait order state",
+        )
+        .unwrap();
+
+        let payment_path = CardanoSigner::payment_derivation_path(0);
+        let payment_key = HdDeriver::derive_from_mnemonic(&m, "", &payment_path, s.curve())
+            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+            .unwrap();
+
+        let address = s.derive_address(&payment_key.expose()).unwrap();
+        assert_eq!(
+            address,
+            "addr1v9dfl5qs6jncq6200cxqy7juhw7fm2mk5wm5p0qnx5pmslqy6xjzf"
+        );
+    }
+
+    #[test]
+    fn sign_message_with_none_address() {
+        let s = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+        let key = derive_key_material(&s, &m, 0);
+        let msg = <Vec<u8>>::from_hex("cafe").unwrap();
+        let sig = s.sign_message(key.expose(), &msg, None).unwrap();
+
+        assert_eq!(hex::encode(sig.signature), "845846a20127676164647265737358390106094a93d88f9d832697898a387d44ecf2265570a6c92718d8ed0303127d430c25123618becd71c191ea1ceb7108e76f479a3e6e839f3983a166686173686564f442cafe5840a16c4eb2e963ebd2555292d3dd51bb6ede526ade7e127a8815c940c51a29029931bf5f1b7ce842f12efe25a8aa28037bc9fcb834501aef79ba3df9c0b80ab009");
+        assert_eq!(
+            hex::encode(sig.public_key.unwrap()),
+            "a401010327200621582065a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a69612128"
+        );
+    }
+
+    #[test]
+    fn sign_message_with_base_address() {
+        let s = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+        let key = derive_key_material(&s, &m, 0);
+        let msg = <Vec<u8>>::from_hex("cafe").unwrap();
+        let sig = s.sign_message(key.expose(), &msg, Some("addr1qyrqjj5nmz8emqexj7yc5wragnk0yfj4wznvjfccmrksxqcj04pscfgjxcvtant3cxg7588twyywwm68nglxaqul8xps7np3y0")).unwrap();
+
+        assert_eq!(hex::encode(sig.signature), "845846a20127676164647265737358390106094a93d88f9d832697898a387d44ecf2265570a6c92718d8ed0303127d430c25123618becd71c191ea1ceb7108e76f479a3e6e839f3983a166686173686564f442cafe5840a16c4eb2e963ebd2555292d3dd51bb6ede526ade7e127a8815c940c51a29029931bf5f1b7ce842f12efe25a8aa28037bc9fcb834501aef79ba3df9c0b80ab009");
+        assert_eq!(
+            hex::encode(sig.public_key.unwrap()),
+            "a401010327200621582065a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a69612128"
+        );
+    }
+
+    #[test]
+    fn sign_message_with_enterprise_address() {
+        let s = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+        let key = derive_key_material(&s, &m, 0);
+        let msg = <Vec<u8>>::from_hex("cafe").unwrap();
+        let sig = s
+            .sign_message(
+                key.expose(),
+                &msg,
+                Some("addr1vyrqjj5nmz8emqexj7yc5wragnk0yfj4wznvjfccmrksxqcx2tst3"),
+            )
+            .unwrap();
+
+        assert_eq!(hex::encode(sig.signature), "84582aa201276761646472657373581d6106094a93d88f9d832697898a387d44ecf2265570a6c92718d8ed0303a166686173686564f442cafe58401bb30176a6f48c3eefd4f659afd29c98e4668e4d5676474b7e4497e960e6a8e79860fd3bdb41093e448fc62aa74291490b683adb579e6a3e17a89d0b329ea70f");
+        assert_eq!(
+            hex::encode(sig.public_key.unwrap()),
+            "a401010327200621582065a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a69612128"
+        );
+    }
+
+    #[test]
+    fn sign_message_with_reward_address() {
+        let s = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+        let key = derive_key_material(&s, &m, 0);
+        let msg = <Vec<u8>>::from_hex("cafe").unwrap();
+        let sig = s
+            .sign_message(
+                key.expose(),
+                &msg,
+                Some("stake1uyf86scvy5frvx97e4cury02rn4hzz88dare50nwsw0nnqcxw9kf5"),
+            )
+            .unwrap();
+
+        assert_eq!(hex::encode(sig.signature), "84582aa201276761646472657373581de1127d430c25123618becd71c191ea1ceb7108e76f479a3e6e839f3983a166686173686564f442cafe58401152563eb2dd6dd9775b1e8cd21d829edb93851aba7705156b68c6b9cde9634e9f85f434287172129d8f49c655876ac64293d5ad8370247a5b04e9bdf675d505");
+        assert_eq!(
+            hex::encode(sig.public_key.unwrap()),
+            "a4010103272006215820097cdc1da25a445eda8db6c3f0a3c3ba86c6a9555df0b4010f4d042ed94c2206"
+        );
+    }
+
+    fn build_test_tx_cbor(
+        inputs: &[(&str, u32)],  // (tx hash, index)
+        outputs: &[(&str, u64)], // (bech32 address, lovelace)
+        customize: impl FnOnce(&mut TransactionBody),
+    ) -> Vec<u8> {
+        let mut tx_inputs = TransactionInputs::new();
+        for (tx_hash, index) in inputs {
+            let input_tx_hash = TransactionHash::from_bytes(hex::decode(tx_hash).unwrap()).unwrap();
+            let input = TransactionInput::new(&input_tx_hash, *index);
+            tx_inputs.add(&input);
+        }
+
+        let mut tx_outputs = TransactionOutputs::new();
+        for (addr, lovelace) in outputs {
+            let output = TransactionOutput::new(
+                &Address::from_bech32(addr).unwrap(),
+                &Value::new(&BigNum::from(*lovelace)),
+            );
+            tx_outputs.add(&output);
+        }
+
+        let mut body =
+            TransactionBody::new_tx_body(&tx_inputs, &tx_outputs, &BigNum::from(1_000_000u64));
+
+        customize(&mut body);
+
+        FixedTransaction::new_from_body_bytes(&body.to_bytes())
+            .unwrap()
+            .to_bytes()
+    }
+
+    #[test]
+    fn sign_transaction_with_payment_key_only() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+        let payment_path = CardanoSigner::payment_derivation_path(0);
+        let payment_key =
+            HdDeriver::derive_from_mnemonic(&mnemonic, "", &payment_path, signer.curve()).unwrap();
+
+        let output_address = signer.derive_address(payment_key.expose()).unwrap();
+        let tx_cbor = build_test_tx_cbor(
+            &[(
+                "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+                0,
+            )],
+            &[(&output_address, 2_000_000)],
+            |_body| {},
+        );
+
+        let sign_output = signer
+            .sign_transaction(payment_key.expose(), &tx_cbor)
+            .unwrap();
+        assert_eq!(
+            hex::encode(&sign_output.signature),
+            "d901028182582065a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a69612128584081a1235ccc8c96203f379891da1041af709f532f97a73d220eb081f444622701ce5660044f8fe90ec74d3d4ad7c1c0aece569a106f08a298566c51b139285500"
+        );
+
+        let signed_tx = signer
+            .encode_signed_transaction(&tx_cbor, &sign_output)
+            .unwrap();
+        assert_eq!(
+            hex::encode(signed_tx),
+            "84a300d9010281825820cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe00018182581d6106094a93d88f9d832697898a387d44ecf2265570a6c92718d8ed03031a001e8480021a000f4240a100d901028182582065a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a69612128584081a1235ccc8c96203f379891da1041af709f532f97a73d220eb081f444622701ce5660044f8fe90ec74d3d4ad7c1c0aece569a106f08a298566c51b139285500f5f6"
+        );
+    }
+
+    #[test]
+    fn sign_transaction_with_payment_and_required_stake_key() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let (_, stake_key) = CardanoSigner::decode_keys(key.expose()).unwrap();
+        let stake_key = stake_key.unwrap();
+        let output_address = signer.derive_address(key.expose()).unwrap();
+        let tx_cbor = build_test_tx_cbor(
+            &[(
+                "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+                1,
+            )],
+            &[(&output_address, 3_000_000)],
+            |body| {
+                let mut signers = Ed25519KeyHashes::new();
+                signers.add(&stake_key.to_public().to_raw_key().hash());
+                body.set_required_signers(&signers);
+            },
+        );
+
+        let sig = signer.sign_transaction(key.expose(), &tx_cbor).unwrap();
+        assert_eq!(
+            hex::encode(&sig.signature),
+            "d901028282582065a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a696121285840f0389089c22a690bcbcab9d5865a2b33c06f0a58ba236adaada5f24adb5a39759667876c24250f8c991d1b8c71dca80e05c789eb23a34b66fd53b81d629d1504825820097cdc1da25a445eda8db6c3f0a3c3ba86c6a9555df0b4010f4d042ed94c22065840610945a63febb28741a4d2f9870e3de903f0a8c2f1c7b86e0a61adb667b973306177827559a1e7bacd452682b90eb5b15f4e5ab5a1433b62e0b2429b76b0a604"
+        );
+
+        let signed_tx = signer.encode_signed_transaction(&tx_cbor, &sig).unwrap();
+        assert_eq!(
+            hex::encode(signed_tx),
+            "84a400d9010281825820cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe0101818258390106094a93d88f9d832697898a387d44ecf2265570a6c92718d8ed0303127d430c25123618becd71c191ea1ceb7108e76f479a3e6e839f39831a002dc6c0021a000f42400ed9010281581c127d430c25123618becd71c191ea1ceb7108e76f479a3e6e839f3983a100d901028282582065a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a696121285840f0389089c22a690bcbcab9d5865a2b33c06f0a58ba236adaada5f24adb5a39759667876c24250f8c991d1b8c71dca80e05c789eb23a34b66fd53b81d629d1504825820097cdc1da25a445eda8db6c3f0a3c3ba86c6a9555df0b4010f4d042ed94c22065840610945a63febb28741a4d2f9870e3de903f0a8c2f1c7b86e0a61adb667b973306177827559a1e7bacd452682b90eb5b15f4e5ab5a1433b62e0b2429b76b0a604f5f6"
+        );
+    }
+
+    #[test]
+    fn sign_transaction_with_stake_delegation_cert() {
+        let signer = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &m, 0);
+        let (_payment_key, stake_key) = CardanoSigner::decode_keys(key.expose()).unwrap();
+
+        let address = signer.derive_address(key.expose()).unwrap();
+
+        let tx_cbor = build_test_tx_cbor(
+            &[(
+                "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+                0,
+            )],
+            &[(&address, 2_000_000)],
+            |body| {
+                let mut certs = Certificates::new();
+                let cert = Certificate::new_stake_delegation(&StakeDelegation::new(
+                    &Credential::from_keyhash(&stake_key.unwrap().to_public().to_raw_key().hash()),
+                    &Ed25519KeyHash::from_bytes(vec![0xcd; 28]).unwrap(), // dummy pool keyhash
+                ));
+                certs.add(&cert);
+                body.set_certs(&certs);
+            },
+        );
+
+        let sign_output = signer.sign_transaction(key.expose(), &tx_cbor).unwrap();
+        let witnesses = Vkeywitnesses::from_bytes(sign_output.signature.clone()).unwrap();
+
+        let witnesses_keys = (0..witnesses.len())
+            .map(|i| hex::encode(witnesses.get(i).vkey().public_key().as_bytes()))
+            .collect::<Vec<String>>();
+        assert_eq!(
+            witnesses_keys,
+            [
+                "65a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a69612128", // payment key
+                "097cdc1da25a445eda8db6c3f0a3c3ba86c6a9555df0b4010f4d042ed94c2206"  // stake key
+            ]
+        );
+    }
+
+    #[test]
+    fn sign_transaction_with_withdrawals() {
+        let signer = CardanoSigner::mainnet();
+        let m = Mnemonic::from_phrase(
+            "jelly wolf grass equip diagram mixed bottom speed luggage venture stool end",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &m, 0);
+        let (_payment_key, stake_key) = CardanoSigner::decode_keys(key.expose()).unwrap();
+        let stake_key = stake_key.unwrap();
+
+        let address = signer.derive_address(key.expose()).unwrap();
+        let reward_address = RewardAddress::new(
+            signer.network_id,
+            &Credential::from_keyhash(&stake_key.to_public().to_raw_key().hash()),
+        );
+
+        let tx_cbor = build_test_tx_cbor(
+            &[(
+                "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+                0,
+            )],
+            &[(&address, 2_000_000)],
+            |body| {
+                let mut withdrawals = Withdrawals::new();
+                withdrawals.insert(&reward_address, &BigNum::from(1_000_000u64));
+                body.set_withdrawals(&withdrawals);
+            },
+        );
+
+        let sign_output = signer.sign_transaction(key.expose(), &tx_cbor).unwrap();
+        let witnesses = Vkeywitnesses::from_bytes(sign_output.signature.clone()).unwrap();
+
+        let witnesses_keys = (0..witnesses.len())
+            .map(|i| hex::encode(witnesses.get(i).vkey().public_key().as_bytes()))
+            .collect::<Vec<String>>();
+        assert_eq!(
+            witnesses_keys,
+            [
+                "65a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a69612128", // payment key
+                "097cdc1da25a445eda8db6c3f0a3c3ba86c6a9555df0b4010f4d042ed94c2206"  // stake key
+            ]
+        );
     }
 }

--- a/ows/crates/ows-signer/src/chains/cardano.rs
+++ b/ows/crates/ows-signer/src/chains/cardano.rs
@@ -1,0 +1,130 @@
+use crate::curve::Curve;
+use crate::traits::{ChainSigner, SignOutput, SignerError};
+use cardano_serialization_lib::NetworkInfo;
+use ows_core::ChainType;
+
+pub struct CardanoSigner {
+    network_id: u8,
+}
+
+impl CardanoSigner {
+    pub fn mainnet() -> Self {
+        Self {
+            network_id: NetworkInfo::mainnet().network_id(),
+        }
+    }
+
+    pub fn preprod() -> Self {
+        Self {
+            network_id: NetworkInfo::testnet_preprod().network_id(),
+        }
+    }
+
+    pub fn preview() -> Self {
+        Self {
+            network_id: NetworkInfo::testnet_preview().network_id(),
+        }
+    }
+
+    pub fn from_chain_id(chain_id: &str) -> Self {
+        match chain_id {
+            "cip34:0-1" => Self::preprod(),
+            "cip34:0-2" => Self::preview(),
+            _ => Self::mainnet(),
+        }
+    }
+
+    /// CIP-1852 payment key path where index is the account index: `m/1852'/1815'/{index}'/0/0`.
+    pub fn payment_derivation_path(index: u32) -> String {
+        format!("m/1852'/1815'/{index}'/0/0")
+    }
+
+    /// CIP-1852 stake key path where index is the account index: `m/1852'/1815'/{index}'/2/0`.
+    pub fn stake_derivation_path(index: u32) -> String {
+        format!("m/1852'/1815'/{index}'/2/0")
+    }
+}
+
+impl ChainSigner for CardanoSigner {
+    fn chain_type(&self) -> ChainType {
+        ChainType::Cardano
+    }
+
+    fn curve(&self) -> Curve {
+        Curve::Ed25519Bip32
+    }
+
+    fn coin_type(&self) -> u32 {
+        1815
+    }
+
+    /// Planned: Shelley **base** address from `payment_xprv || stake_xprv` (see module docs).
+    fn derive_address(&self, _private_key: &[u8]) -> Result<String, SignerError> {
+        Err(SignerError::AddressDerivationFailed(
+            "Cardano Shelley base address encoding not implemented yet; planned `private_key` layout \
+             is 192 bytes: payment XPrv (96) || stake XPrv (96) at matching CIP-1852 indices"
+                .into(),
+        ))
+    }
+
+    fn sign(&self, _private_key: &[u8], _message: &[u8]) -> Result<SignOutput, SignerError> {
+        Err(SignerError::SigningFailed("not implemented".into()))
+    }
+
+    fn sign_message(
+        &self,
+        _private_key: &[u8],
+        _message: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        Err(SignerError::SigningFailed("not implemented".into()))
+    }
+
+    fn sign_transaction(
+        &self,
+        _private_key: &[u8],
+        _tx_bytes: &[u8],
+    ) -> Result<SignOutput, SignerError> {
+        Err(SignerError::SigningFailed("not implemented".into()))
+    }
+
+    /// Payment leaf (account 0) for generic single-path key resolution (`decrypt_signing_key`, etc.).
+    fn default_derivation_path(&self, index: u32) -> String {
+        Self::payment_derivation_path(index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cip1852_paths() {
+        assert_eq!(
+            CardanoSigner::payment_derivation_path(0),
+            "m/1852'/1815'/0'/0/0"
+        );
+        assert_eq!(
+            CardanoSigner::stake_derivation_path(0),
+            "m/1852'/1815'/0'/2/0"
+        );
+        assert_eq!(
+            CardanoSigner::payment_derivation_path(3),
+            "m/1852'/1815'/3'/0/0"
+        );
+    }
+
+    #[test]
+    fn test_chain_type_and_curve() {
+        let s = CardanoSigner::mainnet();
+        assert_eq!(s.chain_type(), ChainType::Cardano);
+        assert_eq!(s.curve(), Curve::Ed25519Bip32);
+        assert_eq!(s.coin_type(), 1815);
+    }
+
+    #[test]
+    fn test_default_derivation_path_is_payment() {
+        let s = CardanoSigner::mainnet();
+        assert_eq!(s.default_derivation_path(0), "m/1852'/1815'/0'/0/0");
+        assert_eq!(s.default_derivation_path(5), "m/1852'/1815'/5'/0/0");
+    }
+}

--- a/ows/crates/ows-signer/src/chains/cardano.rs
+++ b/ows/crates/ows-signer/src/chains/cardano.rs
@@ -75,6 +75,7 @@ impl ChainSigner for CardanoSigner {
         &self,
         _private_key: &[u8],
         _message: &[u8],
+        _address: Option<&str>,
     ) -> Result<SignOutput, SignerError> {
         Err(SignerError::SigningFailed("not implemented".into()))
     }

--- a/ows/crates/ows-signer/src/chains/cardano.rs
+++ b/ows/crates/ows-signer/src/chains/cardano.rs
@@ -12,10 +12,42 @@ use emurgo_cardano_message_signing::utils::ToBytes as EmurgoToBytes;
 use emurgo_cardano_message_signing::{
     HeaderMap, Headers, Label, ProtectedHeaderMap, SignedMessage,
 };
+use ows_core::policy::{TransactionContext, TransactionEffect};
 use ows_core::ChainType;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
 
 pub struct CardanoSigner {
     network_id: u8,
+}
+
+const LOVELACE_ASSET_ID: &str = "lovelace";
+const KOIOS_TXS_CBOR_CHUNK_SIZE: usize = 10;
+const KOIOS_REQUESTS_TIMEOUT: Duration = Duration::from_secs(45);
+
+type AssetBalanceMap = BTreeMap<String, u64>;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KoiosAssetListItem {
+    policy_id: String,
+    asset_name: String,
+    quantity: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KoiosUtxoInfoRow {
+    tx_hash: String,
+    tx_index: u32,
+    address: String,
+    value: String,
+    asset_list: Option<Vec<KoiosAssetListItem>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KoiosTxCborRow {
+    tx_hash: String,
+    cbor: String,
 }
 
 impl CardanoSigner {
@@ -195,6 +227,200 @@ impl CardanoSigner {
         rew.to_address()
             .to_bech32(None)
             .map_err(|e| SignerError::AddressDerivationFailed(e.to_string()))
+    }
+
+    /// Explicit deposit/refund carried on a certificate, attributed to the
+    /// credential's reward address. Legacy Shelley certs without an on-wire
+    /// `coin` are skipped (amount comes from protocol parameters).
+    ///
+    /// Returns `(credential, lovelace, is_deposit)`.
+    fn cert_deposit_or_refund(cert: &Certificate) -> Option<(Credential, u64, bool)> {
+        match cert.kind() {
+            CertificateKind::StakeRegistration => cert.as_reg_cert().and_then(|c| {
+                c.coin()
+                    .map(|coin| (c.stake_credential(), u64::from(coin), true))
+            }),
+            CertificateKind::StakeDeregistration => cert.as_unreg_cert().and_then(|c| {
+                c.coin()
+                    .map(|coin| (c.stake_credential(), u64::from(coin), false))
+            }),
+            CertificateKind::StakeRegistrationAndDelegation => cert
+                .as_stake_registration_and_delegation()
+                .map(|c| (c.stake_credential(), u64::from(c.coin()), true)),
+            CertificateKind::StakeVoteRegistrationAndDelegation => cert
+                .as_stake_vote_registration_and_delegation()
+                .map(|c| (c.stake_credential(), u64::from(c.coin()), true)),
+            CertificateKind::VoteRegistrationAndDelegation => cert
+                .as_vote_registration_and_delegation()
+                .map(|c| (c.stake_credential(), u64::from(c.coin()), true)),
+            CertificateKind::DRepRegistration => cert
+                .as_drep_registration()
+                .map(|c| (c.voting_credential(), u64::from(c.coin()), true)),
+            CertificateKind::DRepDeregistration => cert
+                .as_drep_deregistration()
+                .map(|c| (c.voting_credential(), u64::from(c.coin()), false)),
+            _ => None,
+        }
+    }
+
+    fn add_lovelace_balance(
+        balances: &mut BTreeMap<String, AssetBalanceMap>,
+        address: String,
+        amount: u64,
+    ) {
+        *balances
+            .entry(address)
+            .or_default()
+            .entry(LOVELACE_ASSET_ID.to_string())
+            .or_insert(0) += amount;
+    }
+
+    fn fetch_txs_cbor(
+        koios_base_url: &str,
+        tx_hashes: &[String],
+    ) -> Result<BTreeMap<String, String>, SignerError> {
+        if tx_hashes.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(KOIOS_REQUESTS_TIMEOUT)
+            .build()
+            .map_err(|e| SignerError::RpcError(e.to_string()))?;
+
+        let base_url = koios_base_url.trim_end_matches('/');
+        let url = format!("{base_url}/tx_cbor");
+        let mut txs_cbor: BTreeMap<String, String> = BTreeMap::new();
+
+        for chunk in tx_hashes.chunks(KOIOS_TXS_CBOR_CHUNK_SIZE) {
+            let body = serde_json::json!({
+                "_tx_hashes": chunk,
+            });
+
+            let resp = client
+                .post(&url)
+                .json(&body)
+                .send()
+                .map_err(|e| SignerError::RpcError(e.to_string()))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().unwrap_or_default();
+                return Err(SignerError::RpcError(format!(
+                    "Koios tx_cbor returned {status}: {text}"
+                )));
+            }
+
+            let fetched: Vec<KoiosTxCborRow> = resp
+                .json()
+                .map_err(|e| SignerError::RpcError(format!("Koios tx_cbor JSON: {e}")))?;
+
+            for row in fetched {
+                txs_cbor.insert(row.tx_hash, row.cbor);
+            }
+        }
+
+        Ok(txs_cbor)
+    }
+
+    /// Fetches UTXOs by retrieving each referenced transaction's CBOR and verifying
+    /// that `transaction_hash()` matches the expected hash. This prevents a malicious
+    /// RPC provider from returning fabricated UTXO data under a trusted tx hash.
+    fn fetch_utxos(
+        koios_base_url: &str,
+        input_refs: &[(String, u32)],
+    ) -> Result<Vec<KoiosUtxoInfoRow>, SignerError> {
+        if input_refs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let unique_hashes: Vec<String> = input_refs
+            .iter()
+            .map(|(hash, _)| hash.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
+        let txs_cbor = Self::fetch_txs_cbor(koios_base_url, &unique_hashes)?;
+
+        for hash in &unique_hashes {
+            if !txs_cbor.contains_key(hash) {
+                return Err(SignerError::RpcError(format!(
+                    "Koios tx_cbor missing transaction {hash}"
+                )));
+            }
+        }
+
+        let mut verified_txs: BTreeMap<String, FixedTransaction> = BTreeMap::new();
+        for (expected_hash, cbor_hex) in &txs_cbor {
+            let cbor_bytes = hex::decode(cbor_hex).map_err(|e| {
+                SignerError::RpcError(format!("invalid CBOR hex for tx {expected_hash}: {e}"))
+            })?;
+            let tx = FixedTransaction::from_bytes(cbor_bytes).map_err(|e| {
+                SignerError::RpcError(format!("invalid CBOR for tx {expected_hash}: {e}"))
+            })?;
+            let actual_hash = tx.transaction_hash().to_hex();
+            if &actual_hash != expected_hash {
+                return Err(SignerError::RpcError(format!(
+                    "CBOR hash mismatch for tx {expected_hash}: got {actual_hash}"
+                )));
+            }
+            verified_txs.insert(expected_hash.clone(), tx);
+        }
+
+        let mut utxos = Vec::with_capacity(input_refs.len());
+        for (tx_hash, index) in input_refs {
+            let tx = verified_txs
+                .get(tx_hash)
+                .expect("missing tx already checked above");
+            let outputs = tx.body().outputs();
+            let index_usize = *index as usize;
+            if index_usize >= outputs.len() {
+                return Err(SignerError::InvalidTransaction(format!(
+                    "input {tx_hash}#{index} out of range (tx has {} outputs)",
+                    outputs.len()
+                )));
+            }
+
+            let output = outputs.get(index_usize);
+            let address = output.address().to_bech32(None).map_err(|e| {
+                SignerError::InvalidTransaction(format!(
+                    "invalid address on input {tx_hash}#{index}: {e}"
+                ))
+            })?;
+            let lovelace: u64 = output.amount().coin().into();
+
+            let asset_list = match output.amount().multiasset() {
+                Some(ma) if ma.keys().len() > 0 => {
+                    let mut assets = Vec::new();
+                    for policy_id_index in 0..ma.keys().len() {
+                        let policy_id = ma.keys().get(policy_id_index);
+                        let policy_assets = ma.get(&policy_id).unwrap();
+                        for asset_index in 0..policy_assets.len() {
+                            let asset_name = policy_assets.keys().get(asset_index);
+                            let quantity: u64 = policy_assets.get(&asset_name).unwrap().into();
+                            assets.push(KoiosAssetListItem {
+                                policy_id: policy_id.to_hex(),
+                                asset_name: hex::encode(asset_name.name()),
+                                quantity: quantity.to_string(),
+                            });
+                        }
+                    }
+                    Some(assets)
+                }
+                _ => None,
+            };
+
+            utxos.push(KoiosUtxoInfoRow {
+                tx_hash: tx_hash.clone(),
+                tx_index: *index,
+                address,
+                value: lovelace.to_string(),
+                asset_list,
+            });
+        }
+
+        Ok(utxos)
     }
 }
 
@@ -413,6 +639,205 @@ impl ChainSigner for CardanoSigner {
         Ok(tx.to_bytes())
     }
 
+    fn make_transaction_context(
+        &self,
+        tx_bytes: &[u8],
+        rpc_url: Option<&str>,
+    ) -> Result<TransactionContext, SignerError> {
+        let tx_hex = hex::encode(tx_bytes);
+
+        let tx = FixedTransaction::from_bytes(tx_bytes.to_vec())
+            .map_err(|e| SignerError::InvalidTransaction(e.to_string()))?;
+
+        let tx_input_refs: Vec<(String, u32)> = tx
+            .body()
+            .inputs()
+            .into_iter()
+            .map(|input| (input.transaction_id().to_hex(), input.index()))
+            .collect();
+
+        let mut inputs_balances_by_address: BTreeMap<String, AssetBalanceMap> = BTreeMap::new();
+        if !tx_input_refs.is_empty() {
+            let koios_base_url = rpc_url.ok_or_else(|| {
+                SignerError::InvalidMessage(
+                    "Koios RPC URL is required to fetch Cardano transaction inputs".into(),
+                )
+            })?;
+            let utxos = Self::fetch_utxos(koios_base_url, &tx_input_refs)?;
+
+            for utxo in utxos {
+                let inputs_balances_for_address =
+                    inputs_balances_by_address.entry(utxo.address).or_default();
+
+                *inputs_balances_for_address
+                    .entry(LOVELACE_ASSET_ID.to_string())
+                    .or_insert(0) += utxo.value.parse::<u64>().map_err(|e| {
+                    SignerError::InvalidTransaction(format!(
+                        "invalid lovelace value for utxo {}#{}: {e}",
+                        utxo.tx_hash, utxo.tx_index
+                    ))
+                })?;
+
+                for asset in utxo.asset_list.unwrap_or_default() {
+                    *inputs_balances_for_address
+                        .entry(format!("{}{}", asset.policy_id, asset.asset_name))
+                        .or_insert(0) += asset.quantity.parse::<u64>().map_err(|e| {
+                        SignerError::InvalidTransaction(format!(
+                            "invalid asset quantity for utxo {}#{} and asset {}.{}: {e}",
+                            utxo.tx_hash, utxo.tx_index, asset.policy_id, asset.asset_name
+                        ))
+                    })?;
+                }
+            }
+        }
+
+        let mut outputs_balances_by_address: BTreeMap<String, AssetBalanceMap> = BTreeMap::new();
+        for output in tx.body().outputs().into_iter() {
+            let dest_address = output.address().to_bech32(None).map_err(|e| {
+                SignerError::InvalidTransaction(format!("invalid output address: {e}"))
+            })?;
+
+            let output_balances_for_address =
+                outputs_balances_by_address.entry(dest_address).or_default();
+
+            let lovelace: u64 = output.amount().coin().into();
+
+            *output_balances_for_address
+                .entry(LOVELACE_ASSET_ID.to_string())
+                .or_insert(0) += lovelace;
+
+            let ma = output.amount().multiasset();
+            if ma.is_none() {
+                continue;
+            }
+
+            let ma = ma.unwrap();
+
+            for policy_id_index in 0..ma.keys().len() {
+                let policy_id = ma.keys().get(policy_id_index);
+                let assets = ma.get(&policy_id).unwrap();
+
+                for asset_index in 0..assets.len() {
+                    let asset_name = assets.keys().get(asset_index);
+                    let asset_quantity = assets.get(&asset_name).unwrap();
+                    let asset_quantity: u64 = asset_quantity.into();
+
+                    *output_balances_for_address
+                        .entry(format!(
+                            "{}{}",
+                            policy_id.to_hex(),
+                            hex::encode(asset_name.name())
+                        ))
+                        .or_insert(0) += asset_quantity;
+                }
+            }
+        }
+
+        // Withdrawals leave the reward account and enter the transaction, so
+        // treat them as inputs from the reward address.
+        if let Some(withdrawals) = tx.body().withdrawals() {
+            let reward_addresses = withdrawals.keys();
+            for i in 0..reward_addresses.len() {
+                let reward_address = reward_addresses.get(i);
+                let amount: u64 = withdrawals
+                    .get(&reward_address)
+                    .ok_or_else(|| {
+                        SignerError::InvalidTransaction(
+                            "withdrawal amount missing for reward address".into(),
+                        )
+                    })?
+                    .into();
+                let addr = reward_address.to_address().to_bech32(None).map_err(|e| {
+                    SignerError::InvalidTransaction(format!("invalid withdrawal address: {e}"))
+                })?;
+                Self::add_lovelace_balance(&mut inputs_balances_by_address, addr, amount);
+            }
+        }
+
+        // Certificate deposits lock lovelace under the credential (like an
+        // output to its reward address); refunds unlock it (like an input).
+        if let Some(certs) = tx.body().certs() {
+            for i in 0..certs.len() {
+                let Some((credential, amount, is_deposit)) =
+                    Self::cert_deposit_or_refund(&certs.get(i))
+                else {
+                    continue;
+                };
+                let addr = RewardAddress::new(self.network_id, &credential)
+                    .to_address()
+                    .to_bech32(None)
+                    .map_err(|e| {
+                        SignerError::InvalidTransaction(format!(
+                            "invalid certificate reward address: {e}"
+                        ))
+                    })?;
+                if is_deposit {
+                    Self::add_lovelace_balance(&mut outputs_balances_by_address, addr, amount);
+                } else {
+                    Self::add_lovelace_balance(&mut inputs_balances_by_address, addr, amount);
+                }
+            }
+        }
+
+        let mut all_addresses: BTreeSet<&String> = BTreeSet::new();
+        for c in inputs_balances_by_address.keys() {
+            all_addresses.insert(c);
+        }
+        for c in outputs_balances_by_address.keys() {
+            all_addresses.insert(c);
+        }
+
+        let empty_balances = AssetBalanceMap::new();
+        let mut effects: Vec<TransactionEffect> = Vec::new();
+        for effect_address in all_addresses {
+            let input_balances = inputs_balances_by_address
+                .get(effect_address)
+                .unwrap_or(&empty_balances);
+            let output_balances = outputs_balances_by_address
+                .get(effect_address)
+                .unwrap_or(&empty_balances);
+
+            let mut asset_ids: BTreeSet<&String> = BTreeSet::new();
+            for k in input_balances.keys() {
+                asset_ids.insert(k);
+            }
+            for k in output_balances.keys() {
+                asset_ids.insert(k);
+            }
+
+            let mut diff: Vec<(String, i64)> = Vec::new();
+            for asset_id in asset_ids {
+                let input_balance = *input_balances.get(asset_id).unwrap_or(&0);
+                let output_balance = *output_balances.get(asset_id).unwrap_or(&0);
+
+                let asset_diff = (output_balance as i64) - (input_balance as i64);
+                if asset_diff == 0 {
+                    continue;
+                }
+
+                diff.push((asset_id.clone(), asset_diff));
+            }
+
+            if diff.is_empty() {
+                continue;
+            }
+
+            diff.sort_by(|a, b| a.0.cmp(&b.0));
+            effects.push(TransactionEffect {
+                address: effect_address.clone(),
+                diff,
+            });
+        }
+
+        effects.sort_by(|a, b| a.address.cmp(&b.address));
+
+        Ok(TransactionContext {
+            effects,
+            raw_hex: tx_hex,
+            data: None,
+        })
+    }
+
     fn default_derivation_path(&self, index: u32) -> String {
         Self::payment_derivation_path(index)
     }
@@ -453,10 +878,13 @@ mod tests {
     use crate::hd::HdDeriver;
     use crate::mnemonic::Mnemonic;
     use cardano_serialization_lib::{
-        BigNum, Certificates, Ed25519KeyHash, StakeDelegation, TransactionHash, TransactionInput,
-        TransactionInputs, TransactionOutput, TransactionOutputs, Value, Withdrawals,
+        AssetName, BigNum, Certificates, Ed25519KeyHash, Ed25519KeyHashes, MultiAsset, ScriptHash,
+        StakeDelegation, StakeDeregistration, StakeRegistration, TransactionBody, TransactionHash,
+        TransactionInput, TransactionInputs, TransactionOutput, TransactionOutputs, Value,
+        Withdrawals,
     };
     use hex::FromHex;
+    use mockito::Server;
 
     fn derive_key_material(signer: &CardanoSigner, m: &Mnemonic, index: u32) -> SecretBytes {
         let keys = HdDeriver::derive_keys_from_mnemonic_cached(
@@ -643,9 +1071,13 @@ mod tests {
         );
     }
 
+    const TX_FEE: u64 = 1_000_000u64;
+
+    type TestAsset<'a> = (&'a str, &'a str, u64); // (policy id hex, asset name hex, quantity)
+
     fn build_test_tx_cbor(
-        inputs: &[(&str, u32)],  // (tx hash, index)
-        outputs: &[(&str, u64)], // (bech32 address, lovelace)
+        inputs: &[(&str, u32)],                        // (tx hash, index)
+        outputs: &[(&str, u64, Option<&[TestAsset]>)], // (bech32 address, lovelace, optional assets)
         customize: impl FnOnce(&mut TransactionBody),
     ) -> Vec<u8> {
         let mut tx_inputs = TransactionInputs::new();
@@ -656,16 +1088,29 @@ mod tests {
         }
 
         let mut tx_outputs = TransactionOutputs::new();
-        for (addr, lovelace) in outputs {
-            let output = TransactionOutput::new(
-                &Address::from_bech32(addr).unwrap(),
-                &Value::new(&BigNum::from(*lovelace)),
-            );
+        for (addr, lovelace, assets) in outputs {
+            let mut output_value = Value::new(&BigNum::from(*lovelace));
+
+            if let Some(assets) = assets {
+                let mut multi_asset = MultiAsset::new();
+                for (policy_id_hex, asset_name_hex, quantity) in assets.iter().copied() {
+                    let policy_id = ScriptHash::from_hex(policy_id_hex).unwrap();
+                    let asset_name = AssetName::new(hex::decode(asset_name_hex).unwrap()).unwrap();
+
+                    let mut policy_assets = multi_asset.get(&policy_id).unwrap_or_default();
+                    policy_assets.insert(&asset_name, &BigNum::from(quantity));
+                    multi_asset.insert(&policy_id, &policy_assets);
+                }
+
+                output_value.set_multiasset(&multi_asset);
+            }
+
+            let output =
+                TransactionOutput::new(&Address::from_bech32(addr).unwrap(), &output_value);
             tx_outputs.add(&output);
         }
 
-        let mut body =
-            TransactionBody::new_tx_body(&tx_inputs, &tx_outputs, &BigNum::from(1_000_000u64));
+        let mut body = TransactionBody::new_tx_body(&tx_inputs, &tx_outputs, &BigNum::from(TX_FEE));
 
         customize(&mut body);
 
@@ -691,7 +1136,7 @@ mod tests {
                 "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
                 0,
             )],
-            &[(&output_address, 2_000_000)],
+            &[(&output_address, 2_000_000, None)],
             |_body| {},
         );
 
@@ -728,7 +1173,7 @@ mod tests {
                 "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
                 1,
             )],
-            &[(&output_address, 3_000_000)],
+            &[(&output_address, 3_000_000, None)],
             |body| {
                 let mut signers = Ed25519KeyHashes::new();
                 signers.add(&stake_key.to_public().to_raw_key().hash());
@@ -766,7 +1211,7 @@ mod tests {
                 "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
                 0,
             )],
-            &[(&address, 2_000_000)],
+            &[(&address, 2_000_000, None)],
             |body| {
                 let mut certs = Certificates::new();
                 let cert = Certificate::new_stake_delegation(&StakeDelegation::new(
@@ -815,7 +1260,7 @@ mod tests {
                 "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
                 0,
             )],
-            &[(&address, 2_000_000)],
+            &[(&address, 2_000_000, None)],
             |body| {
                 let mut withdrawals = Withdrawals::new();
                 withdrawals.insert(&reward_address, &BigNum::from(1_000_000u64));
@@ -834,6 +1279,495 @@ mod tests {
             [
                 "65a7f55e5fb6964610d0e220c37aadd502041e8f90a86b82c46e531a69612128", // payment key
                 "097cdc1da25a445eda8db6c3f0a3c3ba86c6a9555df0b4010f4d042ed94c2206"  // stake key
+            ]
+        );
+    }
+
+    /// Build a source transaction whose outputs can be spent as UTXOs, returning
+    /// `(tx_hash, cbor_bytes)` with a real blake2b body hash.
+    fn build_utxo_source_tx(outputs: &[(&str, u64, Option<&[TestAsset]>)]) -> (String, Vec<u8>) {
+        let cbor = build_test_tx_cbor(
+            &[(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                0,
+            )],
+            outputs,
+            |_body| {},
+        );
+        let tx = FixedTransaction::from_bytes(cbor.clone()).unwrap();
+        (tx.transaction_hash().to_hex(), cbor)
+    }
+
+    fn mock_tx_cbor_response(server: &mut Server, txs: &[(String, Vec<u8>)]) -> mockito::Mock {
+        let body: Vec<serde_json::Value> = txs
+            .iter()
+            .map(|(hash, cbor)| {
+                serde_json::json!({
+                    "tx_hash": hash,
+                    "cbor": hex::encode(cbor),
+                })
+            })
+            .collect();
+        server
+            .mock("POST", "/tx_cbor")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(serde_json::to_string(&body).unwrap())
+            .create()
+    }
+
+    #[test]
+    fn transaction_context_self_transfer() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let address = signer.derive_address(&key.expose()).unwrap();
+
+        let input_index = 0;
+        let input_value = 10_000_000;
+        let (input_tx_hash, source_cbor) = build_utxo_source_tx(&[(&address, input_value, None)]);
+
+        let tx_cbor = build_test_tx_cbor(
+            &[(&input_tx_hash, input_index)],
+            &[(&address, input_value - TX_FEE, None)],
+            |_body| {},
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(&mut server, &[(input_tx_hash, source_cbor)]);
+
+        let rpc_url = server.url();
+
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&rpc_url))
+            .unwrap();
+
+        mock.assert();
+        assert_eq!(
+            ctx.effects,
+            vec![TransactionEffect {
+                address,
+                diff: vec![("lovelace".into(), -(TX_FEE as i64))],
+            }]
+        );
+    }
+
+    #[test]
+    fn transaction_context_single_input_external_plus_change() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let my_address = signer.derive_address(&key.expose()).unwrap();
+        let external_address =
+            "addr1vyrqjj5nmz8emqexj7yc5wragnk0yfj4wznvjfccmrksxqcx2tst3".to_string();
+
+        let input_index = 0;
+        let input_value = 10_000_000u64;
+        let external_value = 3_000_000u64;
+        let change_value = input_value - external_value - TX_FEE;
+        let (input_tx_hash, source_cbor) =
+            build_utxo_source_tx(&[(&my_address, input_value, None)]);
+
+        let tx_cbor = build_test_tx_cbor(
+            &[(&input_tx_hash, input_index)],
+            &[
+                (&external_address, external_value, None),
+                (&my_address, change_value, None),
+            ],
+            |_body| {},
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(&mut server, &[(input_tx_hash, source_cbor)]);
+
+        let rpc_url = server.url();
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&rpc_url))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(
+            ctx.effects,
+            vec![
+                TransactionEffect {
+                    address: my_address,
+                    diff: vec![("lovelace".into(), -4_000_000)],
+                },
+                TransactionEffect {
+                    address: external_address,
+                    diff: vec![("lovelace".into(), 3_000_000)],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn transaction_context_single_input_external_plus_change_with_assets() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let my_address = signer.derive_address(&key.expose()).unwrap();
+        let external_address =
+            "addr1vyrqjj5nmz8emqexj7yc5wragnk0yfj4wznvjfccmrksxqcx2tst3".to_string();
+
+        let input_index = 0;
+        let input_value = 10_000_000u64;
+        let external_value = 3_000_000u64;
+        let change_value = input_value - external_value - TX_FEE;
+
+        let policy_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let asset_name = "746f6b656e";
+
+        let input_asset_qty = 100u64;
+        let external_asset_qty = 30u64;
+        let change_asset_qty = input_asset_qty - external_asset_qty;
+        let asset_id = format!("{policy_id}{asset_name}");
+
+        let input_assets: Vec<TestAsset> = vec![(policy_id, asset_name, input_asset_qty)];
+        let (input_tx_hash, source_cbor) =
+            build_utxo_source_tx(&[(&my_address, input_value, Some(&input_assets))]);
+
+        let external_assets: Vec<TestAsset> = vec![(policy_id, asset_name, external_asset_qty)];
+        let change_assets: Vec<TestAsset> = vec![(policy_id, asset_name, change_asset_qty)];
+        let tx_cbor = build_test_tx_cbor(
+            &[(&input_tx_hash, input_index)],
+            &[
+                (&external_address, external_value, Some(&external_assets)),
+                (&my_address, change_value, Some(&change_assets)),
+            ],
+            |_body| {},
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(&mut server, &[(input_tx_hash, source_cbor)]);
+
+        let rpc_url = server.url();
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&rpc_url))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(
+            ctx.effects,
+            vec![
+                TransactionEffect {
+                    address: my_address,
+                    diff: vec![(asset_id.clone(), -30), ("lovelace".into(), -4_000_000)],
+                },
+                TransactionEffect {
+                    address: external_address,
+                    diff: vec![(asset_id, 30), ("lovelace".into(), 3_000_000)],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn transaction_context_two_inputs_a_b_two_outputs_a_b_rebalanced() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key_a = derive_key_material(&signer, &mnemonic, 0);
+        let key_b = derive_key_material(&signer, &mnemonic, 1);
+        let address_a = signer.derive_address(&key_a.expose()).unwrap();
+        let address_b = signer.derive_address(&key_b.expose()).unwrap();
+
+        let input_a_index = 0;
+        let input_b_index = 0;
+        let input_a_value = 8_000_000u64;
+        let input_b_value = 7_000_000u64;
+        let output_a_value = 5_000_000u64;
+        let output_b_value = input_a_value + input_b_value - output_a_value - TX_FEE;
+
+        let (input_a_hash, source_a_cbor) =
+            build_utxo_source_tx(&[(&address_a, input_a_value, None)]);
+        let (input_b_hash, source_b_cbor) =
+            build_utxo_source_tx(&[(&address_b, input_b_value, None)]);
+
+        let tx_cbor = build_test_tx_cbor(
+            &[
+                (&input_a_hash, input_a_index),
+                (&input_b_hash, input_b_index),
+            ],
+            &[
+                (&address_a, output_a_value, None),
+                (&address_b, output_b_value, None),
+            ],
+            |_body| {},
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(
+            &mut server,
+            &[(input_a_hash, source_a_cbor), (input_b_hash, source_b_cbor)],
+        );
+
+        let rpc_url = server.url();
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&rpc_url))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(
+            ctx.effects,
+            vec![
+                TransactionEffect {
+                    address: address_a,
+                    diff: vec![("lovelace".into(), -3_000_000)],
+                },
+                TransactionEffect {
+                    address: address_b,
+                    diff: vec![("lovelace".into(), 2_000_000)],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn transaction_context_inputs_a_b_outputs_a_c() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key_a = derive_key_material(&signer, &mnemonic, 0);
+        let key_b = derive_key_material(&signer, &mnemonic, 1);
+        let key_c = derive_key_material(&signer, &mnemonic, 2);
+        let address_a = signer.derive_address(&key_a.expose()).unwrap();
+        let address_b = signer.derive_address(&key_b.expose()).unwrap();
+        let address_c = signer.derive_address(&key_c.expose()).unwrap();
+
+        let input_a_index = 0;
+        let input_b_index = 0;
+        let input_a_value = 8_000_000u64;
+        let input_b_value = 7_000_000u64;
+        let output_a_value = 4_000_000u64;
+        let output_c_value = input_a_value + input_b_value - output_a_value - TX_FEE;
+
+        let (input_a_hash, source_a_cbor) =
+            build_utxo_source_tx(&[(&address_a, input_a_value, None)]);
+        let (input_b_hash, source_b_cbor) =
+            build_utxo_source_tx(&[(&address_b, input_b_value, None)]);
+
+        let tx_cbor = build_test_tx_cbor(
+            &[
+                (&input_a_hash, input_a_index),
+                (&input_b_hash, input_b_index),
+            ],
+            &[
+                (&address_a, output_a_value, None),
+                (&address_c, output_c_value, None),
+            ],
+            |_body| {},
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(
+            &mut server,
+            &[(input_a_hash, source_a_cbor), (input_b_hash, source_b_cbor)],
+        );
+
+        let rpc_url = server.url();
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&rpc_url))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(
+            ctx.effects,
+            vec![
+                TransactionEffect {
+                    address: address_a,
+                    diff: vec![("lovelace".into(), -4_000_000)],
+                },
+                TransactionEffect {
+                    address: address_b,
+                    diff: vec![("lovelace".into(), -7_000_000)],
+                },
+                TransactionEffect {
+                    address: address_c,
+                    diff: vec![("lovelace".into(), 10_000_000)],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn transaction_context_with_withdrawal() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let (_payment_key, stake_key) = CardanoSigner::decode_keys(key.expose()).unwrap();
+        let stake_key = stake_key.unwrap();
+        let payment_address = signer.derive_address(key.expose()).unwrap();
+        let reward_address_bech32 = signer.reward_address_bech32(&stake_key).unwrap();
+        let reward_address = RewardAddress::new(
+            signer.network_id,
+            &Credential::from_keyhash(&stake_key.to_public().to_raw_key().hash()),
+        );
+
+        let input_value = 10_000_000u64;
+        let withdrawal = 5_000_000u64;
+        let output_value = input_value + withdrawal - TX_FEE;
+        let (input_tx_hash, source_cbor) =
+            build_utxo_source_tx(&[(&payment_address, input_value, None)]);
+
+        let tx_cbor = build_test_tx_cbor(
+            &[(&input_tx_hash, 0)],
+            &[(&payment_address, output_value, None)],
+            |body| {
+                let mut withdrawals = Withdrawals::new();
+                withdrawals.insert(&reward_address, &BigNum::from(withdrawal));
+                body.set_withdrawals(&withdrawals);
+            },
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(&mut server, &[(input_tx_hash, source_cbor)]);
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&server.url()))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(
+            ctx.effects,
+            vec![
+                TransactionEffect {
+                    address: payment_address,
+                    diff: vec![("lovelace".into(), (withdrawal - TX_FEE) as i64)],
+                },
+                TransactionEffect {
+                    address: reward_address_bech32,
+                    diff: vec![("lovelace".into(), -(withdrawal as i64))],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn transaction_context_with_stake_registration_deposit() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let (_payment_key, stake_key) = CardanoSigner::decode_keys(key.expose()).unwrap();
+        let stake_key = stake_key.unwrap();
+        let payment_address = signer.derive_address(key.expose()).unwrap();
+        let reward_address_bech32 = signer.reward_address_bech32(&stake_key).unwrap();
+        let stake_cred = Credential::from_keyhash(&stake_key.to_public().to_raw_key().hash());
+
+        let deposit = 2_000_000u64;
+        let input_value = 10_000_000u64;
+        let output_value = input_value - deposit - TX_FEE;
+        let (input_tx_hash, source_cbor) =
+            build_utxo_source_tx(&[(&payment_address, input_value, None)]);
+
+        let tx_cbor = build_test_tx_cbor(
+            &[(&input_tx_hash, 0)],
+            &[(&payment_address, output_value, None)],
+            |body| {
+                let mut certs = Certificates::new();
+                let reg = StakeRegistration::new_with_explicit_deposit(
+                    &stake_cred,
+                    &BigNum::from(deposit),
+                );
+                certs.add(&Certificate::new_reg_cert(&reg).unwrap());
+                body.set_certs(&certs);
+            },
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(&mut server, &[(input_tx_hash, source_cbor)]);
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&server.url()))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(
+            ctx.effects,
+            vec![
+                TransactionEffect {
+                    address: payment_address,
+                    diff: vec![("lovelace".into(), -((deposit + TX_FEE) as i64))],
+                },
+                TransactionEffect {
+                    // Deposit is locked under the stake credential.
+                    address: reward_address_bech32,
+                    diff: vec![("lovelace".into(), deposit as i64)],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn transaction_context_with_stake_deregistration_refund() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let (_payment_key, stake_key) = CardanoSigner::decode_keys(key.expose()).unwrap();
+        let stake_key = stake_key.unwrap();
+        let payment_address = signer.derive_address(key.expose()).unwrap();
+        let reward_address_bech32 = signer.reward_address_bech32(&stake_key).unwrap();
+        let stake_cred = Credential::from_keyhash(&stake_key.to_public().to_raw_key().hash());
+
+        let refund = 2_000_000u64;
+        let input_value = 10_000_000u64;
+        let output_value = input_value + refund - TX_FEE;
+        let (input_tx_hash, source_cbor) =
+            build_utxo_source_tx(&[(&payment_address, input_value, None)]);
+
+        let tx_cbor = build_test_tx_cbor(
+            &[(&input_tx_hash, 0)],
+            &[(&payment_address, output_value, None)],
+            |body| {
+                let mut certs = Certificates::new();
+                let unreg = StakeDeregistration::new_with_explicit_refund(
+                    &stake_cred,
+                    &BigNum::from(refund),
+                );
+                certs.add(&Certificate::new_unreg_cert(&unreg).unwrap());
+                body.set_certs(&certs);
+            },
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(&mut server, &[(input_tx_hash, source_cbor)]);
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&server.url()))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(
+            ctx.effects,
+            vec![
+                TransactionEffect {
+                    address: payment_address,
+                    diff: vec![("lovelace".into(), (refund - TX_FEE) as i64)],
+                },
+                TransactionEffect {
+                    // Locked deposit is released from the stake credential.
+                    address: reward_address_bech32,
+                    diff: vec![("lovelace".into(), -(refund as i64))],
+                },
             ]
         );
     }

--- a/ows/crates/ows-signer/src/chains/cardano.rs
+++ b/ows/crates/ows-signer/src/chains/cardano.rs
@@ -70,11 +70,19 @@ impl CardanoSigner {
         }
     }
 
-    pub fn from_chain_id(chain_id: &str) -> Self {
+    /// The network lives in the address header byte and is chosen here, not signed
+    /// into the transaction as on EVM, so an unrecognised reference must not fall
+    /// back to a network: assuming mainnet would derive mainnet addresses and produce
+    /// real mainnet signatures for someone who asked for something else.
+    pub fn from_chain_id(chain_id: &str) -> Result<Self, SignerError> {
         match chain_id {
-            "cip34:0-1" => Self::preprod(),
-            "cip34:0-2" => Self::preview(),
-            _ => Self::mainnet(),
+            "cip34:1-764824073" => Ok(Self::mainnet()),
+            "cip34:0-1" => Ok(Self::preprod()),
+            "cip34:0-2" => Ok(Self::preview()),
+            _ => Err(SignerError::UnsupportedChain(format!(
+                "unknown Cardano network '{chain_id}'; expected one of \
+                 cip34:1-764824073 (mainnet), cip34:0-1 (preprod), cip34:0-2 (preview)"
+            ))),
         }
     }
 
@@ -1006,6 +1014,40 @@ mod tests {
         assert_eq!(s.chain_type(), ChainType::Cardano);
         assert_eq!(s.curve(), Curve::Ed25519Bip32);
         assert_eq!(s.coin_type(), 1815);
+    }
+
+    #[test]
+    fn from_chain_id_maps_known_networks_and_rejects_the_rest() {
+        assert_eq!(
+            CardanoSigner::from_chain_id("cip34:1-764824073")
+                .unwrap()
+                .network_id,
+            NetworkInfo::mainnet().network_id()
+        );
+        assert_eq!(
+            CardanoSigner::from_chain_id("cip34:0-1")
+                .unwrap()
+                .network_id,
+            NetworkInfo::testnet_preprod().network_id()
+        );
+        assert_eq!(
+            CardanoSigner::from_chain_id("cip34:0-2")
+                .unwrap()
+                .network_id,
+            NetworkInfo::testnet_preview().network_id()
+        );
+
+        // `parse_chain` accepts any reference under the `cip34` namespace, so these
+        // reach the constructor; none of them may resolve to a network.
+        for chain_id in ["cip34:0-999", "cip34:1-1", "cip34:mainnet", "cip34:", ""] {
+            assert!(
+                matches!(
+                    CardanoSigner::from_chain_id(chain_id),
+                    Err(SignerError::UnsupportedChain(_))
+                ),
+                "{chain_id} was accepted"
+            );
+        }
     }
 
     #[test]

--- a/ows/crates/ows-signer/src/chains/cardano.rs
+++ b/ows/crates/ows-signer/src/chains/cardano.rs
@@ -4,7 +4,7 @@ use crate::{DerivedKey, SecretBytes};
 use cardano_serialization_lib::{
     make_vkey_witness, Address, AddressKind, BaseAddress, Bip32PrivateKey, Certificate,
     CertificateKind, Credential, Ed25519KeyHashes, EnterpriseAddress, FixedTransaction,
-    NetworkInfo, RewardAddress, TransactionBody, Vkeywitnesses,
+    NetworkInfo, RewardAddress, TransactionBody, TransactionOutput, Vkeywitnesses,
 };
 use emurgo_cardano_message_signing::builders::{AlgorithmId, COSESign1Builder, EdDSA25519Key};
 use emurgo_cardano_message_signing::cbor::CBORValue;
@@ -273,6 +273,136 @@ impl CardanoSigner {
             .or_default()
             .entry(LOVELACE_ASSET_ID.to_string())
             .or_insert(0) += amount;
+    }
+
+    /// Fold a resolved UTxO's lovelace and native-asset amounts into `balances`, under its address.
+    fn add_utxo_balance(
+        balances: &mut BTreeMap<String, AssetBalanceMap>,
+        utxo: &KoiosUtxoInfoRow,
+    ) -> Result<(), SignerError> {
+        let for_address = balances.entry(utxo.address.clone()).or_default();
+
+        *for_address
+            .entry(LOVELACE_ASSET_ID.to_string())
+            .or_insert(0) += utxo.value.parse::<u64>().map_err(|e| {
+            SignerError::InvalidTransaction(format!(
+                "invalid lovelace value for utxo {}#{}: {e}",
+                utxo.tx_hash, utxo.tx_index
+            ))
+        })?;
+
+        for asset in utxo.asset_list.iter().flatten() {
+            *for_address
+                .entry(format!("{}{}", asset.policy_id, asset.asset_name))
+                .or_insert(0) += asset.quantity.parse::<u64>().map_err(|e| {
+                SignerError::InvalidTransaction(format!(
+                    "invalid asset quantity for utxo {}#{} and asset {}.{}: {e}",
+                    utxo.tx_hash, utxo.tx_index, asset.policy_id, asset.asset_name
+                ))
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// Fold a transaction output's lovelace and native-asset amounts into `balances`, under its address.
+    fn add_output_balance(
+        balances: &mut BTreeMap<String, AssetBalanceMap>,
+        output: &TransactionOutput,
+    ) -> Result<(), SignerError> {
+        let dest_address = output
+            .address()
+            .to_bech32(None)
+            .map_err(|e| SignerError::InvalidTransaction(format!("invalid output address: {e}")))?;
+
+        let for_address = balances.entry(dest_address).or_default();
+
+        let lovelace: u64 = output.amount().coin().into();
+        *for_address
+            .entry(LOVELACE_ASSET_ID.to_string())
+            .or_insert(0) += lovelace;
+
+        let Some(ma) = output.amount().multiasset() else {
+            return Ok(());
+        };
+
+        for policy_id_index in 0..ma.keys().len() {
+            let policy_id = ma.keys().get(policy_id_index);
+            let assets = ma.get(&policy_id).unwrap();
+
+            for asset_index in 0..assets.len() {
+                let asset_name = assets.keys().get(asset_index);
+                let asset_quantity: u64 = assets.get(&asset_name).unwrap().into();
+
+                *for_address
+                    .entry(format!(
+                        "{}{}",
+                        policy_id.to_hex(),
+                        hex::encode(asset_name.name())
+                    ))
+                    .or_insert(0) += asset_quantity;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Net `outputs` against `inputs` per address and asset id, dropping zero changes.
+    /// Sorted by address and, within an address, by asset id, so the policy context is
+    /// stable across runs and policy decisions are reproducible.
+    fn effects_from_balances(
+        inputs: &BTreeMap<String, AssetBalanceMap>,
+        outputs: &BTreeMap<String, AssetBalanceMap>,
+    ) -> Vec<TransactionEffect> {
+        let mut all_addresses: BTreeSet<&String> = BTreeSet::new();
+        for c in inputs.keys() {
+            all_addresses.insert(c);
+        }
+        for c in outputs.keys() {
+            all_addresses.insert(c);
+        }
+
+        let empty_balances = AssetBalanceMap::new();
+        let mut effects: Vec<TransactionEffect> = Vec::new();
+        for effect_address in all_addresses {
+            let input_balances = inputs.get(effect_address).unwrap_or(&empty_balances);
+            let output_balances = outputs.get(effect_address).unwrap_or(&empty_balances);
+
+            let mut asset_ids: BTreeSet<&String> = BTreeSet::new();
+            for k in input_balances.keys() {
+                asset_ids.insert(k);
+            }
+            for k in output_balances.keys() {
+                asset_ids.insert(k);
+            }
+
+            let mut diff: Vec<(String, String)> = Vec::new();
+            for asset_id in asset_ids {
+                let input_balance = *input_balances.get(asset_id).unwrap_or(&0);
+                let output_balance = *output_balances.get(asset_id).unwrap_or(&0);
+
+                // i128 keeps the subtraction exact: a native-asset quantity can reach u64::MAX
+                let asset_diff = i128::from(output_balance) - i128::from(input_balance);
+                if asset_diff == 0 {
+                    continue;
+                }
+
+                diff.push((asset_id.clone(), asset_diff.to_string()));
+            }
+
+            if diff.is_empty() {
+                continue;
+            }
+
+            diff.sort_by(|a, b| a.0.cmp(&b.0));
+            effects.push(TransactionEffect {
+                address: effect_address.clone(),
+                diff,
+            });
+        }
+
+        effects.sort_by(|a, b| a.address.cmp(&b.address));
+        effects
     }
 
     fn fetch_txs_cbor(
@@ -656,81 +786,45 @@ impl ChainSigner for CardanoSigner {
             .map(|input| (input.transaction_id().to_hex(), input.index()))
             .collect();
 
+        let collateral_refs: Vec<(String, u32)> = tx
+            .body()
+            .collateral()
+            .map(|collateral| {
+                collateral
+                    .into_iter()
+                    .map(|input| (input.transaction_id().to_hex(), input.index()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let mut inputs_balances_by_address: BTreeMap<String, AssetBalanceMap> = BTreeMap::new();
-        if !tx_input_refs.is_empty() {
+        let mut collateral_balances_by_address: BTreeMap<String, AssetBalanceMap> = BTreeMap::new();
+        if !tx_input_refs.is_empty() || !collateral_refs.is_empty() {
             let koios_base_url = rpc_url.ok_or_else(|| {
                 SignerError::InvalidMessage(
                     "Koios RPC URL is required to fetch Cardano transaction inputs".into(),
                 )
             })?;
-            let utxos = Self::fetch_utxos(koios_base_url, &tx_input_refs)?;
 
-            for utxo in utxos {
-                let inputs_balances_for_address =
-                    inputs_balances_by_address.entry(utxo.address).or_default();
+            // Both sets resolve the same way, so they share one round trip. `fetch_utxos`
+            // yields exactly one row per requested ref, in order, so the inputs occupy the
+            // first `tx_input_refs.len()` rows and the collateral the rest.
+            let mut all_refs = tx_input_refs.clone();
+            all_refs.extend(collateral_refs.iter().cloned());
+            let utxos = Self::fetch_utxos(koios_base_url, &all_refs)?;
+            let (input_utxos, collateral_utxos) = utxos.split_at(tx_input_refs.len());
 
-                *inputs_balances_for_address
-                    .entry(LOVELACE_ASSET_ID.to_string())
-                    .or_insert(0) += utxo.value.parse::<u64>().map_err(|e| {
-                    SignerError::InvalidTransaction(format!(
-                        "invalid lovelace value for utxo {}#{}: {e}",
-                        utxo.tx_hash, utxo.tx_index
-                    ))
-                })?;
-
-                for asset in utxo.asset_list.unwrap_or_default() {
-                    *inputs_balances_for_address
-                        .entry(format!("{}{}", asset.policy_id, asset.asset_name))
-                        .or_insert(0) += asset.quantity.parse::<u64>().map_err(|e| {
-                        SignerError::InvalidTransaction(format!(
-                            "invalid asset quantity for utxo {}#{} and asset {}.{}: {e}",
-                            utxo.tx_hash, utxo.tx_index, asset.policy_id, asset.asset_name
-                        ))
-                    })?;
-                }
+            for utxo in input_utxos {
+                Self::add_utxo_balance(&mut inputs_balances_by_address, utxo)?;
+            }
+            for utxo in collateral_utxos {
+                Self::add_utxo_balance(&mut collateral_balances_by_address, utxo)?;
             }
         }
 
         let mut outputs_balances_by_address: BTreeMap<String, AssetBalanceMap> = BTreeMap::new();
         for output in tx.body().outputs().into_iter() {
-            let dest_address = output.address().to_bech32(None).map_err(|e| {
-                SignerError::InvalidTransaction(format!("invalid output address: {e}"))
-            })?;
-
-            let output_balances_for_address =
-                outputs_balances_by_address.entry(dest_address).or_default();
-
-            let lovelace: u64 = output.amount().coin().into();
-
-            *output_balances_for_address
-                .entry(LOVELACE_ASSET_ID.to_string())
-                .or_insert(0) += lovelace;
-
-            let ma = output.amount().multiasset();
-            if ma.is_none() {
-                continue;
-            }
-
-            let ma = ma.unwrap();
-
-            for policy_id_index in 0..ma.keys().len() {
-                let policy_id = ma.keys().get(policy_id_index);
-                let assets = ma.get(&policy_id).unwrap();
-
-                for asset_index in 0..assets.len() {
-                    let asset_name = assets.keys().get(asset_index);
-                    let asset_quantity = assets.get(&asset_name).unwrap();
-                    let asset_quantity: u64 = asset_quantity.into();
-
-                    *output_balances_for_address
-                        .entry(format!(
-                            "{}{}",
-                            policy_id.to_hex(),
-                            hex::encode(asset_name.name())
-                        ))
-                        .or_insert(0) += asset_quantity;
-                }
-            }
+            Self::add_output_balance(&mut outputs_balances_by_address, output)?;
         }
 
         // Withdrawals leave the reward account and enter the transaction, so
@@ -779,63 +873,29 @@ impl ChainSigner for CardanoSigner {
             }
         }
 
-        let mut all_addresses: BTreeSet<&String> = BTreeSet::new();
-        for c in inputs_balances_by_address.keys() {
-            all_addresses.insert(c);
+        let effects =
+            Self::effects_from_balances(&inputs_balances_by_address, &outputs_balances_by_address);
+
+        // Collateral is consumed only when phase-2 (script) validation fails, so it is not part
+        // of `effects`, which describes what the transaction does when it succeeds. Netting the
+        // collateral inputs against `collateral_return` gives the worst-case loss, which a policy
+        // capping outflow has to add to `effects` itself — collateral does not reduce the change
+        // output, so it is invisible there.
+        let mut collateral_return_by_address: BTreeMap<String, AssetBalanceMap> = BTreeMap::new();
+        if let Some(collateral_return) = tx.body().collateral_return() {
+            Self::add_output_balance(&mut collateral_return_by_address, &collateral_return)?;
         }
-        for c in outputs_balances_by_address.keys() {
-            all_addresses.insert(c);
-        }
-
-        let empty_balances = AssetBalanceMap::new();
-        let mut effects: Vec<TransactionEffect> = Vec::new();
-        for effect_address in all_addresses {
-            let input_balances = inputs_balances_by_address
-                .get(effect_address)
-                .unwrap_or(&empty_balances);
-            let output_balances = outputs_balances_by_address
-                .get(effect_address)
-                .unwrap_or(&empty_balances);
-
-            let mut asset_ids: BTreeSet<&String> = BTreeSet::new();
-            for k in input_balances.keys() {
-                asset_ids.insert(k);
-            }
-            for k in output_balances.keys() {
-                asset_ids.insert(k);
-            }
-
-            let mut diff: Vec<(String, String)> = Vec::new();
-            for asset_id in asset_ids {
-                let input_balance = *input_balances.get(asset_id).unwrap_or(&0);
-                let output_balance = *output_balances.get(asset_id).unwrap_or(&0);
-
-                // i128 keeps the subtraction exact: a native-asset quantity can reach u64::MAX
-                let asset_diff = i128::from(output_balance) - i128::from(input_balance);
-                if asset_diff == 0 {
-                    continue;
-                }
-
-                diff.push((asset_id.clone(), asset_diff.to_string()));
-            }
-
-            if diff.is_empty() {
-                continue;
-            }
-
-            diff.sort_by(|a, b| a.0.cmp(&b.0));
-            effects.push(TransactionEffect {
-                address: effect_address.clone(),
-                diff,
-            });
-        }
-
-        effects.sort_by(|a, b| a.address.cmp(&b.address));
+        let collateral_effects = Self::effects_from_balances(
+            &collateral_balances_by_address,
+            &collateral_return_by_address,
+        );
 
         Ok(TransactionContext {
             effects,
             raw_hex: tx_hex,
             data: None,
+            chain_extra: (!collateral_effects.is_empty())
+                .then(|| serde_json::json!({ "collateral_effects": collateral_effects })),
         })
     }
 
@@ -1777,5 +1837,149 @@ mod tests {
                 },
             ]
         );
+    }
+
+    /// Collateral without a `collateral_return`: the whole collateral input is at risk, and
+    /// none of it shows up in `effects` — the change output is unaffected by it.
+    #[test]
+    fn transaction_context_collateral_without_return() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let my_address = signer.derive_address(&key.expose()).unwrap();
+
+        let input_value = 10_000_000u64;
+        let collateral_value = 5_000_000u64;
+        let (source_tx_hash, source_cbor) = build_utxo_source_tx(&[
+            (&my_address, input_value, None),
+            (&my_address, collateral_value, None),
+        ]);
+
+        let tx_cbor = build_test_tx_cbor(
+            &[(&source_tx_hash, 0)],
+            &[(&my_address, input_value - TX_FEE, None)],
+            |body| {
+                let mut collateral = TransactionInputs::new();
+                collateral.add(&TransactionInput::new(
+                    &TransactionHash::from_hex(&source_tx_hash).unwrap(),
+                    1,
+                ));
+                body.set_collateral(&collateral);
+                body.set_total_collateral(&BigNum::from(collateral_value));
+            },
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(&mut server, &[(source_tx_hash, source_cbor)]);
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&server.url()))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(
+            ctx.effects,
+            vec![TransactionEffect {
+                address: my_address.clone(),
+                diff: vec![("lovelace".into(), format!("-{TX_FEE}"))],
+            }]
+        );
+        assert_eq!(
+            ctx.chain_extra,
+            Some(serde_json::json!({
+                "collateral_effects": [{
+                    "address": my_address,
+                    "diff": [["lovelace", format!("-{collateral_value}")]],
+                }],
+            }))
+        );
+    }
+
+    /// With a `collateral_return`, only the unreturned remainder is at risk.
+    #[test]
+    fn transaction_context_collateral_with_partial_return() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let my_address = signer.derive_address(&key.expose()).unwrap();
+
+        let input_value = 10_000_000u64;
+        let collateral_value = 5_000_000u64;
+        let collateral_returned = 3_000_000u64;
+        let (source_tx_hash, source_cbor) = build_utxo_source_tx(&[
+            (&my_address, input_value, None),
+            (&my_address, collateral_value, None),
+        ]);
+
+        let tx_cbor = build_test_tx_cbor(
+            &[(&source_tx_hash, 0)],
+            &[(&my_address, input_value - TX_FEE, None)],
+            |body| {
+                let mut collateral = TransactionInputs::new();
+                collateral.add(&TransactionInput::new(
+                    &TransactionHash::from_hex(&source_tx_hash).unwrap(),
+                    1,
+                ));
+                body.set_collateral(&collateral);
+                body.set_collateral_return(&TransactionOutput::new(
+                    &Address::from_bech32(&my_address).unwrap(),
+                    &Value::new(&BigNum::from(collateral_returned)),
+                ));
+                body.set_total_collateral(&BigNum::from(collateral_value - collateral_returned));
+            },
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(&mut server, &[(source_tx_hash, source_cbor)]);
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&server.url()))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(
+            ctx.chain_extra,
+            Some(serde_json::json!({
+                "collateral_effects": [{
+                    "address": my_address,
+                    "diff": [[
+                        "lovelace",
+                        format!("-{}", collateral_value - collateral_returned),
+                    ]],
+                }],
+            }))
+        );
+    }
+
+    #[test]
+    fn transaction_context_without_collateral_has_no_chain_extra() {
+        let signer = CardanoSigner::mainnet();
+        let mnemonic = Mnemonic::from_phrase(
+            "author cart lend blossom pistol rocket film just distance valid room lock",
+        )
+        .unwrap();
+        let key = derive_key_material(&signer, &mnemonic, 0);
+        let address = signer.derive_address(&key.expose()).unwrap();
+
+        let input_value = 10_000_000u64;
+        let (source_tx_hash, source_cbor) = build_utxo_source_tx(&[(&address, input_value, None)]);
+        let tx_cbor = build_test_tx_cbor(
+            &[(&source_tx_hash, 0)],
+            &[(&address, input_value - TX_FEE, None)],
+            |_body| {},
+        );
+
+        let mut server = Server::new();
+        let mock = mock_tx_cbor_response(&mut server, &[(source_tx_hash, source_cbor)]);
+        let ctx = signer
+            .make_transaction_context(&tx_cbor, Some(&server.url()))
+            .unwrap();
+        mock.assert();
+
+        assert_eq!(ctx.chain_extra, None);
     }
 }

--- a/ows/crates/ows-signer/src/chains/cardano.rs
+++ b/ows/crates/ows-signer/src/chains/cardano.rs
@@ -805,17 +805,18 @@ impl ChainSigner for CardanoSigner {
                 asset_ids.insert(k);
             }
 
-            let mut diff: Vec<(String, i64)> = Vec::new();
+            let mut diff: Vec<(String, String)> = Vec::new();
             for asset_id in asset_ids {
                 let input_balance = *input_balances.get(asset_id).unwrap_or(&0);
                 let output_balance = *output_balances.get(asset_id).unwrap_or(&0);
 
-                let asset_diff = (output_balance as i64) - (input_balance as i64);
+                // i128 keeps the subtraction exact: a native-asset quantity can reach u64::MAX
+                let asset_diff = i128::from(output_balance) - i128::from(input_balance);
                 if asset_diff == 0 {
                     continue;
                 }
 
-                diff.push((asset_id.clone(), asset_diff));
+                diff.push((asset_id.clone(), asset_diff.to_string()));
             }
 
             if diff.is_empty() {
@@ -1350,7 +1351,7 @@ mod tests {
             ctx.effects,
             vec![TransactionEffect {
                 address,
-                diff: vec![("lovelace".into(), -(TX_FEE as i64))],
+                diff: vec![("lovelace".into(), format!("-{TX_FEE}"))],
             }]
         );
     }
@@ -1397,11 +1398,11 @@ mod tests {
             vec![
                 TransactionEffect {
                     address: my_address,
-                    diff: vec![("lovelace".into(), -4_000_000)],
+                    diff: vec![("lovelace".into(), "-4000000".into())],
                 },
                 TransactionEffect {
                     address: external_address,
-                    diff: vec![("lovelace".into(), 3_000_000)],
+                    diff: vec![("lovelace".into(), "3000000".into())],
                 },
             ]
         );
@@ -1461,11 +1462,17 @@ mod tests {
             vec![
                 TransactionEffect {
                     address: my_address,
-                    diff: vec![(asset_id.clone(), -30), ("lovelace".into(), -4_000_000)],
+                    diff: vec![
+                        (asset_id.clone(), "-30".into()),
+                        ("lovelace".into(), "-4000000".into())
+                    ],
                 },
                 TransactionEffect {
                     address: external_address,
-                    diff: vec![(asset_id, 30), ("lovelace".into(), 3_000_000)],
+                    diff: vec![
+                        (asset_id, "30".into()),
+                        ("lovelace".into(), "3000000".into())
+                    ],
                 },
             ]
         );
@@ -1524,11 +1531,11 @@ mod tests {
             vec![
                 TransactionEffect {
                     address: address_a,
-                    diff: vec![("lovelace".into(), -3_000_000)],
+                    diff: vec![("lovelace".into(), "-3000000".into())],
                 },
                 TransactionEffect {
                     address: address_b,
-                    diff: vec![("lovelace".into(), 2_000_000)],
+                    diff: vec![("lovelace".into(), "2000000".into())],
                 },
             ]
         );
@@ -1589,15 +1596,15 @@ mod tests {
             vec![
                 TransactionEffect {
                     address: address_a,
-                    diff: vec![("lovelace".into(), -4_000_000)],
+                    diff: vec![("lovelace".into(), "-4000000".into())],
                 },
                 TransactionEffect {
                     address: address_b,
-                    diff: vec![("lovelace".into(), -7_000_000)],
+                    diff: vec![("lovelace".into(), "-7000000".into())],
                 },
                 TransactionEffect {
                     address: address_c,
-                    diff: vec![("lovelace".into(), 10_000_000)],
+                    diff: vec![("lovelace".into(), "10000000".into())],
                 },
             ]
         );
@@ -1648,11 +1655,11 @@ mod tests {
             vec![
                 TransactionEffect {
                     address: payment_address,
-                    diff: vec![("lovelace".into(), (withdrawal - TX_FEE) as i64)],
+                    diff: vec![("lovelace".into(), (withdrawal - TX_FEE).to_string())],
                 },
                 TransactionEffect {
                     address: reward_address_bech32,
-                    diff: vec![("lovelace".into(), -(withdrawal as i64))],
+                    diff: vec![("lovelace".into(), format!("-{withdrawal}"))],
                 },
             ]
         );
@@ -1704,12 +1711,12 @@ mod tests {
             vec![
                 TransactionEffect {
                     address: payment_address,
-                    diff: vec![("lovelace".into(), -((deposit + TX_FEE) as i64))],
+                    diff: vec![("lovelace".into(), format!("-{}", deposit + TX_FEE))],
                 },
                 TransactionEffect {
                     // Deposit is locked under the stake credential.
                     address: reward_address_bech32,
-                    diff: vec![("lovelace".into(), deposit as i64)],
+                    diff: vec![("lovelace".into(), deposit.to_string())],
                 },
             ]
         );
@@ -1761,12 +1768,12 @@ mod tests {
             vec![
                 TransactionEffect {
                     address: payment_address,
-                    diff: vec![("lovelace".into(), (refund - TX_FEE) as i64)],
+                    diff: vec![("lovelace".into(), (refund - TX_FEE).to_string())],
                 },
                 TransactionEffect {
                     // Locked deposit is released from the stake credential.
                     address: reward_address_bech32,
-                    diff: vec![("lovelace".into(), -(refund as i64))],
+                    diff: vec![("lovelace".into(), format!("-{refund}"))],
                 },
             ]
         );

--- a/ows/crates/ows-signer/src/chains/cardano.rs
+++ b/ows/crates/ows-signer/src/chains/cardano.rs
@@ -2,10 +2,11 @@ use crate::curve::Curve;
 use crate::traits::{ChainSigner, SignOutput, SignerError};
 use crate::{DerivedKey, SecretBytes};
 use cardano_serialization_lib::{
-    make_vkey_witness, Address, AddressKind, BaseAddress, Bip32PrivateKey, Certificate,
-    CertificateKind, Credential, Ed25519KeyHashes, EnterpriseAddress, FixedTransaction,
-    NetworkInfo, RewardAddress, TransactionBody, TransactionOutput, Vkeywitnesses,
+    Address, AddressKind, BaseAddress, Certificate, CertificateKind, Credential, Ed25519KeyHashes,
+    Ed25519Signature, EnterpriseAddress, FixedTransaction, NetworkInfo, PublicKey, RewardAddress,
+    TransactionBody, TransactionHash, TransactionOutput, Vkey, Vkeywitness, Vkeywitnesses,
 };
+use ed25519_bip32::XPrv;
 use emurgo_cardano_message_signing::builders::{AlgorithmId, COSESign1Builder, EdDSA25519Key};
 use emurgo_cardano_message_signing::cbor::CBORValue;
 use emurgo_cardano_message_signing::utils::ToBytes as EmurgoToBytes;
@@ -87,19 +88,23 @@ impl CardanoSigner {
         format!("m/1852'/1815'/{index}'/2/0")
     }
 
-    fn decode_keys(
-        key_material: &[u8],
-    ) -> Result<(Bip32PrivateKey, Option<Bip32PrivateKey>), SignerError> {
+    /// Holds the secret in `ed25519_bip32::XPrv`, not CSL's `Bip32PrivateKey`. CSL
+    /// signs through `Bip32PrivateKey::to_raw_key`, which copies the 64-byte extended
+    /// secret into an `ExtendedPriv` that has no `Drop`, so each call leaves an
+    /// unwiped copy behind. `XPrv` zeroizes on drop and signs out of its own buffer,
+    /// so no heap allocation OWS cannot wipe ever holds the secret. Never `{:?}` or
+    /// `{}` an `XPrv`: both impls hex-encode all 96 bytes into a `String`.
+    fn decode_keys(key_material: &[u8]) -> Result<(XPrv, Option<XPrv>), SignerError> {
         match key_material.len() {
             ed25519_bip32::XPRV_SIZE => {
-                let pay = Bip32PrivateKey::from_bytes(key_material)
+                let pay = XPrv::from_slice_verified(key_material)
                     .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
                 Ok((pay, None))
             }
             len if len == ed25519_bip32::XPRV_SIZE * 2 => {
-                let pay = Bip32PrivateKey::from_bytes(&key_material[..ed25519_bip32::XPRV_SIZE])
+                let pay = XPrv::from_slice_verified(&key_material[..ed25519_bip32::XPRV_SIZE])
                     .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
-                let stake = Bip32PrivateKey::from_bytes(&key_material[ed25519_bip32::XPRV_SIZE..])
+                let stake = XPrv::from_slice_verified(&key_material[ed25519_bip32::XPRV_SIZE..])
                     .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))?;
                 Ok((pay, Some(stake)))
             }
@@ -110,23 +115,40 @@ impl CardanoSigner {
         }
     }
 
-    fn base_address_bech32(
-        &self,
-        pay: &Bip32PrivateKey,
-        stake: &Bip32PrivateKey,
-    ) -> Result<String, SignerError> {
+    fn public_key(xprv: &XPrv) -> Result<PublicKey, SignerError> {
+        PublicKey::from_bytes(xprv.public().public_key_slice())
+            .map_err(|e| SignerError::InvalidPrivateKey(e.to_string()))
+    }
+
+    /// Replaces CSL's `make_vkey_witness`, which would need a `PrivateKey` (see
+    /// `decode_keys`); the witness it builds is identical.
+    fn vkey_witness(tx_hash: &TransactionHash, xprv: &XPrv) -> Result<Vkeywitness, SignerError> {
+        let signature = Ed25519Signature::from_bytes(
+            xprv.sign::<Vec<u8>>(&tx_hash.to_bytes())
+                .to_bytes()
+                .to_vec(),
+        )
+        .map_err(|e| SignerError::SigningFailed(e.to_string()))?;
+
+        Ok(Vkeywitness::new(
+            &Vkey::new(&Self::public_key(xprv)?),
+            &signature,
+        ))
+    }
+
+    fn base_address_bech32(&self, pay: &XPrv, stake: &XPrv) -> Result<String, SignerError> {
         let network_id = self.network_id;
-        let pay_cred = Credential::from_keyhash(&pay.to_public().to_raw_key().hash());
-        let stake_cred = Credential::from_keyhash(&stake.to_public().to_raw_key().hash());
+        let pay_cred = Credential::from_keyhash(&Self::public_key(pay)?.hash());
+        let stake_cred = Credential::from_keyhash(&Self::public_key(stake)?.hash());
         let base = BaseAddress::new(network_id, &pay_cred, &stake_cred);
         base.to_address()
             .to_bech32(None)
             .map_err(|e| SignerError::AddressDerivationFailed(e.to_string()))
     }
 
-    fn enterprise_address_bech32(&self, pay: &Bip32PrivateKey) -> Result<String, SignerError> {
+    fn enterprise_address_bech32(&self, pay: &XPrv) -> Result<String, SignerError> {
         let network_id = self.network_id;
-        let pay_cred = Credential::from_keyhash(&pay.to_public().to_raw_key().hash());
+        let pay_cred = Credential::from_keyhash(&Self::public_key(pay)?.hash());
         let ent = EnterpriseAddress::new(network_id, &pay_cred);
         ent.to_address()
             .to_bech32(None)
@@ -220,9 +242,9 @@ impl CardanoSigner {
         hashes
     }
 
-    fn reward_address_bech32(&self, stake: &Bip32PrivateKey) -> Result<String, SignerError> {
+    fn reward_address_bech32(&self, stake: &XPrv) -> Result<String, SignerError> {
         let network_id = self.network_id;
-        let stake_cred = Credential::from_keyhash(&stake.to_public().to_raw_key().hash());
+        let stake_cred = Credential::from_keyhash(&Self::public_key(stake)?.hash());
         let rew = RewardAddress::new(network_id, &stake_cred);
         rew.to_address()
             .to_bech32(None)
@@ -577,9 +599,9 @@ impl ChainSigner for CardanoSigner {
 
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
         let (pay, _) = Self::decode_keys(private_key)?;
-        let public_key = pay.to_public().to_raw_key().as_bytes();
+        let public_key = pay.public().public_key_slice().to_vec();
 
-        let signature = pay.to_raw_key().sign(message).to_bytes();
+        let signature = pay.sign::<Vec<u8>>(message).to_bytes().to_vec();
 
         Ok(SignOutput {
             signature,
@@ -676,12 +698,12 @@ impl ChainSigner for CardanoSigner {
         let sig_structure = builder.make_data_to_sign();
         let sig_bytes = EmurgoToBytes::to_bytes(&sig_structure);
 
-        let sig = sk.to_raw_key().sign(&sig_bytes);
+        let sig = sk.sign::<Vec<u8>>(&sig_bytes);
 
-        let cose = builder.build(sig.to_bytes());
+        let cose = builder.build(sig.to_bytes().to_vec());
         let signed = SignedMessage::new_cose_sign1(&cose);
         let signature = EmurgoToBytes::to_bytes(&signed);
-        let cose_key = EdDSA25519Key::new(sk.to_public().to_raw_key().as_bytes()).build();
+        let cose_key = EdDSA25519Key::new(sk.public().public_key_slice().to_vec()).build();
 
         Ok(SignOutput {
             signature,
@@ -704,14 +726,14 @@ impl ChainSigner for CardanoSigner {
         let body = tx.body();
         let stake_hashes = Self::stake_key_hashes_required_by_body(&body);
 
-        let pay_witness = make_vkey_witness(&tx_hash, &pay.to_raw_key());
+        let pay_witness = Self::vkey_witness(&tx_hash, &pay)?;
 
         let mut witnesses = Vkeywitnesses::new();
         witnesses.add(&pay_witness);
 
         match stake {
             Some(stake) => {
-                let stake_hash = stake.to_public().to_raw_key().hash();
+                let stake_hash = Self::public_key(&stake)?.hash();
                 let needs_stake_signature = stake_hashes.contains(&stake_hash)
                     || body
                         .required_signers()
@@ -719,14 +741,14 @@ impl ChainSigner for CardanoSigner {
                         .unwrap_or(false);
 
                 if needs_stake_signature {
-                    witnesses.add(&make_vkey_witness(&tx_hash, &stake.to_raw_key()));
+                    witnesses.add(&Self::vkey_witness(&tx_hash, &stake)?);
                 }
             }
             None => {
                 // No stake key to offer. If the body needs one for anything other than
                 // the payment credential, refuse rather than hand back a transaction
                 // that fails phase-1 validation.
-                let pay_hash = pay.to_public().to_raw_key().hash();
+                let pay_hash = Self::public_key(&pay)?.hash();
                 let unsatisfied = (0..stake_hashes.len())
                     .map(|i| stake_hashes.get(i))
                     .any(|hash| hash != pay_hash);
@@ -1241,7 +1263,7 @@ mod tests {
             &[(&output_address, 3_000_000, None)],
             |body| {
                 let mut signers = Ed25519KeyHashes::new();
-                signers.add(&stake_key.to_public().to_raw_key().hash());
+                signers.add(&CardanoSigner::public_key(&stake_key).unwrap().hash());
                 body.set_required_signers(&signers);
             },
         );
@@ -1268,6 +1290,7 @@ mod tests {
         .unwrap();
         let key = derive_key_material(&signer, &m, 0);
         let (_payment_key, stake_key) = CardanoSigner::decode_keys(key.expose()).unwrap();
+        let stake_key = stake_key.unwrap();
 
         let address = signer.derive_address(key.expose()).unwrap();
 
@@ -1280,7 +1303,9 @@ mod tests {
             |body| {
                 let mut certs = Certificates::new();
                 let cert = Certificate::new_stake_delegation(&StakeDelegation::new(
-                    &Credential::from_keyhash(&stake_key.unwrap().to_public().to_raw_key().hash()),
+                    &Credential::from_keyhash(
+                        &CardanoSigner::public_key(&stake_key).unwrap().hash(),
+                    ),
                     &Ed25519KeyHash::from_bytes(vec![0xcd; 28]).unwrap(), // dummy pool keyhash
                 ));
                 certs.add(&cert);
@@ -1317,7 +1342,7 @@ mod tests {
         let address = signer.derive_address(key.expose()).unwrap();
         let reward_address = RewardAddress::new(
             signer.network_id,
-            &Credential::from_keyhash(&stake_key.to_public().to_raw_key().hash()),
+            &Credential::from_keyhash(&CardanoSigner::public_key(&stake_key).unwrap().hash()),
         );
 
         let tx_cbor = build_test_tx_cbor(
@@ -1688,7 +1713,7 @@ mod tests {
         let reward_address_bech32 = signer.reward_address_bech32(&stake_key).unwrap();
         let reward_address = RewardAddress::new(
             signer.network_id,
-            &Credential::from_keyhash(&stake_key.to_public().to_raw_key().hash()),
+            &Credential::from_keyhash(&CardanoSigner::public_key(&stake_key).unwrap().hash()),
         );
 
         let input_value = 10_000_000u64;
@@ -1741,7 +1766,8 @@ mod tests {
         let stake_key = stake_key.unwrap();
         let payment_address = signer.derive_address(key.expose()).unwrap();
         let reward_address_bech32 = signer.reward_address_bech32(&stake_key).unwrap();
-        let stake_cred = Credential::from_keyhash(&stake_key.to_public().to_raw_key().hash());
+        let stake_cred =
+            Credential::from_keyhash(&CardanoSigner::public_key(&stake_key).unwrap().hash());
 
         let deposit = 2_000_000u64;
         let input_value = 10_000_000u64;
@@ -1798,7 +1824,8 @@ mod tests {
         let stake_key = stake_key.unwrap();
         let payment_address = signer.derive_address(key.expose()).unwrap();
         let reward_address_bech32 = signer.reward_address_bech32(&stake_key).unwrap();
-        let stake_cred = Credential::from_keyhash(&stake_key.to_public().to_raw_key().hash());
+        let stake_cred =
+            Credential::from_keyhash(&CardanoSigner::public_key(&stake_key).unwrap().hash());
 
         let refund = 2_000_000u64;
         let input_value = 10_000_000u64;

--- a/ows/crates/ows-signer/src/chains/cardano.rs
+++ b/ows/crates/ows-signer/src/chains/cardano.rs
@@ -899,6 +899,10 @@ impl ChainSigner for CardanoSigner {
         })
     }
 
+    fn transaction_context_needs_rpc(&self) -> bool {
+        true
+    }
+
     fn default_derivation_path(&self, index: u32) -> String {
         Self::payment_derivation_path(index)
     }

--- a/ows/crates/ows-signer/src/chains/cosmos.rs
+++ b/ows/crates/ows-signer/src/chains/cosmos.rs
@@ -100,7 +100,13 @@ impl ChainSigner for CosmosSigner {
         self.sign(private_key, &hash)
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         // Cosmos typically signs the SHA256 hash of the message
         let hash = Sha256::digest(message);
         self.sign(private_key, &hash)

--- a/ows/crates/ows-signer/src/chains/evm.rs
+++ b/ows/crates/ows-signer/src/chains/evm.rs
@@ -289,7 +289,13 @@ impl ChainSigner for EvmSigner {
             .map_err(|e| SignerError::InvalidTransaction(e.to_string()))
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         // EIP-191 personal sign prefix
         let prefix = format!("\x19Ethereum Signed Message:\n{}", message.len());
         let mut prefixed = Vec::new();
@@ -369,8 +375,29 @@ mod tests {
             hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
                 .unwrap();
         let signer = EvmSigner;
-        let result = signer.sign_message(&privkey, b"Hello World").unwrap();
+        let result = signer.sign_message(&privkey, b"Hello World", None).unwrap();
         assert_eq!(result.signature.len(), 65);
+    }
+
+    #[test]
+    fn test_sign_message_address_mismatch() {
+        use crate::traits::SignerError;
+        let privkey =
+            hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
+                .unwrap();
+        let signer = EvmSigner;
+        let err = signer
+            .sign_message(
+                &privkey,
+                b"Hello World",
+                Some("0x0000000000000000000000000000000000000001"),
+            )
+            .unwrap_err();
+        assert!(matches!(err, SignerError::AddressMismatch));
+        let derived = signer.derive_address(&privkey).unwrap();
+        signer
+            .sign_message(&privkey, b"Hello World", Some(derived.as_str()))
+            .unwrap();
     }
 
     #[test]
@@ -457,7 +484,7 @@ mod tests {
             hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
                 .unwrap();
         let signer = EvmSigner;
-        let result = signer.sign_message(&privkey, b"Hello World").unwrap();
+        let result = signer.sign_message(&privkey, b"Hello World", None).unwrap();
         let v = result.signature[64];
         assert!(
             v == 27 || v == 28,
@@ -471,7 +498,9 @@ mod tests {
             hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
                 .unwrap();
         let signer = EvmSigner;
-        let result = signer.sign_message(&privkey, b"test recovery id").unwrap();
+        let result = signer
+            .sign_message(&privkey, b"test recovery id", None)
+            .unwrap();
         let v = result.signature[64];
         let recovery_id = result.recovery_id.unwrap();
         assert_eq!(
@@ -491,7 +520,7 @@ mod tests {
             hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
                 .unwrap();
         let signer = EvmSigner;
-        let result = signer.sign_message(&privkey, b"verify me").unwrap();
+        let result = signer.sign_message(&privkey, b"verify me", None).unwrap();
 
         // Signature should verify
         let signing_key = SigningKey::from_slice(&privkey).unwrap();

--- a/ows/crates/ows-signer/src/chains/filecoin.rs
+++ b/ows/crates/ows-signer/src/chains/filecoin.rs
@@ -137,7 +137,13 @@ impl ChainSigner for FilecoinSigner {
         self.sign(private_key, &hash)
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         // Hash with Blake2b-256 and sign
         let hash = Self::blake2b(message, 32);
         self.sign(private_key, &hash)
@@ -240,7 +246,9 @@ mod tests {
             hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
                 .unwrap();
         let signer = FilecoinSigner;
-        let result = signer.sign_message(&privkey, b"Hello Filecoin").unwrap();
+        let result = signer
+            .sign_message(&privkey, b"Hello Filecoin", None)
+            .unwrap();
         assert_eq!(result.signature.len(), 65);
     }
 }

--- a/ows/crates/ows-signer/src/chains/mod.rs
+++ b/ows/crates/ows-signer/src/chains/mod.rs
@@ -25,11 +25,12 @@ pub use self::tron::TronSigner;
 pub use self::xrpl::XrplSigner;
 
 use crate::traits::ChainSigner;
-use ows_core::ChainType;
+use ows_core::{default_chain_for_type, Chain, ChainType};
 
-/// Get a default signer for a given chain type.
-pub fn signer_for_chain(chain: ChainType) -> Box<dyn ChainSigner> {
-    match chain {
+/// Resolve a signer from a parsed CAIP-2 chain. Families whose address format
+/// depends on the network read `chain.chain_id` inside their constructor.
+pub fn signer_for_chain(chain: &Chain) -> Box<dyn ChainSigner> {
+    match chain.chain_type {
         ChainType::Evm => Box::new(EvmSigner),
         ChainType::Solana => Box::new(SolanaSigner),
         ChainType::Bitcoin => Box::new(BitcoinSigner::mainnet()),
@@ -43,4 +44,9 @@ pub fn signer_for_chain(chain: ChainType) -> Box<dyn ChainSigner> {
         ChainType::Nano => Box::new(NanoSigner),
         ChainType::Near => Box::new(NearSigner),
     }
+}
+
+/// Get a default signer for a given chain family (first registry entry per family).
+pub fn signer_for_chain_type(chain_type: ChainType) -> Box<dyn ChainSigner> {
+    signer_for_chain(&default_chain_for_type(chain_type))
 }

--- a/ows/crates/ows-signer/src/chains/mod.rs
+++ b/ows/crates/ows-signer/src/chains/mod.rs
@@ -1,4 +1,5 @@
 pub mod bitcoin;
+pub mod cardano;
 pub mod cosmos;
 pub mod evm;
 pub mod filecoin;
@@ -12,6 +13,7 @@ pub mod tron;
 pub mod xrpl;
 
 pub use self::bitcoin::BitcoinSigner;
+pub use self::cardano::CardanoSigner;
 pub use self::cosmos::CosmosSigner;
 pub use self::evm::EvmSigner;
 pub use self::filecoin::FilecoinSigner;
@@ -43,6 +45,7 @@ pub fn signer_for_chain(chain: &Chain) -> Box<dyn ChainSigner> {
         ChainType::Xrpl => Box::new(XrplSigner),
         ChainType::Nano => Box::new(NanoSigner),
         ChainType::Near => Box::new(NearSigner),
+        ChainType::Cardano => Box::new(CardanoSigner::from_chain_id(chain.chain_id)),
     }
 }
 

--- a/ows/crates/ows-signer/src/chains/mod.rs
+++ b/ows/crates/ows-signer/src/chains/mod.rs
@@ -26,13 +26,17 @@ pub use self::ton::TonSigner;
 pub use self::tron::TronSigner;
 pub use self::xrpl::XrplSigner;
 
-use crate::traits::ChainSigner;
+use crate::traits::{ChainSigner, SignerError};
 use ows_core::{default_chain_for_type, Chain, ChainType};
 
-/// Resolve a signer from a parsed CAIP-2 chain. Families whose address format
-/// depends on the network read `chain.chain_id` inside their constructor.
-pub fn signer_for_chain(chain: &Chain) -> Box<dyn ChainSigner> {
-    match chain.chain_type {
+/// Resolve a signer from a parsed CAIP-2 chain. `parse_chain` accepts any reference
+/// within a known namespace, so an unsupported network reaches this point as a
+/// `Chain`: `CardanoSigner` reads `chain.chain_id` and rejects a reference it does not
+/// know rather than guessing a network — see [`CardanoSigner::from_chain_id`]. The
+/// other families whose address format depends on the network still resolve to one
+/// fixed network for every reference in their namespace.
+pub fn signer_for_chain(chain: &Chain) -> Result<Box<dyn ChainSigner>, SignerError> {
+    Ok(match chain.chain_type {
         ChainType::Evm => Box::new(EvmSigner),
         ChainType::Solana => Box::new(SolanaSigner),
         ChainType::Bitcoin => Box::new(BitcoinSigner::mainnet()),
@@ -45,11 +49,11 @@ pub fn signer_for_chain(chain: &Chain) -> Box<dyn ChainSigner> {
         ChainType::Xrpl => Box::new(XrplSigner),
         ChainType::Nano => Box::new(NanoSigner),
         ChainType::Near => Box::new(NearSigner),
-        ChainType::Cardano => Box::new(CardanoSigner::from_chain_id(chain.chain_id)),
-    }
+        ChainType::Cardano => Box::new(CardanoSigner::from_chain_id(chain.chain_id)?),
+    })
 }
 
 /// Get a default signer for a given chain family (first registry entry per family).
-pub fn signer_for_chain_type(chain_type: ChainType) -> Box<dyn ChainSigner> {
+pub fn signer_for_chain_type(chain_type: ChainType) -> Result<Box<dyn ChainSigner>, SignerError> {
     signer_for_chain(&default_chain_for_type(chain_type))
 }

--- a/ows/crates/ows-signer/src/chains/nano.rs
+++ b/ows/crates/ows-signer/src/chains/nano.rs
@@ -292,6 +292,7 @@ impl ChainSigner for NanoSigner {
         &self,
         _private_key: &[u8],
         _message: &[u8],
+        _address: Option<&str>,
     ) -> Result<SignOutput, SignerError> {
         Err(SignerError::SigningFailed(
             "Nano off-chain message signing is not supported: no canonical standard exists. \
@@ -489,7 +490,7 @@ mod tests {
         let key = derive_key(MNEMONIC_12, "", "m/44'/165'/0'");
         let signer = NanoSigner;
         let message = b"hello nano";
-        let result = signer.sign_message(&key, message);
+        let result = signer.sign_message(&key, message, None);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/ows/crates/ows-signer/src/chains/near.rs
+++ b/ows/crates/ows-signer/src/chains/near.rs
@@ -69,7 +69,13 @@ impl ChainSigner for NearSigner {
         })
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         // V1: raw ed25519 over message bytes (parity with Solana).
         // NEP-413 message signing (`tag 2147484061 || borsh(payload)`) is a
         // structurally distinct flow with required fields (recipient, nonce);
@@ -201,7 +207,7 @@ mod tests {
         let signer = NearSigner;
         let msg = b"hello near";
         let s1 = signer.sign(&rfc_seed(), msg).unwrap();
-        let s2 = signer.sign_message(&rfc_seed(), msg).unwrap();
+        let s2 = signer.sign_message(&rfc_seed(), msg, None).unwrap();
         assert_eq!(s1.signature, s2.signature);
     }
 

--- a/ows/crates/ows-signer/src/chains/solana.rs
+++ b/ows/crates/ows-signer/src/chains/solana.rs
@@ -136,7 +136,13 @@ impl ChainSigner for SolanaSigner {
         Ok(signed)
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         // Solana doesn't use a special prefix for message signing
         self.sign(private_key, message)
     }
@@ -380,7 +386,7 @@ mod tests {
         let signer = SolanaSigner;
         let message = b"hello solana";
         let sig1 = signer.sign(&privkey, message).unwrap();
-        let sig2 = signer.sign_message(&privkey, message).unwrap();
+        let sig2 = signer.sign_message(&privkey, message, None).unwrap();
         assert_eq!(sig1.signature, sig2.signature);
     }
 

--- a/ows/crates/ows-signer/src/chains/spark.rs
+++ b/ows/crates/ows-signer/src/chains/spark.rs
@@ -72,7 +72,13 @@ impl ChainSigner for SparkSigner {
         self.sign(private_key, &hash)
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         let hash = Sha256::digest(message);
         self.sign(private_key, &hash)
     }
@@ -125,7 +131,9 @@ mod tests {
     #[test]
     fn test_sign_message() {
         let privkey = test_privkey();
-        let result = SparkSigner.sign_message(&privkey, b"hello spark").unwrap();
+        let result = SparkSigner
+            .sign_message(&privkey, b"hello spark", None)
+            .unwrap();
         assert!(!result.signature.is_empty());
         assert!(result.recovery_id.is_some());
     }

--- a/ows/crates/ows-signer/src/chains/sui.rs
+++ b/ows/crates/ows-signer/src/chains/sui.rs
@@ -85,7 +85,13 @@ impl ChainSigner for SuiSigner {
         })
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         let signing_key = Self::signing_key(private_key)?;
 
         // Personal message signing: intent scope = 3
@@ -284,7 +290,7 @@ mod tests {
         let privkey = test_privkey();
         let message = b"hello sui";
 
-        let result = signer.sign_message(&privkey, message).unwrap();
+        let result = signer.sign_message(&privkey, message, None).unwrap();
         assert_eq!(result.signature.len(), 64);
         assert!(result.public_key.is_some());
 

--- a/ows/crates/ows-signer/src/chains/ton.rs
+++ b/ows/crates/ows-signer/src/chains/ton.rs
@@ -193,7 +193,13 @@ impl ChainSigner for TonSigner {
         self.sign(private_key, tx_bytes)
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         self.sign(private_key, message)
     }
 

--- a/ows/crates/ows-signer/src/chains/tron.rs
+++ b/ows/crates/ows-signer/src/chains/tron.rs
@@ -91,7 +91,13 @@ impl ChainSigner for TronSigner {
         self.sign(private_key, &hash)
     }
 
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError> {
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError> {
+        self.verify_sign_message_address(private_key, address)?;
         // Tron uses the same prefix as Ethereum for personal messages
         let prefix = format!("\x19TRON Signed Message:\n{}", message.len());
         let mut prefixed = Vec::new();

--- a/ows/crates/ows-signer/src/chains/xrpl.rs
+++ b/ows/crates/ows-signer/src/chains/xrpl.rs
@@ -198,6 +198,7 @@ impl ChainSigner for XrplSigner {
         &self,
         _private_key: &[u8],
         _message: &[u8],
+        _address: Option<&str>,
     ) -> Result<SignOutput, SignerError> {
         Err(SignerError::SigningFailed(
             "XRPL off-chain message signing is not supported: no canonical standard exists. \
@@ -413,7 +414,7 @@ mod tests {
     fn test_sign_message_unsupported() {
         let privkey = test_privkey();
         let signer = XrplSigner;
-        let result = signer.sign_message(&privkey, b"hello");
+        let result = signer.sign_message(&privkey, b"hello", None);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(

--- a/ows/crates/ows-signer/src/curve.rs
+++ b/ows/crates/ows-signer/src/curve.rs
@@ -3,6 +3,7 @@
 pub enum Curve {
     Secp256k1,
     Ed25519,
+    Ed25519Bip32,
 }
 
 impl Curve {
@@ -11,6 +12,7 @@ impl Curve {
         match self {
             Curve::Secp256k1 => 32,
             Curve::Ed25519 => 32,
+            Curve::Ed25519Bip32 => ed25519_bip32::XPRV_SIZE,
         }
     }
 
@@ -19,6 +21,7 @@ impl Curve {
         match self {
             Curve::Secp256k1 => 33, // compressed
             Curve::Ed25519 => 32,
+            Curve::Ed25519Bip32 => 32,
         }
     }
 }
@@ -40,9 +43,20 @@ mod tests {
     }
 
     #[test]
+    fn test_key_lengths_ed25519_bip32() {
+        assert_eq!(
+            Curve::Ed25519Bip32.private_key_len(),
+            ed25519_bip32::XPRV_SIZE
+        );
+        assert_eq!(Curve::Ed25519Bip32.public_key_len(), 32);
+    }
+
+    #[test]
     fn test_equality() {
         assert_eq!(Curve::Secp256k1, Curve::Secp256k1);
         assert_eq!(Curve::Ed25519, Curve::Ed25519);
+        assert_eq!(Curve::Ed25519Bip32, Curve::Ed25519Bip32);
         assert_ne!(Curve::Secp256k1, Curve::Ed25519);
+        assert_ne!(Curve::Ed25519, Curve::Ed25519Bip32);
     }
 }

--- a/ows/crates/ows-signer/src/hd.rs
+++ b/ows/crates/ows-signer/src/hd.rs
@@ -87,6 +87,28 @@ impl HdDeriver {
 
     /// Derive one [`DerivedKey`] per path on the given `curve`, preserving order.
     ///
+    /// The non-cached sibling of [`Self::derive_keys_from_mnemonic_cached`]:
+    /// every path goes through the non-cached singular, so no derived secret is
+    /// retained in the global key cache. Address derivation uses this — it only
+    /// needs the public address, not to warm the cache — while the signing path
+    /// uses the cached variant.
+    pub fn derive_keys_from_mnemonic(
+        mnemonic: &Mnemonic,
+        passphrase: &str,
+        paths: Vec<String>,
+        curve: Curve,
+    ) -> Result<Vec<DerivedKey>, HdError> {
+        paths
+            .into_iter()
+            .map(|path| {
+                let secret = Self::derive_from_mnemonic(mnemonic, passphrase, &path, curve)?;
+                Ok(DerivedKey { path, secret })
+            })
+            .collect()
+    }
+
+    /// Derive one [`DerivedKey`] per path on the given `curve`, preserving order.
+    ///
     /// Same interface as [`Self::derive_from_mnemonic_cached`] but plural in the
     /// path: every path goes through the cached singular under the hood, and the
     /// returned bundle pairs each secret with the path it came from so chains

--- a/ows/crates/ows-signer/src/hd.rs
+++ b/ows/crates/ows-signer/src/hd.rs
@@ -3,6 +3,9 @@ use crate::mnemonic::Mnemonic;
 use crate::zeroizing::SecretBytes;
 use hmac::{Hmac, Mac};
 use sha2::Sha512;
+use zeroize::Zeroizing;
+
+const HARDENED_THRESHOLD: u32 = 0x80000000;
 
 /// Errors from HD key derivation.
 #[derive(Debug, thiserror::Error)]
@@ -20,15 +23,16 @@ pub enum HdError {
     InvalidSeedLength(usize),
 }
 
-/// HD key deriver supporting BIP-32 (secp256k1) and SLIP-10 (ed25519).
+/// HD key deriver supporting BIP-32 (secp256k1), SLIP-10 (ed25519), and Ed25519-BIP32.
 pub struct HdDeriver;
 
 impl HdDeriver {
     /// Derive a child private key from a seed and derivation path.
     ///
-    /// Seed must be 16-64 bytes (BIP-32 §2).
+    /// Seed must be 16-64 bytes (BIP-32 §2) for secp256k1 and ed25519, and 96 bytes for ed25519-bip32.
+    /// For Ed25519-BIP32, the seed must be the master extended private key.
     pub fn derive(seed: &[u8], path: &str, curve: Curve) -> Result<SecretBytes, HdError> {
-        if seed.len() < 16 || seed.len() > 64 {
+        if curve != Curve::Ed25519Bip32 && (seed.len() < 16 || seed.len() > 64) {
             return Err(HdError::InvalidSeedLength(seed.len()));
         }
         Self::validate_path(path)?;
@@ -36,6 +40,13 @@ impl HdDeriver {
         match curve {
             Curve::Secp256k1 => Self::derive_secp256k1(seed, path),
             Curve::Ed25519 => Self::derive_ed25519(seed, path),
+            Curve::Ed25519Bip32 => {
+                if seed.len() != ed25519_bip32::XPRV_SIZE {
+                    return Err(HdError::InvalidSeedLength(seed.len()));
+                }
+
+                Self::derive_ed25519_bip32(seed, path)
+            }
         }
     }
 
@@ -46,8 +57,17 @@ impl HdDeriver {
         path: &str,
         curve: Curve,
     ) -> Result<SecretBytes, HdError> {
-        let seed = mnemonic.to_seed(passphrase);
-        Self::derive(seed.expose(), path, curve)
+        match curve {
+            Curve::Ed25519Bip32 => {
+                let entropy = mnemonic.entropy();
+                let seed = Self::ed25519_bip32_master_xprv_from_entropy(entropy.expose());
+                Self::derive(seed.as_ref(), path, curve)
+            }
+            _ => {
+                let seed = mnemonic.to_seed(passphrase);
+                Self::derive(seed.expose(), path, curve)
+            }
+        }
     }
 
     /// Like `derive_from_mnemonic`, but checks the global key cache first.
@@ -72,6 +92,7 @@ impl HdDeriver {
         hasher.update(match curve {
             Curve::Secp256k1 => b"secp256k1" as &[u8],
             Curve::Ed25519 => b"ed25519",
+            Curve::Ed25519Bip32 => b"ed25519_bip32",
         });
         let cache_key = hex::encode(hasher.finalize());
 
@@ -129,31 +150,53 @@ impl HdDeriver {
             .collect()
     }
 
-    /// Validate a derivation path. Must start with "m/" and contain valid indices.
-    pub fn validate_path(path: &str) -> Result<(), HdError> {
-        if !path.starts_with("m/") && path != "m" {
+    /// Parse a derivation path into `(index, hardened)` pairs.
+    ///
+    /// The single parser behind [`Self::validate_path`] and the per-curve derivation
+    /// functions, so every curve agrees on what a path means. `"m"` yields no components.
+    fn parse_path_components(path: &str) -> Result<Vec<(u32, bool)>, HdError> {
+        if path == "m" {
+            return Ok(vec![]);
+        }
+        if !path.starts_with("m/") {
             return Err(HdError::InvalidPath(format!(
                 "path must start with 'm/', got '{}'",
                 path
             )));
         }
-        if path == "m" {
-            return Ok(());
-        }
-        let components = path[2..].split('/');
-        for component in components {
-            let index_str = component.trim_end_matches('\'');
-            if index_str.is_empty() {
-                return Err(HdError::InvalidPath(format!(
-                    "empty component in path '{}'",
-                    path
-                )));
-            }
-            index_str.parse::<u32>().map_err(|_| {
-                HdError::InvalidPath(format!("invalid index '{}' in path '{}'", component, path))
-            })?;
-        }
-        Ok(())
+        path[2..]
+            .split('/')
+            .map(|component| {
+                let (index_str, hardened) = match component.strip_suffix('\'') {
+                    Some(stripped) => (stripped, true),
+                    None => (component, false),
+                };
+                if index_str.is_empty() {
+                    return Err(HdError::InvalidPath(format!(
+                        "empty component in path '{}'",
+                        path
+                    )));
+                }
+                let index: u32 = index_str.parse().map_err(|_| {
+                    HdError::InvalidPath(format!(
+                        "invalid index '{}' in path '{}'",
+                        component, path
+                    ))
+                })?;
+                if index >= HARDENED_THRESHOLD {
+                    return Err(HdError::InvalidPath(format!(
+                        "index '{}' in path '{}' must be below {}",
+                        component, path, HARDENED_THRESHOLD
+                    )));
+                }
+                Ok((index, hardened))
+            })
+            .collect()
+    }
+
+    /// Validate a derivation path. Must start with "m/" and contain valid indices.
+    pub fn validate_path(path: &str) -> Result<(), HdError> {
+        Self::parse_path_components(path).map(|_| ())
     }
 
     /// BIP-32 derivation for secp256k1 using coins-bip32.
@@ -181,24 +224,11 @@ impl HdDeriver {
     fn derive_ed25519(seed: &[u8], path: &str) -> Result<SecretBytes, HdError> {
         use zeroize::Zeroize;
 
-        // Parse path components
-        let components = if path == "m" {
-            vec![]
-        } else {
-            path[2..]
-                .split('/')
-                .map(|c| {
-                    if !c.ends_with('\'') {
-                        return Err(HdError::Ed25519NonHardened);
-                    }
-                    let index_str = c.trim_end_matches('\'');
-                    let index: u32 = index_str
-                        .parse()
-                        .map_err(|_| HdError::InvalidPath(format!("invalid index: {}", c)))?;
-                    Ok(index)
-                })
-                .collect::<Result<Vec<_>, _>>()?
-        };
+        // Parse path components (hardened only)
+        let components = Self::parse_path_components(path)?;
+        if components.iter().any(|(_, hardened)| !hardened) {
+            return Err(HdError::Ed25519NonHardened);
+        }
 
         // SLIP-10: Master key generation
         type HmacSha512 = Hmac<Sha512>;
@@ -212,12 +242,17 @@ impl HdDeriver {
 
         // Derive each component (hardened only)
         let mut data = Vec::new();
-        for index in components {
+        for (index, _) in components {
+            // `parse_path_components` bounds `index` below HARDENED_THRESHOLD, so this cannot overflow
+            let child_index = index.checked_add(HARDENED_THRESHOLD).ok_or_else(|| {
+                HdError::InvalidPath(format!("invalid hardened index: {}", index))
+            })?;
+
             data.zeroize();
             data.clear();
             data.push(0u8); // 0x00 prefix for private key derivation
             data.extend_from_slice(&key);
-            data.extend_from_slice(&(index + 0x80000000u32).to_be_bytes());
+            data.extend_from_slice(&child_index.to_be_bytes());
 
             let mut mac =
                 HmacSha512::new_from_slice(&chain_code).expect("HMAC can take key of any size");
@@ -233,6 +268,35 @@ impl HdDeriver {
         data.zeroize();
         chain_code.zeroize();
         Ok(SecretBytes::new(key))
+    }
+
+    /// Build the Ed25519-BIP32 master extended private key (96-byte `XPrv`) from raw BIP-39 entropy
+    fn ed25519_bip32_master_xprv_from_entropy(
+        entropy: &[u8],
+    ) -> Zeroizing<[u8; ed25519_bip32::XPRV_SIZE]> {
+        let mut out = Zeroizing::new([0u8; ed25519_bip32::XPRV_SIZE]);
+        // password slot stays empty on purpose to keep compatibility with Cardano software wallets
+        pbkdf2::pbkdf2_hmac::<sha2::Sha512>("".as_bytes(), entropy, 4096, out.as_mut());
+        Zeroizing::new(ed25519_bip32::XPrv::normalize_bytes_force3rd(*out).into())
+    }
+
+    /// Ed25519-BIP32 path derivation (V2) from an existing seed (master extended private key).
+    fn derive_ed25519_bip32(seed: &[u8], path: &str) -> Result<SecretBytes, HdError> {
+        let mut xprv = ed25519_bip32::XPrv::from_slice_verified(seed)
+            .map_err(|e| HdError::DerivationFailed(e.to_string()))?;
+
+        for (index, hardened) in Self::parse_path_components(path)? {
+            // `parse_path_components` bounds `index` below HARDENED_THRESHOLD, so this cannot overflow
+            let child_index = if hardened {
+                index.checked_add(HARDENED_THRESHOLD).ok_or_else(|| {
+                    HdError::InvalidPath(format!("invalid hardened index: {}", index))
+                })?
+            } else {
+                index
+            };
+            xprv = xprv.derive(ed25519_bip32::DerivationScheme::V2, child_index);
+        }
+        Ok(SecretBytes::new(xprv.as_ref().to_vec()))
     }
 }
 
@@ -319,6 +383,64 @@ mod tests {
         assert!(HdDeriver::validate_path("44'/60'/0'/0/0").is_err());
         assert!(HdDeriver::validate_path("").is_err());
         assert!(HdDeriver::validate_path("x/44'/60'").is_err());
+    }
+
+    #[test]
+    fn test_path_validation_rejects_index_at_or_above_hardened_threshold() {
+        // A bare 2147483648 would alias the hardened 0' (both are child index 0x80000000),
+        // and 2147483648' would overflow the hardening offset.
+        for path in [
+            "m/2147483648",
+            "m/2147483648'",
+            "m/4294967295",
+            "m/44'/0/2147483648",
+        ] {
+            assert!(
+                HdDeriver::validate_path(path).is_err(),
+                "expected '{path}' to be rejected"
+            );
+        }
+        // The largest legal index is still accepted.
+        assert!(HdDeriver::validate_path("m/2147483647'").is_ok());
+        assert!(HdDeriver::validate_path("m/2147483647").is_ok());
+    }
+
+    #[test]
+    fn test_path_validation_rejects_repeated_hardened_marker() {
+        assert!(HdDeriver::validate_path("m/44''").is_err());
+        assert!(HdDeriver::validate_path("m/44'/0''''").is_err());
+    }
+
+    #[test]
+    fn test_derive_rejects_out_of_range_index_on_every_curve() {
+        let seed = test_seed();
+        let xprv = HdDeriver::ed25519_bip32_master_xprv_from_entropy(&[0u8; 32]);
+
+        for path in ["m/2147483648", "m/2147483648'"] {
+            for (curve, seed) in [
+                (Curve::Secp256k1, seed.expose()),
+                (Curve::Ed25519, seed.expose()),
+                (Curve::Ed25519Bip32, &xprv[..]),
+            ] {
+                let err = HdDeriver::derive(seed, path, curve)
+                    .expect_err("expected '{path}' on {curve:?} to be rejected");
+                match err {
+                    HdError::InvalidPath(_) => {}
+                    other => {
+                        panic!("expected InvalidPath for '{path}' on {curve:?}, got {other:?}")
+                    }
+                }
+            }
+        }
+    }
+
+    /// `m/2147483648` and `m/0'` are the same child index (0x80000000); rejecting the
+    /// former is what keeps two spellings of one path from being two paths.
+    #[test]
+    fn test_ed25519_bip32_no_longer_aliases_hardened_zero() {
+        let xprv = HdDeriver::ed25519_bip32_master_xprv_from_entropy(&[0u8; 32]);
+        assert!(HdDeriver::derive(&xprv[..], "m/0'", Curve::Ed25519Bip32).is_ok());
+        assert!(HdDeriver::derive(&xprv[..], "m/2147483648", Curve::Ed25519Bip32).is_err());
     }
 
     #[test]
@@ -638,5 +760,60 @@ mod tests {
         let key0 = HdDeriver::derive(seed.expose(), "m/44'/60'/0'/0/0", Curve::Secp256k1).unwrap();
         let key1 = HdDeriver::derive(seed.expose(), "m/44'/60'/0'/0/1", Curve::Secp256k1).unwrap();
         assert_ne!(key0.expose(), key1.expose());
+    }
+
+    // === Ed25519-BIP32 master key vectors (entropy + PBKDF2 root) ===
+
+    #[test]
+    fn test_ed25519_bip32_master() {
+        let phrase = "eight country switch draw meat scout mystery blade tip drift useless good keep usage title";
+        let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+        let key = HdDeriver::derive_from_mnemonic(&mnemonic, "", "m", Curve::Ed25519Bip32).unwrap();
+        let expected = "c065afd2832cd8b087c4d9ab7011f481ee1e0721e78ea5dd609f3ab3f156d245d176bd8fd4ec60b4731c3918a2a72a0226c0cd119ec35b47e4d55884667f552a23f7fdcd4a10c6cd2c7393ac61d877873e248f417634aa3d812af327ffe9d620";
+        assert_eq!(hex::encode(key.expose()), expected);
+        assert_eq!(key.len(), ed25519_bip32::XPRV_SIZE);
+    }
+
+    /// "abandon … about" (zero entropy) — root `XPrv` bytes.
+    #[test]
+    fn test_ed25519_bip32_abandon_mnemonic_root_vector() {
+        let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
+        let key = HdDeriver::derive_from_mnemonic(&mnemonic, "", "m", Curve::Ed25519Bip32).unwrap();
+        let expected = "60ce7dbec3616e9fc17e0c32578b3f380337b1b61a1f3cb9651aee30670e6f53970419a23a2e4e4082d12bf78faa8645dfc882cee2ae7179e2b07fe88098abb2072310084784c7308182dbbdb1449b2706586f1ff5cbf13d15e9b6e78c15f067";
+        assert_eq!(hex::encode(key.expose()), expected);
+    }
+
+    // === Ed25519-BIP32 child derivation (V2) ===
+    // Parent XPrv from ed25519-bip32 crate tests: src/tests.rs
+
+    #[test]
+    fn test_ed25519_bip32_derive_hardened_zero_from_test_vector_xprv() {
+        // ed25519-bip32 0.4.1 `src/tests.rs` constants D1, D1_H0
+        let d1_hex = "f8a29231ee38d6c5bf715d5bac21c750577aa3798b22d79d65bf97d6fadea15adcd1ee1abdf78bd4be64731a12deb94d3671784112eb6f364b871851fd1c9a247384db9ad6003bbd08b3b1ddc0d07a597293ff85e961bf252b331262eddfad0d";
+        let d1_h0_hex = "60d399da83ef80d8d4f8d223239efdc2b8fef387e1b5219137ffb4e8fbdea15adc9366b7d003af37c11396de9a83734e30e05e851efa32745c9cd7b42712c890608763770eddf77248ab652984b21b849760d1da74a6f5bd633ce41adceef07a";
+
+        let d1_bytes: [u8; ed25519_bip32::XPRV_SIZE] =
+            hex::decode(d1_hex).unwrap().try_into().unwrap();
+        let derived = HdDeriver::derive_ed25519_bip32(&d1_bytes, "m/0'").unwrap();
+        assert_eq!(hex::encode(derived.expose()), d1_h0_hex);
+    }
+
+    #[test]
+    fn test_derive_rejects_bip39_seed_for_ed25519_bip32() {
+        let seed = test_seed();
+        let r = HdDeriver::derive(seed.expose(), "m/0'", Curve::Ed25519Bip32);
+        assert!(matches!(r, Err(HdError::InvalidSeedLength(64))));
+    }
+
+    #[test]
+    fn test_derive_ed25519_bip32_from_master_xprv_matches_from_mnemonic() {
+        let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
+        let path = "m/1852'/1815'/0'/0/0";
+        let from_mnemonic =
+            HdDeriver::derive_from_mnemonic(&mnemonic, "", path, Curve::Ed25519Bip32).unwrap();
+        let master =
+            HdDeriver::derive_from_mnemonic(&mnemonic, "", "m", Curve::Ed25519Bip32).unwrap();
+        let from_derive = HdDeriver::derive(master.expose(), path, Curve::Ed25519Bip32).unwrap();
+        assert_eq!(from_mnemonic.expose(), from_derive.expose());
     }
 }

--- a/ows/crates/ows-signer/src/hd.rs
+++ b/ows/crates/ows-signer/src/hd.rs
@@ -85,6 +85,28 @@ impl HdDeriver {
         Ok(key)
     }
 
+    /// Derive one [`DerivedKey`] per path on the given `curve`, preserving order.
+    ///
+    /// Same interface as [`Self::derive_from_mnemonic_cached`] but plural in the
+    /// path: every path goes through the cached singular under the hood, and the
+    /// returned bundle pairs each secret with the path it came from so chains
+    /// that bind several keys per account (e.g. Midnight) can tell roles apart
+    /// by path instead of position.
+    pub fn derive_keys_from_mnemonic_cached(
+        mnemonic: &Mnemonic,
+        passphrase: &str,
+        paths: Vec<String>,
+        curve: Curve,
+    ) -> Result<Vec<DerivedKey>, HdError> {
+        paths
+            .into_iter()
+            .map(|path| {
+                let secret = Self::derive_from_mnemonic_cached(mnemonic, passphrase, &path, curve)?;
+                Ok(DerivedKey { path, secret })
+            })
+            .collect()
+    }
+
     /// Validate a derivation path. Must start with "m/" and contain valid indices.
     pub fn validate_path(path: &str) -> Result<(), HdError> {
         if !path.starts_with("m/") && path != "m" {
@@ -190,6 +212,18 @@ impl HdDeriver {
         chain_code.zeroize();
         Ok(SecretBytes::new(key))
     }
+}
+
+/// A derived secret paired with the path it was derived from.
+///
+/// Most chains bind one key per account; chains that bind several (e.g.
+/// Midnight's unshielded / shielded / dust roles) get one `DerivedKey` per
+/// path, and the carried `path` is what tells them apart — callers select a
+/// key by its path, not by position in the bundle. The first entry is the
+/// primary (address / signing) key.
+pub struct DerivedKey {
+    pub path: String,
+    pub secret: SecretBytes,
 }
 
 #[cfg(test)]

--- a/ows/crates/ows-signer/src/hd.rs
+++ b/ows/crates/ows-signer/src/hd.rs
@@ -275,7 +275,11 @@ impl HdDeriver {
         entropy: &[u8],
     ) -> Zeroizing<[u8; ed25519_bip32::XPRV_SIZE]> {
         let mut out = Zeroizing::new([0u8; ed25519_bip32::XPRV_SIZE]);
-        // password slot stays empty on purpose to keep compatibility with Cardano software wallets
+        // CIP-3 defines this as PBKDF2 over (password, entropy) and publishes vectors for both an
+        // empty password and a non-empty one, so the empty slot is a choice, not a requirement.
+        // OWS has no BIP-39 passphrase to put there — the passphrase it exposes is the vault's
+        // encryption passphrase — and the empty-password form is what the published vector in the
+        // tests pins. Accepting one later adds a parameter here rather than changing this call.
         pbkdf2::pbkdf2_hmac::<sha2::Sha512>("".as_bytes(), entropy, 4096, out.as_mut());
         Zeroizing::new(ed25519_bip32::XPrv::normalize_bytes_force3rd(*out).into())
     }

--- a/ows/crates/ows-signer/src/lib.rs
+++ b/ows/crates/ows-signer/src/lib.rs
@@ -10,7 +10,7 @@ pub mod rlp;
 pub mod traits;
 pub mod zeroizing;
 
-pub use chains::signer_for_chain;
+pub use chains::{signer_for_chain, signer_for_chain_type};
 pub use crypto::{
     decrypt, encrypt, encrypt_with_hkdf, CipherParams, CryptoEnvelope, CryptoError, HkdfKdfParams,
     KdfParams, KdfParamsVariant,
@@ -41,7 +41,7 @@ mod integration_tests {
     const ABANDON_PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     fn derive_address_for_chain(mnemonic: &Mnemonic, chain: ChainType) -> String {
-        let signer = signer_for_chain(chain);
+        let signer = signer_for_chain_type(chain);
         let curve = signer.curve();
         let path = signer.default_derivation_path(0);
 
@@ -142,8 +142,8 @@ mod integration_tests {
     #[test]
     fn test_spark_uses_bitcoin_derivation_path() {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
-        let btc_signer = signer_for_chain(ChainType::Bitcoin);
-        let spark_signer = signer_for_chain(ChainType::Spark);
+        let btc_signer = signer_for_chain_type(ChainType::Bitcoin);
+        let spark_signer = signer_for_chain_type(ChainType::Spark);
 
         // Same derivation path
         assert_eq!(
@@ -222,7 +222,7 @@ mod integration_tests {
             ChainType::Spark,
             ChainType::Filecoin,
         ] {
-            let signer = signer_for_chain(chain);
+            let signer = signer_for_chain_type(chain);
             let path = signer.default_derivation_path(0);
             let key =
                 HdDeriver::derive_from_mnemonic(&mnemonic, "", &path, Curve::Secp256k1).unwrap();
@@ -240,7 +240,7 @@ mod integration_tests {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
 
         for chain in [ChainType::Solana, ChainType::Ton] {
-            let signer = signer_for_chain(chain);
+            let signer = signer_for_chain_type(chain);
             let path = signer.default_derivation_path(0);
             let key =
                 HdDeriver::derive_from_mnemonic(&mnemonic, "", &path, Curve::Ed25519).unwrap();
@@ -265,7 +265,7 @@ mod integration_tests {
             ChainType::Filecoin,
             ChainType::Xrpl,
         ] {
-            let signer = signer_for_chain(chain);
+            let signer = signer_for_chain_type(chain);
             assert_eq!(signer.chain_type(), chain);
         }
     }

--- a/ows/crates/ows-signer/src/lib.rs
+++ b/ows/crates/ows-signer/src/lib.rs
@@ -16,7 +16,7 @@ pub use crypto::{
     KdfParams, KdfParamsVariant,
 };
 pub use curve::Curve;
-pub use hd::HdDeriver;
+pub use hd::{DerivedKey, HdDeriver};
 pub use mnemonic::{Mnemonic, MnemonicStrength};
 pub use traits::{ChainSigner, SignOutput, SignerError};
 pub use zeroizing::SecretBytes;

--- a/ows/crates/ows-signer/src/lib.rs
+++ b/ows/crates/ows-signer/src/lib.rs
@@ -43,9 +43,10 @@ mod integration_tests {
     fn derive_address_for_chain(mnemonic: &Mnemonic, chain: ChainType) -> String {
         let signer = signer_for_chain_type(chain);
         let curve = signer.curve();
-        let path = signer.default_derivation_path(0);
+        let paths = signer.default_derivation_paths(0);
 
-        let key = HdDeriver::derive_from_mnemonic(mnemonic, "", &path, curve).unwrap();
+        let keys = HdDeriver::derive_keys_from_mnemonic(mnemonic, "", paths, curve).unwrap();
+        let key = signer.encode_keys(&keys).unwrap();
         signer.derive_address(key.expose()).unwrap()
     }
 
@@ -140,6 +141,17 @@ mod integration_tests {
     }
 
     #[test]
+    fn test_full_pipeline_cardano() {
+        let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
+        let address = derive_address_for_chain(&mnemonic, ChainType::Cardano);
+        assert!(
+            address.starts_with("addr1"),
+            "Cardano mainnet address should start with addr1, got: {address}"
+        );
+        assert_eq!(address.len(), 103);
+    }
+
+    #[test]
     fn test_spark_uses_bitcoin_derivation_path() {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
         let btc_signer = signer_for_chain_type(ChainType::Bitcoin);
@@ -182,6 +194,7 @@ mod integration_tests {
         let spark_addr = derive_address_for_chain(&mnemonic, ChainType::Spark);
         let fil_addr = derive_address_for_chain(&mnemonic, ChainType::Filecoin);
         let xrpl_addr = derive_address_for_chain(&mnemonic, ChainType::Xrpl);
+        let cardano_addr = derive_address_for_chain(&mnemonic, ChainType::Cardano);
 
         // All addresses should be different
         let addrs = [
@@ -194,6 +207,7 @@ mod integration_tests {
             &spark_addr,
             &fil_addr,
             &xrpl_addr,
+            &cardano_addr,
         ];
         for i in 0..addrs.len() {
             for j in (i + 1)..addrs.len() {
@@ -264,6 +278,7 @@ mod integration_tests {
             ChainType::Spark,
             ChainType::Filecoin,
             ChainType::Xrpl,
+            ChainType::Cardano,
         ] {
             let signer = signer_for_chain_type(chain);
             assert_eq!(signer.chain_type(), chain);

--- a/ows/crates/ows-signer/src/lib.rs
+++ b/ows/crates/ows-signer/src/lib.rs
@@ -41,7 +41,7 @@ mod integration_tests {
     const ABANDON_PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     fn derive_address_for_chain(mnemonic: &Mnemonic, chain: ChainType) -> String {
-        let signer = signer_for_chain_type(chain);
+        let signer = signer_for_chain_type(chain).unwrap();
         let curve = signer.curve();
         let paths = signer.default_derivation_paths(0);
 
@@ -154,8 +154,8 @@ mod integration_tests {
     #[test]
     fn test_spark_uses_bitcoin_derivation_path() {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
-        let btc_signer = signer_for_chain_type(ChainType::Bitcoin);
-        let spark_signer = signer_for_chain_type(ChainType::Spark);
+        let btc_signer = signer_for_chain_type(ChainType::Bitcoin).unwrap();
+        let spark_signer = signer_for_chain_type(ChainType::Spark).unwrap();
 
         // Same derivation path
         assert_eq!(
@@ -236,7 +236,7 @@ mod integration_tests {
             ChainType::Spark,
             ChainType::Filecoin,
         ] {
-            let signer = signer_for_chain_type(chain);
+            let signer = signer_for_chain_type(chain).unwrap();
             let path = signer.default_derivation_path(0);
             let key =
                 HdDeriver::derive_from_mnemonic(&mnemonic, "", &path, Curve::Secp256k1).unwrap();
@@ -254,7 +254,7 @@ mod integration_tests {
         let mnemonic = Mnemonic::from_phrase(ABANDON_PHRASE).unwrap();
 
         for chain in [ChainType::Solana, ChainType::Ton] {
-            let signer = signer_for_chain_type(chain);
+            let signer = signer_for_chain_type(chain).unwrap();
             let path = signer.default_derivation_path(0);
             let key =
                 HdDeriver::derive_from_mnemonic(&mnemonic, "", &path, Curve::Ed25519).unwrap();
@@ -280,8 +280,18 @@ mod integration_tests {
             ChainType::Xrpl,
             ChainType::Cardano,
         ] {
-            let signer = signer_for_chain_type(chain);
+            let signer = signer_for_chain_type(chain).unwrap();
             assert_eq!(signer.chain_type(), chain);
         }
+    }
+
+    #[test]
+    fn test_signer_for_chain_rejects_unknown_cardano_network() {
+        let chain = ows_core::parse_chain("cip34:0-999").unwrap();
+        assert_eq!(chain.chain_type, ChainType::Cardano);
+        assert!(matches!(
+            signer_for_chain(&chain),
+            Err(SignerError::UnsupportedChain(_))
+        ));
     }
 }

--- a/ows/crates/ows-signer/src/mnemonic.rs
+++ b/ows/crates/ows-signer/src/mnemonic.rs
@@ -1,4 +1,5 @@
 use crate::zeroizing::SecretBytes;
+use coins_bip39::wordlist::Wordlist;
 use coins_bip39::{English, Mnemonic as Bip39Mnemonic};
 
 /// Mnemonic strength / word count.
@@ -41,6 +42,35 @@ impl Mnemonic {
     pub fn phrase(&self) -> SecretBytes {
         let phrase_str = self.inner.to_phrase();
         SecretBytes::new(phrase_str.into_bytes())
+    }
+
+    /// Raw BIP-39 entropy bytes (English wordlist; checksum bits excluded).
+    /// NOTE: assumes that the phrase is valid and in the English wordlist.
+    pub fn entropy(&self) -> SecretBytes {
+        use zeroize::Zeroize;
+
+        let phrase = self.inner.to_phrase();
+
+        let total_bits = phrase.split(' ').count() * 11;
+        let ent_bytes = (total_bits - total_bits / 33) / 8;
+
+        let mut out = Vec::with_capacity(total_bits / 8);
+        let mut acc: u32 = 0;
+        let mut acc_bits: u32 = 0;
+        for word in phrase.split(' ') {
+            acc = (acc << 11) | English::get_index(word).unwrap() as u32;
+            acc_bits += 11;
+            while acc_bits >= 8 {
+                acc_bits -= 8;
+                out.push((acc >> acc_bits) as u8);
+            }
+        }
+        out.truncate(ent_bytes);
+
+        acc.zeroize();
+        let mut phrase = phrase;
+        Zeroize::zeroize(unsafe { phrase.as_mut_vec() });
+        SecretBytes::new(out)
     }
 
     /// Derive a BIP-39 seed from this mnemonic with an optional passphrase.
@@ -123,6 +153,47 @@ mod tests {
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon",
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_entropy_abandon_all_zero() {
+        let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+        let ent = mnemonic.entropy();
+        assert_eq!(ent.expose(), &[0u8; 16]);
+    }
+
+    // BIP-39 test vectors (Trezor). The 24-word cases matter because 24 words carry
+    // 264 bits, so the last emitted byte is pure checksum and must be dropped.
+    #[test]
+    fn test_entropy_bip39_vectors() {
+        let cases: [(&str, &[u8]); 3] = [
+            (
+                "legal winner thank year wave sausage worth useful legal winner thank yellow",
+                &[0x7f; 16],
+            ),
+            (
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon \
+                 abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon \
+                 abandon abandon abandon art",
+                &[0x00; 32],
+            ),
+            (
+                "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo \
+                 zoo zoo zoo vote",
+                &[0xff; 32],
+            ),
+        ];
+
+        for (phrase, expected) in cases {
+            let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+            let ent = mnemonic.entropy();
+            assert_eq!(
+                hex::encode(ent.expose()),
+                hex::encode(expected),
+                "entropy mismatch for '{phrase}'"
+            );
+        }
     }
 
     #[test]

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -86,6 +86,7 @@ pub trait ChainSigner: Send + Sync {
         Ok(TransactionContext {
             to: None,
             value: None,
+            effects: vec![],
             raw_hex: hex::encode(tx_bytes),
             data: None,
         })

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -84,8 +84,6 @@ pub trait ChainSigner: Send + Sync {
         _rpc_url: Option<&str>,
     ) -> Result<TransactionContext, SignerError> {
         Ok(TransactionContext {
-            to: None,
-            value: None,
             effects: vec![],
             raw_hex: hex::encode(tx_bytes),
             data: None,

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -1,4 +1,5 @@
 use crate::curve::Curve;
+use ows_core::policy::TransactionContext;
 use ows_core::ChainType;
 
 /// Output of a signing operation.
@@ -75,6 +76,19 @@ pub trait ChainSigner: Send + Sync {
             "encode_signed_transaction not implemented for {}",
             self.chain_type()
         )))
+    }
+
+    fn make_transaction_context(
+        &self,
+        tx_bytes: &[u8],
+        _rpc_url: Option<&str>,
+    ) -> Result<TransactionContext, SignerError> {
+        Ok(TransactionContext {
+            to: None,
+            value: None,
+            raw_hex: hex::encode(tx_bytes),
+            data: None,
+        })
     }
 
     /// Returns the default BIP-44 derivation path template for this chain.

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -1,4 +1,6 @@
 use crate::curve::Curve;
+use crate::hd::DerivedKey;
+use crate::zeroizing::SecretBytes;
 use ows_core::policy::TransactionContext;
 use ows_core::ChainType;
 
@@ -92,6 +94,32 @@ pub trait ChainSigner: Send + Sync {
 
     /// Returns the default BIP-44 derivation path template for this chain.
     fn default_derivation_path(&self, index: u32) -> String;
+
+    /// All derivation paths this chain binds to one account at `index`.
+    ///
+    /// Defaults to the single [`ChainSigner::default_derivation_path`] on this
+    /// chain's [`ChainSigner::curve`]. Chains that derive several keys per
+    /// account (e.g. Midnight's unshielded / shielded / dust roles) override
+    /// this; the first path is the primary (address / signing) key.
+    fn default_derivation_paths(&self, index: u32) -> Vec<String> {
+        vec![self.default_derivation_path(index)]
+    }
+
+    /// Collapse a resolved key bundle into the single key-material blob the
+    /// signing methods (`sign`, `sign_message`, `sign_transaction`) consume.
+    ///
+    /// Most chains bind one key per account, so the default returns the primary
+    /// (first) key unchanged — `default_derivation_paths[0]` is the contractual
+    /// primary. Chains that bind several keys per account (e.g. Midnight)
+    /// override this to pack them into one blob; the matching decode lives in
+    /// that chain's signer, which unpacks it inside its signing methods. The
+    /// blob is opaque to the generic signing path — only the producing chain
+    /// interprets it.
+    fn encode_keys(&self, keys: &[DerivedKey]) -> Result<SecretBytes, SignerError> {
+        keys.first()
+            .map(|k| k.secret.clone())
+            .ok_or_else(|| SignerError::InvalidPrivateKey("no derived keys to encode".into()))
+    }
 }
 
 /// Errors that can occur during signing operations.

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -39,7 +39,30 @@ pub trait ChainSigner: Send + Sync {
     fn sign(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError>;
 
     /// Sign an arbitrary message with chain-specific prefixing/hashing.
-    fn sign_message(&self, private_key: &[u8], message: &[u8]) -> Result<SignOutput, SignerError>;
+    /// When `address` is `Some`, the implementation should call [`ChainSigner::verify_sign_message_address`] first.
+    fn sign_message(
+        &self,
+        private_key: &[u8],
+        message: &[u8],
+        address: Option<&str>,
+    ) -> Result<SignOutput, SignerError>;
+
+    fn verify_sign_message_address(
+        &self,
+        private_key: &[u8],
+        address: Option<&str>,
+    ) -> Result<(), SignerError> {
+        let Some(expected) = address else {
+            return Ok(());
+        };
+        let derived = self.derive_address(private_key)?;
+        if derived.trim_start_matches("0x").to_lowercase()
+            != expected.trim_start_matches("0x").to_lowercase()
+        {
+            return Err(SignerError::AddressMismatch);
+        }
+        Ok(())
+    }
 
     /// Sign an unsigned transaction. Each chain hashes the raw transaction
     /// bytes according to its own rules before signing.
@@ -143,4 +166,7 @@ pub enum SignerError {
 
     #[error("invalid transaction: {0}")]
     InvalidTransaction(String),
+
+    #[error("address does not match derived address")]
+    AddressMismatch,
 }

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -169,4 +169,7 @@ pub enum SignerError {
 
     #[error("address does not match derived address")]
     AddressMismatch,
+
+    #[error("RPC error: {0}")]
+    RpcError(String),
 }

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -29,7 +29,10 @@ pub trait ChainSigner: Send + Sync {
     /// The BIP-44 coin type for this chain.
     fn coin_type(&self) -> u32;
 
-    /// Derive an on-chain address from a private key.
+    /// Derive an on-chain address from the key material produced by
+    /// [`ChainSigner::encode_keys`] — the primary key for single-key chains, or
+    /// the full encoded bundle for chains that bind several keys per account
+    /// (e.g. Cardano's payment + staking), which decode it here.
     fn derive_address(&self, private_key: &[u8]) -> Result<String, SignerError>;
 
     /// Sign a pre-hashed message (32 bytes for secp256k1, raw message for ed25519).
@@ -105,16 +108,17 @@ pub trait ChainSigner: Send + Sync {
         vec![self.default_derivation_path(index)]
     }
 
-    /// Collapse a resolved key bundle into the single key-material blob the
-    /// signing methods (`sign`, `sign_message`, `sign_transaction`) consume.
+    /// Collapse a resolved key bundle into the single key-material blob that the
+    /// signing methods (`sign`, `sign_message`, `sign_transaction`) and
+    /// `derive_address` consume.
     ///
     /// Most chains bind one key per account, so the default returns the primary
     /// (first) key unchanged — `default_derivation_paths[0]` is the contractual
-    /// primary. Chains that bind several keys per account (e.g. Midnight)
-    /// override this to pack them into one blob; the matching decode lives in
-    /// that chain's signer, which unpacks it inside its signing methods. The
-    /// blob is opaque to the generic signing path — only the producing chain
-    /// interprets it.
+    /// primary. Chains that bind several keys per account (e.g. Midnight,
+    /// Cardano) override this to pack them into one blob; the matching decode
+    /// lives in that chain's signer, which unpacks it inside its signing and
+    /// address methods. The blob is opaque to the generic path — only the
+    /// producing chain interprets it.
     fn encode_keys(&self, keys: &[DerivedKey]) -> Result<SecretBytes, SignerError> {
         keys.first()
             .map(|k| k.secret.clone())

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -115,6 +115,7 @@ pub trait ChainSigner: Send + Sync {
             effects: vec![],
             raw_hex: hex::encode(tx_bytes),
             data: None,
+            chain_extra: None,
         })
     }
 

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -181,4 +181,7 @@ pub enum SignerError {
 
     #[error("RPC error: {0}")]
     RpcError(String),
+
+    #[error("unsupported chain: {0}")]
+    UnsupportedChain(String),
 }

--- a/ows/crates/ows-signer/src/traits.rs
+++ b/ows/crates/ows-signer/src/traits.rs
@@ -119,6 +119,14 @@ pub trait ChainSigner: Send + Sync {
         })
     }
 
+    /// Whether [`ChainSigner::make_transaction_context`] needs an RPC URL to do its work.
+    /// True for chains that resolve state the transaction only references (Cardano's input
+    /// UTxOs); callers resolve the chain's configured endpoint before the policy pass when
+    /// this is set, instead of matching on the chain type themselves.
+    fn transaction_context_needs_rpc(&self) -> bool {
+        false
+    }
+
     /// Returns the default BIP-44 derivation path template for this chain.
     fn default_derivation_path(&self, index: u32) -> String;
 

--- a/readme/partials/supported-chains.md
+++ b/readme/partials/supported-chains.md
@@ -13,3 +13,4 @@
 | Spark (Bitcoin L2) | secp256k1 | spark: prefixed | `m/84'/0'/0'/0/0` |
 | Filecoin | secp256k1 | f1 base32 | `m/44'/461'/0'/0/0` |
 | NEAR | Ed25519 | implicit hex (64 chars) | `m/44'/397'/0'` |
+| Cardano | Ed25519-BIP32 (CIP-1852) | Shelley Bech32 base (`addr1…`) | Payment `m/1852'/1815'/0'/0/0` + stake `m/1852'/1815'/0'/2/0` |

--- a/readme/templates/node.md
+++ b/readme/templates/node.md
@@ -26,7 +26,7 @@ Using viem, `@solana/web3.js`, or the Tether WDK? Install [`@open-wallet-standar
 import { createWallet, signMessage } from "@open-wallet-standard/core";
 
 const wallet = createWallet("agent-treasury");
-// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, and NEAR
+// => accounts for EVM, Solana, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Sui, XRPL, Nano, NEAR, and Cardano
 
 const sig = signMessage("agent-treasury", "evm", "hello");
 console.log(sig.signature);
@@ -44,6 +44,32 @@ ows sign message --wallet agent-treasury --chain evm --message "hello"
 # Sign a transaction
 ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
 ```
+
+## API Reference
+
+| Function | Description |
+|----------|-------------|
+| `createWallet(name, passphrase?, words?, vaultPath?)` | Create a new wallet with addresses for the current auto-derived chain set |
+| `importWalletMnemonic(name, mnemonic, passphrase?, index?, vaultPath?)` | Import a wallet from a BIP-39 mnemonic |
+| `importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?, ed25519Bip32Key?)` | Import a wallet from a private key |
+| `listWallets(vaultPath?)` | List all wallets in the vault |
+| `getWallet(nameOrId, vaultPath?)` | Get details of a specific wallet |
+| `deleteWallet(nameOrId, vaultPath?)` | Delete a wallet |
+| `exportWallet(nameOrId, passphrase?, vaultPath?)` | Export a wallet's mnemonic or keys |
+| `renameWallet(nameOrId, newName, vaultPath?)` | Rename a wallet |
+| `signMessage(wallet, chain, message, passphrase?, encoding?, index?, address?, vaultPath?)` | Sign a message with chain-specific formatting |
+| `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, address?, vaultPath?)` | Sign EIP-712 typed data (EVM only) |
+| `signTransaction(wallet, chain, txHex, passphrase?, index?, vaultPath?)` | Sign a raw transaction |
+| `signAndSend(wallet, chain, txHex, passphrase?, index?, rpcUrl?, vaultPath?)` | Sign and broadcast a transaction |
+| `generateMnemonic(words?)` | Generate a BIP-39 mnemonic phrase |
+| `deriveAddress(mnemonic, chain, index?)` | Derive an address from a mnemonic |
+| `createPolicy(policyJson, vaultPath?)` | Register a policy from a JSON string |
+| `listPolicies(vaultPath?)` | List all registered policies |
+| `getPolicy(id, vaultPath?)` | Get a single policy by ID |
+| `deletePolicy(id, vaultPath?)` | Delete a policy by ID |
+| `createApiKey(name, walletIds, policyIds, passphrase, expiresAt?, vaultPath?)` | Create an API key for agent access |
+| `listApiKeys(vaultPath?)` | List all API keys (tokens never returned) |
+| `revokeApiKey(id, vaultPath?)` | Revoke an API key |
 
 {{> supported-chains}}
 

--- a/readme/templates/node.md
+++ b/readme/templates/node.md
@@ -57,8 +57,8 @@ ows sign tx --wallet agent-treasury --chain evm --tx "deadbeef..."
 | `deleteWallet(nameOrId, vaultPath?)` | Delete a wallet |
 | `exportWallet(nameOrId, passphrase?, vaultPath?)` | Export a wallet's mnemonic or keys |
 | `renameWallet(nameOrId, newName, vaultPath?)` | Rename a wallet |
-| `signMessage(wallet, chain, message, passphrase?, encoding?, index?, address?, vaultPath?)` | Sign a message with chain-specific formatting |
-| `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, address?, vaultPath?)` | Sign EIP-712 typed data (EVM only) |
+| `signMessage(wallet, chain, message, passphrase?, encoding?, index?, vaultPath?, address?)` | Sign a message with chain-specific formatting |
+| `signTypedData(wallet, chain, typedDataJson, passphrase?, index?, vaultPath?, address?)` | Sign EIP-712 typed data (EVM only) |
 | `signTransaction(wallet, chain, txHex, passphrase?, index?, vaultPath?)` | Sign a raw transaction |
 | `signAndSend(wallet, chain, txHex, passphrase?, index?, rpcUrl?, vaultPath?)` | Sign and broadcast a transaction |
 | `generateMnemonic(words?)` | Generate a BIP-39 mnemonic phrase |

--- a/readme/templates/python.md
+++ b/readme/templates/python.md
@@ -41,10 +41,10 @@ print(sig["signature"])
 | `delete_wallet(name_or_id, vault_path?)` | Delete a wallet |
 | `export_wallet(name_or_id, passphrase?, vault_path?)` | Export a wallet's mnemonic or keys |
 | `rename_wallet(name_or_id, new_name, vault_path?)` | Rename a wallet |
-| `sign_message(wallet, chain, message, passphrase?, encoding?, index?, vault_path?)` | Sign a message with chain-specific formatting |
+| `sign_message(wallet, chain, message, passphrase?, encoding?, index?, address?, vault_path?)` | Sign a message with chain-specific formatting |
 | `sign_hash(wallet, chain, hash_hex, passphrase?, index?, vault_path?)` | Sign a raw 32-byte hash on a secp256k1-backed chain |
 | `sign_authorization(wallet, chain, address, nonce, passphrase?, index?, vault_path?)` | Sign an EIP-7702 authorization tuple |
-| `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, vault_path?)` | Sign EIP-712 typed data (EVM only) |
+| `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, address?, vault_path?)` | Sign EIP-712 typed data (EVM only) |
 | `sign_transaction(wallet, chain, tx_hex, passphrase?, index?, vault_path?)` | Sign a raw transaction |
 | `sign_and_send(wallet, chain, tx_hex, passphrase?, index?, rpc_url?, vault_path?)` | Sign and broadcast a transaction |
 | `generate_mnemonic(words?)` | Generate a BIP-39 mnemonic phrase |

--- a/readme/templates/python.md
+++ b/readme/templates/python.md
@@ -35,7 +35,7 @@ print(sig["signature"])
 |----------|-------------|
 | `create_wallet(name, passphrase?, words?, vault_path?)` | Create a new wallet with addresses for the current auto-derived chain set |
 | `import_wallet_mnemonic(name, mnemonic, passphrase?, index?, vault_path?)` | Import a wallet from a BIP-39 mnemonic |
-| `import_wallet_private_key(name, private_key_hex, chain?, passphrase?, vault_path?, secp256k1_key?, ed25519_key?)` | Import a wallet from a private key |
+| `import_wallet_private_key(name, private_key_hex, chain?, passphrase?, vault_path?, secp256k1_key?, ed25519_key?, ed25519_bip32_key?)` | Import a wallet from a private key |
 | `list_wallets(vault_path?)` | List all wallets in the vault |
 | `get_wallet(name_or_id, vault_path?)` | Get details of a specific wallet |
 | `delete_wallet(name_or_id, vault_path?)` | Delete a wallet |

--- a/readme/templates/python.md
+++ b/readme/templates/python.md
@@ -41,10 +41,10 @@ print(sig["signature"])
 | `delete_wallet(name_or_id, vault_path?)` | Delete a wallet |
 | `export_wallet(name_or_id, passphrase?, vault_path?)` | Export a wallet's mnemonic or keys |
 | `rename_wallet(name_or_id, new_name, vault_path?)` | Rename a wallet |
-| `sign_message(wallet, chain, message, passphrase?, encoding?, index?, address?, vault_path?)` | Sign a message with chain-specific formatting |
+| `sign_message(wallet, chain, message, passphrase?, encoding?, index?, vault_path?, address?)` | Sign a message with chain-specific formatting |
 | `sign_hash(wallet, chain, hash_hex, passphrase?, index?, vault_path?)` | Sign a raw 32-byte hash on a secp256k1-backed chain |
 | `sign_authorization(wallet, chain, address, nonce, passphrase?, index?, vault_path?)` | Sign an EIP-7702 authorization tuple |
-| `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, address?, vault_path?)` | Sign EIP-712 typed data (EVM only) |
+| `sign_typed_data(wallet, chain, typed_data_json, passphrase?, index?, vault_path?, address?)` | Sign EIP-712 typed data (EVM only) |
 | `sign_transaction(wallet, chain, tx_hex, passphrase?, index?, vault_path?)` | Sign a raw transaction |
 | `sign_and_send(wallet, chain, tx_hex, passphrase?, index?, rpc_url?, vault_path?)` | Sign and broadcast a transaction |
 | `generate_mnemonic(words?)` | Generate a BIP-39 mnemonic phrase |

--- a/scripts/build-llms-full.sh
+++ b/scripts/build-llms-full.sh
@@ -16,6 +16,7 @@ SPEC_FILES=(
   06-wallet-lifecycle.md
   07-supported-chains.md
   policy-engine-implementation.md
+  cardano.md
 )
 
 SDK_FILES=(
@@ -42,6 +43,7 @@ Sitemap:
 - [06 — Wallet Lifecycle](https://docs.openwallet.sh/doc.html?slug=06-wallet-lifecycle): Creation, backup, recovery, rotation, and deletion
 - [07 — Supported Chains](https://docs.openwallet.sh/doc.html?slug=07-supported-chains): Blockchain networks supported by OWS and how to add new ones
 - [Policy Engine Implementation](https://docs.openwallet.sh/doc.html?slug=policy-engine-implementation): Detailed implementation guide for the policy engine
+- [Cardano Support](https://docs.openwallet.sh/doc.html?slug=cardano): Cardano integration — CIP-34 addressing, Ed25519-BIP32 derivation, CIP-8 signing, and policy context
 - [CLI Reference](https://docs.openwallet.sh/doc.html?slug=sdk-cli): Command-line interface for managing wallets, signing, and key operations
 - [Node.js SDK](https://docs.openwallet.sh/doc.html?slug=sdk-node): Node.js / TypeScript SDK for programmatic wallet access
 - [Python SDK](https://docs.openwallet.sh/doc.html?slug=sdk-python): Python SDK for programmatic wallet access

--- a/skills/ows/SKILL.md
+++ b/skills/ows/SKILL.md
@@ -103,7 +103,7 @@ ows wallet rename --wallet "my-wallet" --new-name "treasury"
 
 ### Signing
 
-The `--wallet` flag can also be set via `OWS_WALLET` env var. Use `--json` for structured output, `--index N` to select an HD account index.
+The `--wallet` flag can also be set via `OWS_WALLET` env var. Use `--json` for structured output, `--index N` to select an HD account index, and optional `--address` that will be used to sign the message (e.g. stake/base/enterprise address on Cardano).
 
 ```bash
 # Sign a message

--- a/skills/ows/SKILL.md
+++ b/skills/ows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ows
-description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, and NEAR via CLI, Node.js, or Python.
+description: Secure, local-first multi-chain wallet management — create wallets, derive addresses, sign messages and transactions across EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, NEAR, and Cardano via CLI, Node.js, or Python.
 version: 1.3.2
 metadata:
   openclaw:
@@ -33,7 +33,7 @@ Use this skill when the user asks to:
 
 - Create, import, list, delete, or manage crypto wallets
 - Derive blockchain addresses from a mnemonic
-- Sign messages or transactions for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, or NEAR
+- Sign messages or transactions for EVM, Solana, XRPL, Sui, Bitcoin, Cosmos, Tron, TON, Spark, Filecoin, Nano, NEAR, or Cardano
 - Broadcast signed transactions to a chain
 - Generate BIP-39 mnemonic phrases
 - Fund a wallet with USDC (MoonPay) or check token balances
@@ -57,6 +57,7 @@ Use this skill when the user asks to:
 | XRPL | `xrpl` | secp256k1 | Base58Check (`r...`) |
 | Filecoin | `filecoin` | secp256k1 | f1 secp256k1 |
 | NEAR | `near`, `near-testnet` | Ed25519 | implicit hex (64 chars) |
+| Cardano | `cardano` | Ed25519-BIP32 (CIP-1852) | Shelley Bech32 base (`addr1…`) |
 
 ## Installation
 
@@ -89,9 +90,9 @@ echo "goose puzzle decorate ..." | ows wallet import --name "imported" --mnemoni
 echo "4c0883a691..." | ows wallet import --name "from-evm" --private-key
 echo "9d61b19d..." | ows wallet import --name "from-sol" --private-key --chain solana
 
-# Import explicit keys for both curves (via env vars)
-OWS_SECP256K1_KEY="4c0883a691..." OWS_ED25519_KEY="9d61b19d..." \
-  ows wallet import --name "both"
+# Import explicit keys for all three curves (via env vars)
+OWS_SECP256K1_KEY="4c0883a691..." OWS_ED25519_KEY="9d61b19d..." OWS_ED25519_BIP32_KEY="cafe..." \
+  ows wallet import --name "all-curves"
 
 # List / info / export / delete / rename
 ows wallet list

--- a/skills/ows/references/node.md
+++ b/skills/ows/references/node.md
@@ -97,7 +97,7 @@ import { signMessage, signTransaction, signAndSend } from "@open-wallet-standard
 const sig = signMessage("my-wallet", "evm", "hello world");
 // sig.signature => hex string
 // sig.recoveryId => 0 or 1 (EVM/Tron only)
-// signMessage(wallet, chain, message, passphrase?, encoding?, index?, vaultPath?)
+// signMessage(wallet, chain, message, passphrase?, encoding?, index?, address?, vaultPath?)
 
 // Sign transaction
 const txSig = signTransaction("my-wallet", "evm", "02f8...");
@@ -117,7 +117,7 @@ import { signTypedData } from "@open-wallet-standard/core";
 const sig = signTypedData("my-wallet", "evm", '{"types":...}');
 // sig.signature => hex string
 // sig.recoveryId => 0 or 1
-// signTypedData(wallet, chain, typedDataJson, passphrase?, index?, vaultPath?)
+// signTypedData(wallet, chain, typedDataJson, passphrase?, index?, address?, vaultPath?)
 ```
 
 ## Policy Management

--- a/skills/ows/references/node.md
+++ b/skills/ows/references/node.md
@@ -44,7 +44,7 @@ interface ApiKeyResult {
 import { generateMnemonic, deriveAddress } from "@open-wallet-standard/core";
 
 const phrase = generateMnemonic(12);       // or 24
-const addr = deriveAddress(phrase, "evm"); // any chain: evm, solana, sui, bitcoin, cosmos, tron, ton, spark, filecoin
+const addr = deriveAddress(phrase, "evm"); // any chain: evm, solana, sui, bitcoin, cosmos, tron, ton, spark, filecoin, xrpl, nano, cardano
 ```
 
 ## Wallet Management
@@ -75,9 +75,9 @@ const w2 = importWalletPrivateKey("from-evm", "4c0883a691...");
 // Import Ed25519 key (solana/sui/ton)
 const w3 = importWalletPrivateKey("from-sol", "9d61b19d...", undefined, undefined, "solana");
 
-// Import explicit keys for both curves
-const w4 = importWalletPrivateKey("both", "", undefined, undefined, undefined, "4c08...", "9d61...");
-// importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?)
+// Import explicit keys for all curves
+const w4 = importWalletPrivateKey("all", "", undefined, undefined, undefined, "4c08...", "9d61...", "cafe...");
+// importWalletPrivateKey(name, privateKeyHex, passphrase?, vaultPath?, chain?, secp256k1Key?, ed25519Key?, ed25519Bip32Key?)
 
 // List / get / delete / rename / export
 const wallets = listWallets();           // listWallets(vaultPath?)
@@ -85,7 +85,7 @@ const w = getWallet("my-wallet");        // getWallet(nameOrId, vaultPath?)
 deleteWallet("my-wallet");               // deleteWallet(nameOrId, vaultPath?)
 renameWallet("old", "new");              // renameWallet(nameOrId, newName, vaultPath?)
 const secret = exportWallet("my-wallet"); // exportWallet(nameOrId, passphrase?, vaultPath?)
-// Returns mnemonic string or JSON: {"secp256k1":"hex","ed25519":"hex"}
+// Returns mnemonic string or JSON: {"secp256k1":"hex","ed25519":"hex","ed25519_bip32":"hex"}
 ```
 
 ## Signing

--- a/skills/ows/references/node.md
+++ b/skills/ows/references/node.md
@@ -97,7 +97,7 @@ import { signMessage, signTransaction, signAndSend } from "@open-wallet-standard
 const sig = signMessage("my-wallet", "evm", "hello world");
 // sig.signature => hex string
 // sig.recoveryId => 0 or 1 (EVM/Tron only)
-// signMessage(wallet, chain, message, passphrase?, encoding?, index?, address?, vaultPath?)
+// signMessage(wallet, chain, message, passphrase?, encoding?, index?, vaultPath?, address?)
 
 // Sign transaction
 const txSig = signTransaction("my-wallet", "evm", "02f8...");
@@ -117,7 +117,7 @@ import { signTypedData } from "@open-wallet-standard/core";
 const sig = signTypedData("my-wallet", "evm", '{"types":...}');
 // sig.signature => hex string
 // sig.recoveryId => 0 or 1
-// signTypedData(wallet, chain, typedDataJson, passphrase?, index?, address?, vaultPath?)
+// signTypedData(wallet, chain, typedDataJson, passphrase?, index?, vaultPath?, address?)
 ```
 
 ## Policy Management

--- a/skills/ows/references/python.md
+++ b/skills/ows/references/python.md
@@ -93,7 +93,7 @@ from open_wallet_standard import sign_message, sign_transaction, sign_and_send
 sig = sign_message("my-wallet", "evm", "hello world")
 # sig["signature"] => hex string
 # sig["recovery_id"] => 0 or 1 (EVM/Tron only)
-# sign_message(wallet, chain, message, passphrase=None, encoding=None, index=None, vault_path=None)
+# sign_message(wallet, chain, message, passphrase=None, encoding=None, index=None, address=None, vault_path=None)
 
 # Sign transaction
 tx_sig = sign_transaction("my-wallet", "evm", "02f8...")

--- a/skills/ows/references/python.md
+++ b/skills/ows/references/python.md
@@ -38,7 +38,7 @@ All functions return Python dicts:
 from open_wallet_standard import generate_mnemonic, derive_address
 
 phrase = generate_mnemonic(12)         # or 24
-addr = derive_address(phrase, "evm")   # any chain: evm, solana, sui, bitcoin, cosmos, tron, ton, spark, filecoin
+addr = derive_address(phrase, "evm")   # any chain: evm, solana, sui, bitcoin, cosmos, tron, ton, spark, filecoin, xrpl, nano, cardano
 # derive_address(mnemonic, chain, index=None)
 ```
 
@@ -70,10 +70,13 @@ w2 = import_wallet_private_key("from-evm", "4c0883a691...")
 # Import Ed25519 key (solana/sui/ton)
 w3 = import_wallet_private_key("from-sol", "9d61b19d...", chain="solana")
 
-# Import explicit keys for both curves
-w4 = import_wallet_private_key("both", "", secp256k1_key="4c08...", ed25519_key="9d61...")
+# Import Ed25519-Bip32 key (Cardano)
+w3 = import_wallet_private_key("from-cardano", "cafe...", chain="cardano")
+
+# Import explicit keys for all curves
+w5 = import_wallet_private_key("all", "", secp256k1_key="4c08...", ed25519_key="9d61...", ed25519_bip32_key="cafe...")
 # import_wallet_private_key(name, private_key_hex, chain=None, passphrase=None,
-#                           vault_path=None, secp256k1_key=None, ed25519_key=None)
+#                           vault_path=None, secp256k1_key=None, ed25519_key=None, ed25519_bip32_key=None)
 
 # List / get / delete / rename / export
 wallets = list_wallets()                    # list_wallets(vault_path=None)
@@ -81,7 +84,7 @@ w = get_wallet("my-wallet")                 # get_wallet(name_or_id, vault_path=
 delete_wallet("my-wallet")                  # delete_wallet(name_or_id, vault_path=None)
 rename_wallet("old", "new")                 # rename_wallet(name_or_id, new_name, vault_path=None)
 secret = export_wallet("my-wallet")         # export_wallet(name_or_id, passphrase=None, vault_path=None)
-# Returns mnemonic string or JSON: {"secp256k1":"hex","ed25519":"hex"}
+# Returns mnemonic string or JSON: {"secp256k1":"hex","ed25519":"hex","ed25519_bip32":"hex"}
 ```
 
 ## Signing

--- a/skills/ows/references/python.md
+++ b/skills/ows/references/python.md
@@ -96,7 +96,7 @@ from open_wallet_standard import sign_message, sign_transaction, sign_and_send
 sig = sign_message("my-wallet", "evm", "hello world")
 # sig["signature"] => hex string
 # sig["recovery_id"] => 0 or 1 (EVM/Tron only)
-# sign_message(wallet, chain, message, passphrase=None, encoding=None, index=None, address=None, vault_path=None)
+# sign_message(wallet, chain, message, passphrase=None, encoding=None, index=None, vault_path=None, address=None)
 
 # Sign transaction
 tx_sig = sign_transaction("my-wallet", "evm", "02f8...")
@@ -116,7 +116,7 @@ from open_wallet_standard import sign_typed_data
 sig = sign_typed_data("my-wallet", "evm", '{"types":...}')
 # sig["signature"] => hex string
 # sig["recovery_id"] => 0 or 1
-# sign_typed_data(wallet, chain, typed_data_json, passphrase=None, index=None, vault_path=None)
+# sign_typed_data(wallet, chain, typed_data_json, passphrase=None, index=None, vault_path=None, address=None)
 ```
 
 ## Policy Management

--- a/website-docs/index.html
+++ b/website-docs/index.html
@@ -33,6 +33,8 @@
         <a href="doc.html?slug=sdk-cli">CLI</a>
         <a href="doc.html?slug=sdk-node">Node.js</a>
         <a href="doc.html?slug=sdk-python">Python</a>
+        <div class="docs-sidebar-title" style="margin-top: 1rem;">Chains</div>
+        <a href="doc.html?slug=cardano">Cardano</a>
       </div>
       <div class="docs-sidebar-footer">
         <a href="https://github.com/open-wallet-standard/core">

--- a/website-docs/js/docs.js
+++ b/website-docs/js/docs.js
@@ -19,7 +19,12 @@ var SDK_DOCS = [
   { slug: 'sdk-python', title: 'Python SDK',       sidebar: 'Python' },
 ];
 
-var DOCS = QUICKSTART_DOCS.concat(SDK_DOCS).concat(SPEC_DOCS);
+// Non-normative reference implementation docs (see docs/00-specification.md)
+var REFERENCE_DOCS = [
+  { slug: 'cardano', title: 'Cardano Support', sidebar: 'Cardano' },
+];
+
+var DOCS = QUICKSTART_DOCS.concat(SDK_DOCS).concat(SPEC_DOCS).concat(REFERENCE_DOCS);
 
 // Vercel build copies docs into website-docs/md/; local dev serves from repo root
 var DOCS_PATHS = ['md', '../docs'];
@@ -92,6 +97,12 @@ function buildSidebar(currentSlug) {
 
   html += '<div class="docs-sidebar-title" style="margin-top: 1rem;">Specification</div>';
   SPEC_DOCS.forEach(function (doc) {
+    var active = doc.slug === currentSlug ? ' class="active"' : '';
+    html += '<a href="doc.html?slug=' + doc.slug + '"' + active + '>' + doc.sidebar + '</a>';
+  });
+
+  html += '<div class="docs-sidebar-title" style="margin-top: 1rem;">Chains</div>';
+  REFERENCE_DOCS.forEach(function (doc) {
     var active = doc.slug === currentSlug ? ' class="active"' : '';
     html += '<a href="doc.html?slug=' + doc.slug + '"' + active + '>' + doc.sidebar + '</a>';
   });


### PR DESCRIPTION
## What

Adds **Cardano** support across signing, derivation, message signing, and balance lookup.

- Introduces **Ed25519-BIP32** for Cardano-compatible key derivation.
- Derives **base addresses** (payment + staking parts). Because each part uses a **different derivation path**, this adds **`default_derivation_paths`** and **`encode_keys`** to `ChainSigner` so payment and staking material can be derived independently.
- Adds an **`address` parameter** to message signing so users can sign CIP-style messages with their **base, enterprise, or reward** address as appropriate.
- **Transactions** are always signed with the **payment** key. If the transaction body’s **`required_signers`** includes the user’s **staking** key hash, or if the transaction's certificates require it, the transaction is also signed with the **staking** key when that key material is available.
- Adds **`make_transaction_context`** to **`ChainSigner`** and implements it for Cardano by **parsing the transaction** and building **`TransactionContext`** for policy flows.
- **Moonpay does not support Cardano**; balances are fetched via **Koios** RPC instead.
- Technical documentation can be found at `docs/cardano.md`.

## Why

Enables Wallet Recovery / OWS workflows on Cardano: correct multi-path derivation, address-aware message signing, policy-aware tx context from raw CBTX, and spendable balances without Moonpay.

## Testing

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` is clean
- [x] `npm test` passes (if Node bindings changed)
- [x] Tested manually with `ows` CLI

## Notes
This Cardano integration was implemented by the WingRiders team in cooperation with IOG and the Midnight Foundation, with their support, coordination, and technical review throughout the development process.

The first eight commits contain general preparation for integrating Cardano and Midnight into OWS. They are the same commits as in https://github.com/open-wallet-standard/core/pull/246 and only need to be reviewed once.

We would like to acknowledge @adacapo21 for their earlier work on exploring Cardano support for OWS in [#186](https://github.com/open-wallet-standard/core/pull/186). That PR helped initiate the upstream discussion around Cardano integration. However, after evaluating it in detail, we concluded that its underlying foundation and implementation logic do not cover several important requirements of a complete OWS Cardano integration, and addressing those gaps would require substantial changes rather than incremental additions. For this reason, our implementation takes a different architectural approach and does not directly build on the existing code. We therefore suggest prioritizing this PR as the primary Cardano implementation. A more detailed technical comparison, including the missing and incompatible areas, is available in our [comment on the existing PR](https://github.com/open-wallet-standard/core/pull/186#issuecomment-5105366439). We appreciate the time and effort invested in the earlier contribution and welcome further review and feedback on this PR.

cardano-serialization-lib 14.1.2 pins wasm-bindgen = "=0.2.92", which forces a workspace-wide downgrade of reqwest (0.12.28 → 0.12.12), uuid, and the wasm-bindgen family, and takes cargo audit from 5 advisories to 6. The new one, quinn-proto (RUSTSEC-2026-0037), is lockfile-only — quinn isn't compiled on any target we build. A conscious cost for a signing library.